### PR TITLE
Replaced clojure.data.json with Cheshire

### DIFF
--- a/service/project.clj
+++ b/service/project.clj
@@ -21,7 +21,7 @@
                  ;; interceptors
                  [ring/ring-core "1.2.0-beta1"
                   :exclusions [javax.servlet/servlet-api]]
-                 [org.clojure/data.json "0.2.0"]]
+                 [cheshire "5.2.0"]]
   :min-lein-version "2.0.0"
   :java-source-paths ["java"]
   :javac-options ["-target" "1.5" "-source" "1.5"]

--- a/service/src/io/pedestal/service/http.clj
+++ b/service/src/io/pedestal/service/http.clj
@@ -21,7 +21,7 @@
             [ring.util.mime-type :as ring-mime]
             [ring.util.response :as ring-response]
             [clojure.string :as string]
-            [clojure.data.json :as json]
+            [cheshire.core :as json]
             [io.pedestal.service.log :as log])
   (:import (java.io OutputStreamWriter)))
 
@@ -46,10 +46,15 @@
   [obj]
   (data-response #(pr obj) "application/edn;charset=UTF-8"))
 
+(defn json-print
+  "Print object as JSON to *out*"
+  [obj]
+  (json/generate-stream obj *out*))
+
 (defn json-response
   "Return a Ring response that will print the given `obj` to the HTTP output stream in JSON format."
   [obj]
-  (data-response #(json/pprint obj) "application/json;charset=UTF-8"))
+  (data-response #(json-print obj) "application/json;charset=UTF-8"))
 
 ;; interceptors
 
@@ -91,7 +96,7 @@
     (if (and (coll? body) (not content-type))
       (-> response
           (ring-response/content-type "application/json;charset=UTF-8")
-          (assoc :body (print-fn #(json/pprint body))))
+          (assoc :body (print-fn #(json-print body))))
       response)))
 
 (defn default-interceptors

--- a/service/test/io/pedestal/service/http_test.clj
+++ b/service/test/io/pedestal/service/http_test.clj
@@ -174,7 +174,7 @@
 (deftest json-response-test
   (let [obj {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
-    (is (= (with-out-str (clojure.data.json/pprint obj))
+    (is (= (cheshire.core/generate-string obj)
            (do (io.pedestal.service.http.impl.servlet-interceptor/write-body-to-stream
                 (-> obj
                     service/json-response


### PR DESCRIPTION
Exposes Cheshire BigDecimal, key-fn and array-coerce-fn options as
body-params parser-map options hash-map. Discussion at #110

The commit content is the same, but I have rebased it on top of a newer master.
