### PR TITLE
Use the io.pedestal.app.messages namespace in generated behavior.clj

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/annotated/app/src/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/annotated/app/src/behavior.clj
@@ -1,12 +1,19 @@
 (ns ^:shared {{name}}.behavior
-    (:require [clojure.string :as string]))
+    (:require [clojure.string :as string]
+              [io.pedestal.app.messages :as msg]))
 
 ;; While creating new behavior, write tests to confirm that it is
 ;; correct. For examples of various kinds of tests, see
 ;; test/{{sanitized}}/test/behavior.clj.
 
+;; You'll always receive a message with the type msg/init when your
+;; app starts up. This message will include a :value key with the
+;; value of the :init key from your dataflow.
+
 (defn example-transform [transform-state message]
-  (:value message))
+  (condp = (msg/type message)
+    msg/init (:value message)
+    transform-state))
 
 (def example-app
   {:transform {:example-transform {:init "Hello World!" :fn example-transform}}})

--- a/app-template/src/leiningen/new/pedestal_app/annotated/test/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/annotated/test/behavior.clj
@@ -12,7 +12,7 @@
 ;; Test a transform function
 
 (deftest test-example-transform
-  (is (= (example-transform {} {:value "x"})
+  (is (= (example-transform {} {msg/type msg/init, :value "x"})
          "x")))
 
 ;; Build an application, send a message to a transform and check the transform
@@ -21,7 +21,7 @@
 (deftest test-app-state
   (let [app (app/build example-app)]
     (app/begin app)
-    (is (true? (test/run-sync! app [{msg/topic :example-transform :value "x"}])))
+    (is (true? (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
     (is (= (-> app :state deref :models :example-transform) "x"))))
 
 ;; Use io.pedestal.app.query to query the current application model
@@ -30,7 +30,7 @@
   (let [app (app/build example-app)
         app-model (render/consume-app-model app (constantly nil))]
     (app/begin app)
-    (is (test/run-sync! app [{msg/topic :example-transform :value "x"}]))
+    (is (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}]))
     (is (= (q '[:find ?v
                 :where
                 [?n :t/path [:io.pedestal.app/view-example-transform]]

--- a/app-template/src/leiningen/new/pedestal_app/plain/app/src/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/plain/app/src/behavior.clj
@@ -1,8 +1,11 @@
 (ns ^:shared {{name}}.behavior
-    (:require [clojure.string :as string]))
+    (:require [clojure.string :as string]
+              [io.pedestal.app.messages :as msg]))
 
 (defn example-transform [transform-state message]
-  (:value message))
+  (condp = (msg/type message)
+    msg/init (:value message)
+    transform-state))
 
 (def example-app
   {:transform {:example-transform {:init "Hello World!" :fn example-transform}}})

--- a/app-template/src/leiningen/new/pedestal_app/plain/test/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/plain/test/behavior.clj
@@ -10,20 +10,20 @@
         [io.pedestal.app.query :only [q]]))
 
 (deftest test-example-transform
-  (is (= (example-transform {} {:value "x"})
+  (is (= (example-transform {} {msg/type msg/init, :value "x"})
          "x")))
 
 (deftest test-app-state
   (let [app (app/build example-app)]
     (app/begin app)
-    (is (true? (test/run-sync! app [{msg/topic :example-transform :value "x"}])))
+    (is (true? (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
     (is (= (-> app :state deref :models :example-transform) "x"))))
 
 (deftest test-query-ui
   (let [app (app/build example-app)
         app-model (render/consume-app-model app (constantly nil))]
     (app/begin app)
-    (is (test/run-sync! app [{msg/topic :example-transform :value "x"}]))
+    (is (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}]))
     (is (= (q '[:find ?v
                 :where
                 [?n :t/path [:io.pedestal.app/view-example-transform]]


### PR DESCRIPTION
As it currently stands, the app-template generated behavior.clj doesn't include any reference to the messages namespace. I believe this is a mistake, as it doesn't lay out a clear path for adding further message types to transforms.

This pull request adds the messages namespace to app-template's behavior.clj and uses msg/type and msg/init to showcase how you can handle different message types.

Generated tests also needed to be adjusted as they relied on underspecified messages working when passed through the transform.
