### PR TITLE
Upgrade ClojureScript to 1806

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/project.clj
+++ b/app-template/src/leiningen/new/pedestal_app/project.clj
@@ -1,7 +1,7 @@
 (defproject {{raw-name}} "0.0.1-SNAPSHOT"
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1820"]
+                 [org.clojure/clojurescript "0.0-1835"]
                  [domina "1.0.1"]
                  [ch.qos.logback/logback-classic "1.0.7" :exclusions [org.slf4j/slf4j-api]]
                  [io.pedestal/pedestal.app "0.1.9-SNAPSHOT"]

--- a/app-tools/project.clj
+++ b/app-tools/project.clj
@@ -13,7 +13,7 @@
   :description "Pedestal tools for application development"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1820"]
+                 [org.clojure/clojurescript "0.0-1835"]
                  [org.clojure/tools.namespace "0.2.1"]
                  [org.clojure/java.classpath "0.2.0"]
                  [ch.qos.logback/logback-classic "1.0.7" :exclusions [org.slf4j/slf4j-api]]

--- a/app/project.clj
+++ b/app/project.clj
@@ -13,7 +13,7 @@
   :description "Pedestal applications"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1820"]
+                 [org.clojure/clojurescript "0.0-1835"]
                  [ch.qos.logback/logback-classic "1.0.7"]
                  [enlive "1.0.0" :exclusions [org.clojure/clojure]]
                  [domina "1.0.1"]]


### PR DESCRIPTION
Our versions of ClojureScript are quite old (almost a year). This pull request is to upgrade our ClojureScript dependency to the latest release [r1806](https://github.com/clojure/clojurescript/tree/r1806).

I'd like to have people try out this version and see if any errors pop up. One particular thing we'd like to do is move from `msg/topic`-style keywords to `:msg/topic`-style keywords (if that feature made it into this release of ClojureScript?)
