### PR TITLE
Add .lein-repl-history to app template .gitignore.

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/annotated/.gitignore
+++ b/app-template/src/leiningen/new/pedestal_app/annotated/.gitignore
@@ -1,3 +1,4 @@
 out/
 target/
 logs/
+.lein-repl-history

--- a/app-template/src/leiningen/new/pedestal_app/plain/.gitignore
+++ b/app-template/src/leiningen/new/pedestal_app/plain/.gitignore
@@ -1,3 +1,4 @@
 out/
 target/
 logs/
+.lein-repl-history


### PR DESCRIPTION
The usage docs instruct users to use `lein repl` to begin working on a new app, so the `.lein-repl-history` file will always be created. Since it shouldn't be version controlled this commit adds it to the app template .gitignore files.
