### PR TITLE
add docstrings for http interceptors

### DIFF
--- a/service/src/io/pedestal/service/http.clj
+++ b/service/src/io/pedestal/service/http.clj
@@ -59,6 +59,7 @@
 ;; interceptors
 
 (interceptor/defon-request log-request
+  "Logs the request's method and uri."
   [request]
   (log/info :msg (format "%s %s"
                          (string/upper-case (name (:request-method request)))
@@ -82,6 +83,7 @@
     context))
 
 (interceptor/defon-response html-body
+  "Sets the content-type headers to text/html if the body is a string and no content type is set."
   [response]
   (let [body (:body response)
         content-type (get-in response [:headers "Content-Type"])]
@@ -90,6 +92,8 @@
       response)))
 
 (interceptor/defon-response json-body
+  "Sets the content-type headers and converts the body to JSON if there's no content type and the
+  body is true for coll? i.e. is a map, vector or list. It uses Cheshire to generate the JSON body."
   [response]
   (let [body (:body response)
         content-type (get-in response [:headers "Content-Type"])]


### PR DESCRIPTION
We use json-body on a client project and figured it's better to document it here than internally. The other two are ones that generated services use by default
