### PR TITLE
#211 dtfn squashes id of elements in templates

### DIFF
--- a/app/src/io/pedestal/app/templates.clj
+++ b/app/src/io/pedestal/app/templates.clj
@@ -273,10 +273,12 @@ starting with file, to an arbitrary level of nesting."
    (let [map-sym (gensym)
          field-nodes (-> nodes (select [(attr? :field)]))
          ts (map (fn [x] (-> x :attrs :field)) field-nodes)
-         ts-syms (reduce (fn [a x]
-                           (assoc a x (gensym)))
-                         {}
-                         ts)
+         ts-syms (reduce (fn [m x] 
+                           (assoc m 
+                                  (-> x :attrs :field) 
+                                  (symbol (or (-> x :attrs :id) (gensym))) )) 
+                         {} 
+                         field-nodes)
          changes (-> ts
                      gen-change-index
                      (insert-ids ts-syms)
@@ -288,7 +290,7 @@ starting with file, to an arbitrary level of nesting."
          changes (simplify-info-maps changes)
          ids (set (mapcat (fn [[_ field-infos]] (map :id field-infos))
                           changes))]
-     (list 'fn [] (list 'let (vec (interleave ids (repeat (list 'gensym))))
+     (list 'fn [] (list 'let (vec (interleave ids (map str ids)))
                         [changes (list 'fn [map-sym]
                                        (list (tfn nodes)
                                              (let [id-map (interleave (map keyword ids) ids)]

--- a/app/test/clj/io/pedestal/app/test/templates.clj
+++ b/app/test/clj/io/pedestal/app/test/templates.clj
@@ -33,7 +33,7 @@
 
 (def dtfn-test-nodes
   (enlive/html-snippet "<li template='todo'>
-                          <div field='class:completed'>
+                          <div id='completed_123' field='class:completed'>
                             <div class='view'>
                               <input class='toggle' type='checkbox' checked>
                               <label field='content:text'>Create a TodoMVC template</label>
@@ -64,6 +64,14 @@
         result-nodes  (enlive/html-snippet result-html)]
     (is (= #{:id :completed :text} (set (keys dynamic-attributes))))
     (is (= 1 (count (:id dynamic-attributes))))
+	  (is (= "completed_123" (-> (:completed dynamic-attributes) first :id))
+	      "when id exists, it is preserved in id map")
+	  (is (= "completed_123" (-> (enlive/select result-nodes [:li :div.incomplete]) first :attrs :id))
+	      "when id exists, it is preserved in result-html")
+	  (is (.startsWith (-> (:id dynamic-attributes) first :id str) "G__")
+	      "when id does not exist, it is auto generated in id map")
+	  (is (.startsWith (-> (enlive/select result-nodes [:li :div.incomplete :input.todo-1]) first :attrs :id str) "G__")
+	      "when id does not exist, id is auto generated in result-html")
     (is (= 1 (count (:completed dynamic-attributes))))
     (is (= 2 (count (:text dynamic-attributes))))
     (is (let [info-map (-> dynamic-attributes :id first)]


### PR DESCRIPTION
Testcases and fix for #211

Tests check
- When ids already exist, we reuse those instead of regenerating new ones
- When ids are not provided, we auto-generate symbols in their place

Fixes
- `ts_syms` is rewritten to absorb ids as well as field data
- When `ids` are being replaced within the content rendered by `tfn`, we replace them with the existing ids instead of new ones
