### PR TITLE
Ensure non-standard ports get included in generated URL

### DIFF
--- a/service/src/io/pedestal/service/http/route.clj
+++ b/service/src/io/pedestal/service/http/route.clj
@@ -290,6 +290,13 @@
                        :else (:context-path request))]
     (str/split context-str #"/")))
 
+(def ^{:private true} standard-scheme->port {:http  80
+                                             :https 443})
+
+(defn- non-standard-port?
+  [scheme port]
+  (not= port (standard-scheme->port scheme)))
+
 (defn- link-str
   "Returns a string for a route, providing the minimum URL necessary
   given the route and opts. opts is a map as described in the
@@ -313,20 +320,21 @@
                          (concat context-path-parts (rest path-parts))
                          path-parts))
         path (str/join \/ (map #(get path-params % %) path-parts))
-        scheme (or override-scheme scheme)
-        host (or override-host host)
-        port (or override-port port)
         request-scheme (:scheme request)
         request-host (:server-name request)
-        scheme-match (or (nil? scheme) (= scheme request-scheme))
-        host-match (or (nil? host) (= host request-host))
-        port-match (or (nil? port) (= port (:server-port request)))]
+        request-port (:server-port request)
+        scheme (or override-scheme scheme request-scheme)
+        host (or override-host host request-host)
+        port (or override-port port request-port)
+        scheme-mismatch (not= scheme request-scheme)
+        host-mismatch   (not= host   request-host)
+        port-mismatch   (not= port   request-port)]
     (str
-     (when (or (not scheme-match) (not host-match) (not port-match) absolute?)
-       (str (when (or (not scheme-match) absolute?) (str (name (or scheme request-scheme)) \:))
+     (when (or absolute? scheme-mismatch host-mismatch port-mismatch)
+       (str (when (or absolute? scheme-mismatch) (str (name scheme) \:))
             "//"
-            (or host request-host)
-            (when port (str \: port))))
+            host
+            (when (non-standard-port? scheme port) (str \: port))))
      (str (when-not (.startsWith path "/") "/") path)
      (when-not (str/blank? fragment) (str "#" fragment))
      (when (seq query-params)

--- a/service/test/io/pedestal/service/http/route_test.clj
+++ b/service/test/io/pedestal/service/http/route_test.clj
@@ -561,6 +561,18 @@
        data-routes
        syntax-quote-data-routes))
 
+(deftest view-user-link-on-non-standard-port
+  (are [routes] (= "http://example.com:8080/user/456"
+                   ((make-linker routes) ::view-user
+                    :app-name :public
+                    :params {:user-id 456}
+                    :absolute? true
+                    :request {:scheme :http :server-name "example.com" :server-port 8080}))
+       verbose-routes
+       terse-routes
+       data-routes
+       syntax-quote-data-routes))
+
 (deftest delete-user-link
   (are [routes] (= "https://admin.example.com:9999/user/456/delete"
                    ((make-linker routes) ::delete-user :app-name :admin :params {:user-id 456}))


### PR DESCRIPTION
Whenever host is included in a URL, always include ports that are non-standard for the given scheme
