### PR TITLE
Modernize conversion of request headers map to JS object

### DIFF
--- a/app/src/io/pedestal/app/net/xhr.cljs
+++ b/app/src/io/pedestal/app/net/xhr.cljs
@@ -88,7 +88,7 @@
            uri
            request-method
            body
-           (when headers (.-strobj headers))
+           (when headers (clj->js headers))
            priority
            (partial handle-response on-success on-error id)
            retries)


### PR DESCRIPTION
Reported by Jonathan Boston on this mailing list thread: https://groups.google.com/d/msg/pedestal-users/KbRsgSKfxSo/ClsTYH_Ft5AJ.
