### PR TITLE
Escape backslashes used as dir separators on windows

### DIFF
--- a/app-tools/src/io/pedestal/app_tools/build.clj
+++ b/app-tools/src/io/pedestal/app_tools/build.clj
@@ -26,7 +26,7 @@
 (def ^:dynamic *public* "out/public")
 
 (defn- split-path [s]
-  (string/split s (re-pattern File/separator)))
+  (string/split s (re-pattern (java.util.regex.Pattern/quote File/separator))))
 
 (defn- ensure-ends-with-sep [p]
   (if (.endsWith p File/separator) p (str p File/separator)))


### PR DESCRIPTION
#23 fix for backslashes causing a regex error on windows
