### PR TITLE
Add app-tools.test.build to test split-path on *nix or windows

### DIFF
--- a/app-tools/test/io/pedestal/app_tools/test/build.clj
+++ b/app-tools/test/io/pedestal/app_tools/test/build.clj
@@ -1,0 +1,25 @@
+; Copyright 2013 Relevance, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.app-tools.test.build
+  (:require [io.pedestal.app.protocols :as p]
+            [io.pedestal.app.messages :as msg]
+            [io.pedestal.app.tree :as tree])
+  (:use io.pedestal.app-tools.build
+        clojure.test)
+  (:import [java.nio.file Paths]))
+
+
+
+(deftest test-split-path
+  (let [split-path #'io.pedestal.app-tools.build/split-path
+        path (Paths/get "some" (into-array ["path"]))] ; Behold, the ugliness that is varargs 
+    (is (= (split-path (str path)) ["some" "path"]))))


### PR DESCRIPTION
Added multi-platform test to stress the changes made in #29.

These tests pass on Mac OS X, but I was unable to get leiningen/clojure/java working on my Windows box, so I defer to @djpowell to lend a hand. If tests run successfully then this also closes #23.
