### PR TITLE
app-template should mention lein2 is required

### DIFF
--- a/app-template/project.clj
+++ b/app-template/project.clj
@@ -1,3 +1,4 @@
 (defproject pedestal-app/lein-template "0.0.9-SNAPSHOT"
   :description "A Pedestal Application template."
+  :min-lein-version "2.0.0"
   :eval-in-leiningen true)


### PR DESCRIPTION
This is the only project that doesn't have :min-lein-version specified. By having those in all our libraries we remove the need to explicitly mention that lein2 is required 
