### PR TITLE
Fix implementation of heartbeat scheduling

### DIFF
--- a/service/src/io/pedestal/service/http/sse.clj
+++ b/service/src/io/pedestal/service/http/sse.clj
@@ -1,13 +1,13 @@
-                                        ; Copyright 2013 Relevance, Inc.
+; Copyright 2013 Relevance, Inc.
 
-                                        ; The use and distribution terms for this software are covered by the
-                                        ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
-                                        ; which can be found in the file epl-v10.html at the root of this distribution.
-                                        ;
-                                        ; By using this software in any fashion, you are agreeing to be bound by
-                                        ; the terms of this license.
-                                        ;
-                                        ; You must not remove this notice, or any other, from this software.
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
 
 (ns io.pedestal.service.http.sse
   (:require [ring.util.response :as ring-response]


### PR DESCRIPTION
Heartbeat functionality in pedestal uses class Executors
from package java.util.concurrent, its method newScheduledThreadPool
is used to initialize thread pool for sse heartbeat functionality.
However, threads created by default are non-daemon threads where
they really should be rather daemon threads, so they don't prevent
the JVM process from exiting.

My fix supplies ThreadFactory for newScheduledThreadPool, this factory
just sets every jvm thread in the thread pool to be daemon thread.
