### PR TITLE
lein run starts an app server, same as a service server

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/dev/dev.clj
+++ b/app-template/src/leiningen/new/pedestal_app/dev/dev.clj
@@ -119,3 +119,8 @@
   (println "Type (watch aspect) to build a specific aspect when it changes")
   (println "Type (unwatch) to stop the current watcher")
   (println))
+
+(defn -main
+  "Used by `lein run` to start the server from the commandline."
+  [& args]
+  (apply start args))

--- a/app-template/src/leiningen/new/pedestal_app/project.clj
+++ b/app-template/src/leiningen/new/pedestal_app/project.clj
@@ -11,4 +11,5 @@
   :source-paths ["app/src" "app/templates"]
   :resource-paths ["config"]
   :target-path "out/"
-  :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]})
+  :aliases {"dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]}
+  :main ^{:skip-aot true} dev)


### PR DESCRIPTION
This enables starting a server with `lein run`, same as we do for [service](https://github.com/pedestal/pedestal/blob/master/service-template/src/leiningen/new/pedestal_service/project.clj#L26). While a developer often needs the repl, an end user of an app does not. We should make it just as easy for end users to try a pedestal-app app as we do in service.
