### PR TITLE
rename dispatcher to input-queue

### DIFF
--- a/app/src/io/pedestal/app/render/events.cljs
+++ b/app/src/io/pedestal/app/render/events.cljs
@@ -29,19 +29,19 @@
   (if (fn? messages) (messages e) messages))
 
 (defn send-on
-  ([event-type dc dispatcher event-name messages]
+  ([event-type dc input-queue event-name messages]
      (send-on event-type
               dc
-              dispatcher
+              input-queue
               (fn [e] (map (partial msg/add-message-type event-name)
                           (produce-messages messages e)))))
-  ([event-type dc dispatcher messages]
+  ([event-type dc input-queue messages]
      (event/listen! (-coerce-to-dom-content dc)
                     event-type
                     (fn [e]
                       (event/prevent-default e)
                       (doseq [message (produce-messages messages e)]
-                        (p/put-message dispatcher message))))))
+                        (p/put-message input-queue message))))))
 
 (defn send-on-click [& args]
   (apply send-on :click args))
@@ -55,7 +55,7 @@
           {}
           input-map))
 
-(defn collect-and-send [event-type dc dispatcher event-name messages input-map]
-  (send-on event-type dc dispatcher
+(defn collect-and-send [event-type dc input-queue event-name messages input-map]
+  (send-on event-type dc input-queue
            (fn [_]
              (msg/fill event-name messages (collect-inputs input-map)))))

--- a/app/src/io/pedestal/app/render/push.clj
+++ b/app/src/io/pedestal/app/render/push.clj
@@ -130,9 +130,9 @@
   ([root-id handlers log-fn]
      (let [handlers (if (vector? handlers) (add-handlers handlers) handlers)
            renderer (->DomRenderer (atom {:id root-id}))]
-       (fn [deltas dispatcher]
+       (fn [deltas input-queue]
          (log-fn deltas)
          (doseq [d deltas]
            (let [[op path] d
                  handler (find-handler handlers op path)]
-             (when handler (handler renderer d dispatcher))))))))
+             (when handler (handler renderer d input-queue))))))))

--- a/app/test/io/pedestal/app/render/test/push.clj
+++ b/app/test/io/pedestal/app/render/test/push.clj
@@ -323,7 +323,7 @@
                  (add-handler :transform-enable [:t :chart] chart-event-enter)
                  (add-handler :* [:t :chart :back-button] bb-enter)
                  (add-handler :node-destroy [:**] d/default-exit))
-          ;; create a dispatcher
+          ;; create a mock input-queue
           last-user-action (atom nil)
           input-queue (->TestQueue last-user-action)
           ;; create renderer


### PR DESCRIPTION
All input to the application is put on a single input-queue. In the
past, this was called the dispatcher. Update the name to the more
descriptive "input-queue".
