### PR TITLE
Assert that recording dir is in config

### DIFF
--- a/app-tools/src/io/pedestal/app_tools/rendering_view/routes.clj
+++ b/app-tools/src/io/pedestal/app_tools/rendering_view/routes.clj
@@ -147,7 +147,7 @@
            recording (format-output (slurp (io/reader (:body request))))
            dir (get-in config [:built-in :render :dir])]
        (assert recording-name "Recordings must have a name")
-       (assert recording-name "No dir found in config under [:built-in :render :dir]")
+       (assert dir "No dir found in config under [:built-in :render :dir]")
        (let [f (io/file (str "tools/recordings/" dir "/" recording-name ".clj"))]
          (.mkdirs (.getParentFile f))
          (spit f recording)))


### PR DESCRIPTION
Looks like there was a typo that asserted twice on `recording-name` instead of both `recording-name` and `dir`.
