### PR TITLE
Performance optimization for immediate timeouts

### DIFF
--- a/app/src/io/pedestal/app/util/platform.cljs
+++ b/app/src/io/pedestal/app/util/platform.cljs
@@ -23,8 +23,15 @@
 (defn date []
   (js/Date.))
 
+(def immediate-timeout
+  (cond
+   (exists? js/setImmediate) js/setImmediate 
+   :else #(js/setTimeout % 0)))
+
 (defn create-timeout [msecs f]
-  (js/setTimeout f msecs))
+  (cond
+   (= 0 msecs) (immediate-timeout f)
+   :else (js/setTimeout f msecs)))
 
 (defn cancel-timeout [timeout]
   (js/clearTimeout timeout))


### PR DESCRIPTION
Created a shim for immediate timeouts to use setImmediate when
supported by the browser or setTimeout otherwise.
The performance difference of setImmediate is much improved over
setTimeout where it exists
(http://jsperf.com/setimmediate-vs-settimeout)
