### PR TITLE
body-param's set-content-type should set Content-Type rather than content-type

### DIFF
--- a/service/src/io/pedestal/service/http/body_params.clj
+++ b/service/src/io/pedestal/service/http/body_params.clj
@@ -34,7 +34,7 @@
   [request content-type]
   (-> request
       (assoc :content-type content-type)
-      (assoc-in [:headers "content-type"] content-type)))
+      (assoc-in [:headers "Content-Type"] content-type)))
 
 (defn- convert-middleware
   "Turn a ring middleware into a parser. If a content type is given, return a parser


### PR DESCRIPTION
for consistency with the rest of pedestal and http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
