### PR TITLE
Enable Access-Control-Allow-Credentials in dev mode

### DIFF
--- a/service-tools/src/io/pedestal/service_tools/dev.clj
+++ b/service-tools/src/io/pedestal/service_tools/dev.clj
@@ -29,7 +29,7 @@
                            ;; reload routes on every request
                            ::bootstrap/routes #(deref routes-var)
                            ;; all origins are allowed in dev mode
-                           ::bootstrap/allowed-origins (constantly true)})
+                           ::bootstrap/allowed-origins {:creds true :allowed-origins (constantly true)}})
                    (bootstrap/default-interceptors)
                    (bootstrap/dev-interceptors))))
 


### PR DESCRIPTION
Using dev mode overwrites ::bootstrap/allowed-origins settings, canceling the original setting. 
