### PR TITLE
Fix memory leak in push renderer's delete-id! function.

### DIFF
--- a/app/src/io/pedestal/app/render/push.clj
+++ b/app/src/io/pedestal/app/render/push.clj
@@ -74,6 +74,20 @@
 (defn find-handler [handlers op path]
   (find-handler* {:children handlers} (vec (cons op path))))
 
+(defn dissoc-in
+  "Dissociates an entry from a nested associative structure returning a new
+  nested structure. keys is a sequence of keys. Any empty maps that result
+  will not be present in the new structure."
+  [m [k & ks :as keys]]
+  (if ks
+    (if-let [nextmap (get m k)]
+      (let [newmap (dissoc-in nextmap ks)]
+        (if (seq newmap)
+          (assoc m k newmap)
+          (dissoc m k)))
+      m)
+    (dissoc m k)))
+
 ;; Rendering
 ;; ================================================================================
 
@@ -121,7 +135,7 @@
     v)
   (delete-id! [this path]
     (run-on-destroy! (get-in @env path))
-    (swap! env assoc-in path nil))
+    (swap! env dissoc-in path))
   (on-destroy! [this path f]
     (swap! env update-in (conj path :on-destroy) (fnil conj []) f))
   (set-data! [this ks d]

--- a/app/test/clj/io/pedestal/app/render/test/push.clj
+++ b/app/test/clj/io/pedestal/app/render/test/push.clj
@@ -103,6 +103,11 @@
               :children [{:content 1
                           :attrs {:id :a}}]})))))
 
+(defn key-absent-from-renderer
+  [r key]
+  (not (contains? (-> r :env deref)
+                  key)))
+
 (deftest test-working-with-ids
   (let [r (->DomRenderer (atom {:id :root}))]
     (is (nil? (get-parent-id r [])))
@@ -111,7 +116,8 @@
       (is (= root-id (get-parent-id r [:a])))
       (let [a-id (new-id! r [:a])
             b-id (new-id! r [:b] :b)
-            c-id (new-id! r [:b :c])]
+            c-id (new-id! r [:b :c])
+            e-id (new-id! r [:d :e])]
         (is (= :b b-id))
         (is (= a-id (get-id r [:a])))
         (is (= :b (get-id r [:b])))
@@ -119,13 +125,15 @@
         (is (= :b (get-id r [:b]) (get-parent-id r [:b :c])))
 
         (delete-id! r [:a])
-        
-        (is (nil? (get-id r [:a])))
+        (is (key-absent-from-renderer r :a))
         (is (= c-id (get-id r [:b :c])))
-        
+
         (delete-id! r [:b])
-        (is (nil? (get-id r [:a])))
-        (is (nil? (get-id r [:b :c])))))))
+        (is (key-absent-from-renderer r :a))
+        (is (key-absent-from-renderer r :b))
+
+        (delete-id! r [:d :e])
+        (is (key-absent-from-renderer r :d))))))
 
 (deftest test-render-build-up-tear-down
 


### PR DESCRIPTION
Current behavior leaves 'deleted' keys hanging around with nil values.

Instead, dissoc them entirely.

Let's say I have a Pedestal application that polls a Twitter feed, and I want to show the last 3 tweets, destroying the older tweets.

In my rendering logic, I'm responding to `:node-destroy` messages by calling `io.pedestal.app.render.push.handlers/default-destroy`.

When tweet D is `:node-create`d, tweet A is updated in the rendering data to have a nil value, as per the current behavior of `delete-id!`.

![example](https://dl-web.dropbox.com/spa/s4p7nbfvfh34fmn/zuebnpvk.png)

A few dozen tweets later, my rendering data contains one unwanted key for every element I've `:node-destroy`ed...

![example](https://dl-web.dropbox.com/spa/s4p7nbfvfh34fmn/1a0qg94u.png)

This patch resolves this behavior such that the keys are dissoced rather than nulled, so that final state now looks like...

![example](https://dl-web.dropbox.com/spa/s4p7nbfvfh34fmn/xt5xptyo.png)
