### PR TITLE
Custom parsers for io.pedestal.service.http.body_params

### DIFF
--- a/service/src/io/pedestal/service/http/body_params.clj
+++ b/service/src/io/pedestal/service/http/body_params.clj
@@ -55,36 +55,73 @@
   [parser-map content-type middleware]
   (add-parser parser-map content-type (convert-middleware middleware)))
 
-(defn edn-parser [& [opts]]
+(defn custom-edn-parser
+  "Return an edn-parser fn that, given a request, will read the body of that
+  request with `edn/read`. options are key-val pairs that will be passed as a
+  hash-map to `edn/read`."
+  [& options]
+  (let [edn-options (merge {:eof nil}
+                           (apply hash-map options))]
+    (fn [request]
+      (let [encoding (or (:character-encoding request) "UTF-8")]
+        (assoc request
+               :edn-params (->
+                             (:body request)
+                             (java.io.InputStreamReader. encoding)
+                             java.io.PushbackReader.
+                             (->> (edn/read edn-options))))))))
+
+(def edn-parser
+  "Take a request and parse its body as edn."
+  (custom-edn-parser))
+
+(defn custom-json-parser
+  "Return a json-parser fn that, given a request, will read the body of that
+  request with `json/read`. options are key-val pairs that will be passed along
+  to `json/read`."
+  [& options]
   (fn [request]
     (let [encoding (or (:character-encoding request) "UTF-8")]
       (assoc request
-        :edn-params (->
-                     (:body request)
-                     (java.io.InputStreamReader. encoding)
-                     java.io.PushbackReader.
-                     (->> (edn/read (merge {:eof nil} opts))))))))
+             :json-params
+             (apply json/read
+                    (-> (:body request)
+                        (java.io.InputStreamReader. encoding))
+                    options)))))
 
-(defn json-parser [& [opts]]
-  (fn [request]
-    (let [encoding (or (:character-encoding request) "UTF-8")]
-      (assoc request
-        :json-params
-        (apply json/read
-               (-> (:body request)
-                   (java.io.InputStreamReader. encoding))
-               (apply concat (seq opts)))))))
+(def json-parser
+  "Take a request and parse its body as json."
+  (custom-json-parser))
 
-(defn form-parser [& [opts]]
-  (fn [request]
-    (let [encoding (or (:character-encoding request) "UTF-8")]
-      (params/assoc-form-params request encoding))))
+(defn form-parser
+  "Take a request and parse its body as a form."
+  [request]
+  (let [encoding (or (:character-encoding request) "UTF-8")]
+    (params/assoc-form-params request encoding)))
 
 (defn default-parser-map
-  [& {:keys [edn form json]}]
-  {#"^application/edn" (edn-parser edn)
-   #"^application/json" (json-parser json)
-   #"^application/x-www-form-urlencoded" (form-parser form)})
+  "Return a map of MIME-type to parsers. Included types are edn, json and
+  form-encoding. parser-options are key-val pairs, valid options are:
+
+    :edn-options A hash-map of options to be used when invoking `edn/read`.
+    :json-options A hash-map of options to be used when invoking `json/read`.
+
+  Examples:
+
+  (default-parser-map :json-options {:key-fn keyword})
+  ;; This parser-map would parse the json body '{\"foo\": \"bar\"}' as
+  ;; {:foo \"bar\"}
+
+  (default-parser-map :edn-options {:readers *data-readers*})
+  ;; This parser-map will parse edn bodies using any custom edn readers you
+  ;; define (in a data_readers.clj file, for example.)"
+  [& parser-options]
+  (let [{:keys [edn-options json-options]} (apply hash-map parser-options)
+        edn-options-vec (apply concat edn-options)
+        json-options-vec (apply concat json-options)]
+    {#"^application/edn" (apply custom-edn-parser edn-options-vec)
+     #"^application/json" (apply custom-json-parser json-options-vec)
+     #"^application/x-www-form-urlencoded" form-parser}))
 
 (definterceptorfn body-params
   ([] (body-params (default-parser-map)))

--- a/service/test/io/pedestal/service/http/body_params_test.clj
+++ b/service/test/io/pedestal/service/http/body_params_test.clj
@@ -25,10 +25,10 @@
 
 (def i (:enter (body-params)))
 
-(def i2
+(def i-using-opts
   (-> (default-parser-map
-        :edn {:readers {'inst inst/read-instant-timestamp}}
-        :json {:key-fn keyword})
+        :edn-options {:readers {'inst inst/read-instant-timestamp}}
+        :json-options {:key-fn keyword})
       body-params :enter))
 
 (deftest parses-json
@@ -39,13 +39,13 @@
 
 (deftest parses-json-using-opts
   (let [json-context (as-context "application/json" "{ \"foo\": \"BAR\"}")
-        new-context (i2 json-context)
+        new-context (i-using-opts json-context)
         new-request (:request new-context)]
     (is (= (:json-params new-request) {:foo "BAR"}))))
 
 (deftest parses-form-data
   (let [form-context (as-context  "application/x-www-form-urlencoded" "foo=BAR")
-        new-context  (i2 form-context)
+        new-context  (i form-context)
         new-request  (:request new-context)]
     (is (= (:form-params new-request) {"foo" "BAR"}))))
 
@@ -57,7 +57,7 @@
 
 (deftest parses-edn-using-opts
   (let [edn-context (as-context "application/edn" "#inst \"1970-01-01T00:00:00.000-00:00\"")
-        new-context (i2 edn-context)
+        new-context (i-using-opts edn-context)
         new-request (:request new-context)]
     (is (= (:edn-params new-request) (java.sql.Timestamp. 0)))))
 


### PR DESCRIPTION
This is a bit more work than @r0man's proposal (#97), but it maintains API
compatibility for existing users. Instead of changing existing APIs I
created new custom-{json/edn}-parser functions, with existing functions
being the "default" versions of these parsers. I opted _not_ to include
a version for form parsing--we'll cross that bridge when we get to it.

Since it seems to already be an established practice on the project I
preferred key-val pairs over hash-map options, even if at times slightly
more work than necessary.

I also shored up the docs! Thanks again to @r0man for bringing this up
and given me something to do on my plane ride home.

This fixes #96, #97.

Thoughts @r0man and @timewald? 
