### PR TITLE
this function should be public for samples like friend sample

### DIFF
--- a/service/src/io/pedestal/service/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/service/http/ring_middlewares.clj
@@ -26,7 +26,7 @@
             [ring.middleware.resource :as resource]
             [ring.middleware.session :as session]))
 
-(defn- response-fn-adapter
+(defn response-fn-adapter
   "Adapts a ring middleware fn taking a response and request to an interceptor context."
   [response-fn & [opts]]
   (fn [{:keys [request response] :as context}]


### PR DESCRIPTION
I'd like this fn to be public for the friend sample https://github.com/pedestal/samples/blob/friend-sample/friend-auth/src/friend_auth/service.clj#L47-L48. Not a showstopper
