### PR TITLE
app-template project dependencies bump cljs/logback

### DIFF
--- a/app-template/src/leiningen/new/pedestal_app/project.clj
+++ b/app-template/src/leiningen/new/pedestal_app/project.clj
@@ -3,7 +3,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/clojurescript "0.0-1835"]
                  [domina "1.0.1"]
-                 [ch.qos.logback/logback-classic "1.0.7" :exclusions [org.slf4j/slf4j-api]]
+                 [ch.qos.logback/logback-classic "1.0.13" :exclusions [org.slf4j/slf4j-api]]
                  [io.pedestal/pedestal.app "0.2.2-SNAPSHOT"]
                  [io.pedestal/pedestal.app-tools "0.2.2-SNAPSHOT"]
                  [com.cemerick/piggieback "0.1.0"]]


### PR DESCRIPTION
Service template only carries its own internal libraries which are already 0.2.2-SNAPSHOT updated. So it is fine.

On the issue of trying to improve the ease of upgrading, also template dependencies, I requested the author of `lein-ancient` to refactor some parts so the plugin can be used on template `project.clj` files as well since it throws an exception atm.

Do you like to see those under `service/project.clj` updated as well? This is what I got

``` sh
[org.slf4j/slf4j-api "1.7.5"] is available but we use "1.7.2"
[org.clojure/core.incubator "0.1.3"] is available but we use "0.1.2"
[ring/ring-core "1.2.0"] is available but we use "1.2.0-beta1"
[criterium "0.4.2"] is available but we use "0.3.1"
[org.clojure/java.classpath "0.2.1"] is available but we use "0.2.0"
[org.clojure/tools.namespace "0.2.4"] is available but we use "0.2.2"
[clj-http "0.7.6"] is available but we use "0.6.4"
[javax.servlet/javax.servlet-api "3.1.0"] is available but we use "3.0.1"
[ch.qos.logback/logback-classic "1.0.13"] is available but we use "1.0.7"
[org.clojure/tools.logging "0.2.6"] is available but we use "0.2.4"
[org.slf4j/jul-to-slf4j "1.7.5"] is available but we use "1.7.2"
[org.slf4j/jcl-over-slf4j "1.7.5"] is available but we use "1.7.2"
[org.slf4j/log4j-over-slf4j "1.7.5"] is available but we use "1.7.2"
```
