### PR TITLE
remove dependency on clj-http

### DIFF
--- a/app-tools/project.clj
+++ b/app-tools/project.clj
@@ -24,6 +24,5 @@
                  [io.pedestal/pedestal.service "0.1.2"]
                  [io.pedestal/pedestal.jetty "0.1.2"]
                  [enlive "1.0.0" :exclusions [org.clojure/clojure]]
-                 [domina "1.0.1"]
-                 [clj-http "0.5.5"]]
+                 [domina "1.0.1"]]
   :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})


### PR DESCRIPTION
We have not needed this since the proxy server was removed.
