### PR TITLE
fix app-template tests to work with new run-sync! return value

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/annotated/test/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/annotated/test/behavior.clj
@@ -21,7 +21,8 @@
 (deftest test-app-state
   (let [app (app/build example-app)]
     (app/begin app)
-    (is (true? (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
+    (is (vector?
+         (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
     (is (= (-> app :state deref :models :example-transform) "x"))))
 
 ;; Use io.pedestal.app.query to query the current application model

--- a/app-template/src/leiningen/new/pedestal_app/plain/test/behavior.clj
+++ b/app-template/src/leiningen/new/pedestal_app/plain/test/behavior.clj
@@ -16,7 +16,8 @@
 (deftest test-app-state
   (let [app (app/build example-app)]
     (app/begin app)
-    (is (true? (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
+    (is (vector?
+         (test/run-sync! app [{msg/topic :example-transform, msg/type msg/init, :value "x"}])))
     (is (= (-> app :state deref :models :example-transform) "x"))))
 
 (deftest test-query-ui


### PR DESCRIPTION
The example tests in the generated app template checked that the
return value of run-sync! was true (not truthy). run-sync! has been
updated to return a vector of app states. The tests have been updated
to check for a vector.
