### PR TITLE
Performance improvements for update-template fn

### DIFF
--- a/app/src/io/pedestal/app/render/push/templates.cljs
+++ b/app/src/io/pedestal/app/render/push/templates.cljs
@@ -29,12 +29,10 @@
       nil)))
 
 (defn- add-in-template [f t m]
-  (doseq [[k v] m]
-    (assert (every? (fn [info] (= :content (:type info))) (get t k))
+  (doseq [[k v] m {:keys [id type]} (get t k)]
+    (assert (= :content type)
             "You may only add to content")
-    (when (contains? t k)
-      (doseq [info (get t k)]
-        (f (d/by-id (:id info)) v)))))
+    (f (d/by-id id) v)))
 
 (defn update-t [r path data]
   (let [template (render/get-data r (conj path ::template))]


### PR DESCRIPTION
In order to improve performance of the pedestal push renderer
template helpers, i refactored the update-template function in
namespace io.pedestal.app.render.push.templates.

Implemented changes:
- The function now walks only over fields which are actualy
  updated, instead of walking over all the fields in the
  stored dynamic template change map
- Because of the first point, is no longer necessary to run
  contains? checks in each side-effect evaulation, which
  further improves performance
- Because there are only two possible actions for :attr template
  keys, which is either to remove attr if it's set to nil or to
  set attr if it's set to every other value, i changed the control
  structure from using cond to simple if macro
