### PR TITLE
Add marginalia plugin to app

### DIFF
--- a/app/project.clj
+++ b/app/project.clj
@@ -6,5 +6,6 @@
                  [ch.qos.logback/logback-classic "1.0.6"]
                  [enlive "1.0.0" :exclusions [org.clojure/clojure]]
                  [domina "1.0.1"]]
+  :plugins [[lein-marginalia "0.7.1"]]
   :profiles {:dev {:source-paths ["dev"]}}
   :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})


### PR DESCRIPTION
The pedestal docs instruct the user to `lein marg` within pedestal/app and pedestal/service. I added the marginalia plugin to app so the docs were consistent.

https://github.com/pedestal/documentation/blob/master/source/documentation/index.md 
