### PR TITLE
parse query-string from root url correctly in tests

### DIFF
--- a/service/src/io/pedestal/service/test.clj
+++ b/service/src/io/pedestal/service/test.clj
@@ -28,7 +28,7 @@
 (defn parse-url
   [url]
   (->> url
-      (re-matches #"(?:([^:]+)://)?([^/]+)?(?:/([^\?]+)(?:\?(.*))?)?")
+      (re-matches #"(?:([^:]+)://)?([^/]+)?(?:/([^\?]*)(?:\?(.*))?)?")
       (drop 1)
       ((fn [[scheme host path query-string]]
          {:scheme scheme

--- a/service/test/io/pedestal/service/test_test.clj
+++ b/service/test/io/pedestal/service/test_test.clj
@@ -1,0 +1,28 @@
+; Copyright 2013 Relevance, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.service.test-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.service.test :refer :all]))
+
+(deftest parse-url-test
+  (testing "non-root url parses query-string correctly"
+    (is (=
+         "param=value"
+         (-> "/foo?param=value"
+             parse-url
+             :query-string))))
+  (testing "root url parses query-string correctly"
+    (is (=
+         "param=value"
+         (-> "/?param=value"
+             parse-url
+             :query-string)))))


### PR DESCRIPTION
I was getting bit by this bug while trying to [test this](https://github.com/cldwalker/sse-chat/blob/master/test/sse_chat/service_test.clj#L20-L24)
