### PR TITLE
start can just take port

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/dev/dev.clj
+++ b/app-template/src/leiningen/new/pedestal_app/dev/dev.clj
@@ -44,6 +44,8 @@
   3000. The default application is the first of config/configs."
   ([]
      (start 3000 (ffirst config/configs)))
+  ([port]
+      (start port (ffirst config/configs)))
   ([port config-name]
      (init port config-name)
      ((:start-fn app-development-server))


### PR DESCRIPTION
This is the first thing I reached for one I already had something on 3000. If we're going to make it easy to run with no args, I don't see why it can't also be easy to just choose a port
