### PR TITLE
Pedestal client's exception catching code makes it significantly more difficult to debug in-browser errors

### DIFF
--- a/app/src/io/pedestal/app/render.clj
+++ b/app/src/io/pedestal/app/render.clj
@@ -29,7 +29,4 @@
     app-model))
 
 (defn log-fn [deltas]
-  (platform/log-group
-   "<----------------------------------------------------------------------"
-   "---------------------------------------------------------------------->"
-   deltas))
+  (platform/log-group "Rendering Deltas" deltas))

--- a/app/src/io/pedestal/app/render/push.clj
+++ b/app/src/io/pedestal/app/render/push.clj
@@ -117,7 +117,6 @@
   (new-id! [this path]
     (new-id! this path (gensym)))
   (new-id! [this path v]
-    (log/info :in :new-id! :msg (str "creating new id " v " at path " path))
     (swap! env assoc-in (conj path :id) v)
     v)
   (delete-id! [this path]

--- a/app/src/io/pedestal/app/render/push/handlers.cljs
+++ b/app/src/io/pedestal/app/render/push/handlers.cljs
@@ -32,10 +32,9 @@
 
 (defn destroy! [r path]
   (if-let [id (render/get-id r path)]
-    (do (log/debug :in :default-exit :msg (str "deleteing id " id " for path " path))
-        (render/delete-id! r path)
+    (do (render/delete-id! r path)
         (d/destroy! (d/by-id id)))
-    (log/debug :in :default-exit :msg (str "warning! no id " id " found for path " (pr-str path)))))
+    (log/warn :in :default-exit :msg (str "warning! no id " id " found for path " (pr-str path)))))
 
 (defn default-destroy [r [_ path] _]
   (destroy! r path))

--- a/app/src/io/pedestal/app/render/push/handlers/automatic.cljs
+++ b/app/src/io/pedestal/app/render/push/handlers/automatic.cljs
@@ -24,7 +24,6 @@
           (mapv #(js/prompt (str "Enter value for: " (name %))) syms)))
 
 (defn get-missing-input [messages]
-  (log/debug :messages messages)
   (let [syms (msg/message-params messages)]
     (if (seq syms)
       (fn [_]
@@ -182,12 +181,7 @@
                           input-queue
                           (get-missing-input (mapv #(assoc % :from :ui) messages))))
 
-      (log/debug :on-destroy! path)
-      (render/on-destroy! r path #(do (log/debug :in (str "data render unlisten! path: "
-                                                          path
-                                                          " button-id: "
-                                                          button-id))
-                                      (event/unlisten! (d/by-id button-id) :click))))))
+      (render/on-destroy! r path #(event/unlisten! (d/by-id button-id) :click)))))
 
 (defn render-node-enter [r [_ path] input-queue]
   (let [parent (render/get-parent-id r path)
@@ -275,7 +269,6 @@
         default-button-id (render/get-id r (conj path "control" transform-name))
         id (or default-button-id node-id)]
     (when id
-      (log/debug :in (str "unlistening! transform-name " transform-name  " path " path " with id " id))
       (event/unlisten! (d/by-id id) :click))
     (when default-button-id
       (d/destroy! (d/by-id default-button-id)))))
@@ -283,10 +276,9 @@
 ;; deprecated - use io.pedestal.app.render.push.handlers/destroy!
 (defn destroy! [r path]
   (if-let [id (render/get-id r path)]
-    (do (log/debug :in :default-exit :msg (str "deleteing id " id " for path " path))
-        (render/delete-id! r path)
+    (do (render/delete-id! r path)
         (d/destroy! (d/by-id id)))
-    (log/debug :in :default-exit :msg (str "warning! no id " id " found for path " (pr-str path)))))
+    (log/warn :in :default-exit :msg (str "warning! no id " id " found for path " (pr-str path)))))
 
 ;; deprecated - use io.pedestal.app.render.push.handlers/default-destroy
 (defn default-exit [r [_ path] d]

--- a/app/src/io/pedestal/app/util/platform.clj
+++ b/app/src/io/pedestal/app/util/platform.clj
@@ -42,12 +42,13 @@
          (catch Throwable _ nil))
     x))
 
-(defn log-group [pre post coll]
+(defn log-group [group-name coll]
   (println "\n")
-  (println pre)
+  (println "<---------------------------------------------------------------------")
+  (println group-name)
   (doseq [d coll]
     (println (pr-str d)))
-  (println post)
+  (println "---------------------------------------------------------------------->")
   (println "\n"))
 
 (defn log-exceptions [f & args]

--- a/app/src/io/pedestal/app/util/platform.cljs
+++ b/app/src/io/pedestal/app/util/platform.cljs
@@ -35,17 +35,18 @@
          (catch js/Error _ nil))
     x))
 
-(defn log-group [pre post coll]
-  (.log js/console "\n")
-  (.log js/console pre)
+(defn log-group [group-name coll]
+  (.group js/console group-name)
   (doseq [d coll]
     (.log js/console (pr-str d)))
-  (.log js/console post)
-  (.log js/console "\n"))
+  (.groupEnd js/console))
 
 (defn log-exceptions [f & args]
   (try (apply f args)
        (catch js/Error e
-         (.log js/console (pr-str e))
-         (.log js/console (pr-str f))
-         (.log js/console (pr-str args)))))
+         (.groupCollapsed js/console "Caught exception" e)
+         (.log js/console "Was applying function\n" f)
+         (.log js/console "With arguments" (pr-str args))
+         (.log js/console "Re-throwing error...")
+         (.groupEnd js/console)
+         (throw e))))


### PR DESCRIPTION
Presently exceptions raised during pedestal-app's dataflow execution are caught and printed as simple errors. This is undesirable because it stops quite advanced built-in JS development tools like Chrome's Developer Tools from providing their own exception functionality (linked stack traces, stack inspection, etc.).

We should consider think about and consider _not_ catching this errors and allowing them to bubble up to user-space.
