### PR TITLE
Update documentation links

### DIFF
--- a/guides/documentation/connecting-to-datomic.md
+++ b/guides/documentation/connecting-to-datomic.md
@@ -19,7 +19,7 @@ title: Connecting 'Hello World' to Datomic
 # Connecting "Hello World" to Datomic
 
 This tutorial extends the
-[Hello World Service](/guides/documentation/hello-world-service.md) to use
+[Hello World Service](hello-world-service.md) to use
 strings retrieved from [Datomic]. We will start from the "helloworld"
 service that we created in our first tutorial.
 
@@ -146,7 +146,7 @@ see the output from Datomic.
 ```
 
 If you still have the service running from
-[Hello World Service](/guides/documentation/hello-world-service.md), then you
+[Hello World Service](hello-world-service.md), then you
 will need to exit the REPL. Restart the service the same way as
 before: `lein repl`, `(use 'dev)`, and `(start)`.
 

--- a/guides/documentation/hello-world-service.md
+++ b/guides/documentation/hello-world-service.md
@@ -206,6 +206,6 @@ nil
 ## Where To Go Next
 
 For more about building out the server side, you can look at
-[Routing and Linking](/guides/documentation/service-routing.md) or
-[Connecting to Datomic](/guides/documentation/connecting-to-datomic.md).
+[Routing and Linking](service-routing.md) or
+[Connecting to Datomic](connecting-to-datomic.md).
 

--- a/guides/documentation/service-async.md
+++ b/guides/documentation/service-async.md
@@ -104,6 +104,6 @@ Pedestal's built in support for server-sent events works.
 _io.pedestal.impl.inteceptor_ namespace. The code in this
 namespace is subject to change.)
 
-For more about streaming, see [Streaming Responses](//guidesdocumentation/service-streaming.md). For more
-about SSE, see [Server-Sent Events](/guides/documentation/service-sse.md).
+For more about streaming, see [Streaming Responses](service-streaming.md). For more
+about SSE, see [Server-Sent Events](service-sse.md).
 

--- a/guides/documentation/service-interceptors.md
+++ b/guides/documentation/service-interceptors.md
@@ -88,7 +88,7 @@ Interceptors aim to explicitly solve the issue of request processing
 being coupled tightly to one thread. It does this with two mechanisms:
 
 1. Interceptors operate on a
-    [context](/guides/documentation/service-context-reference.md) which
+    [context](service-context-reference.md) which
     explicitly retains all data associated with processing one
     request.
 
@@ -306,7 +306,7 @@ You can port Ring code to Pedestal by:
 
 - If you are using Compojure for routing requests, rewrite your route
   definitions using the terse routing format (see
-  [Service Routing](/guides/documentation/service-routing.md)). Any Ring middlewares that run
+  [Service Routing](service-routing.md)). Any Ring middlewares that run
   before your Compojure routes should be replaced by interceptors that
   run before routing. Any middlewares specified in your Compojure
   routes should be replaced by interceptors referenced directly in

--- a/guides/documentation/service-sse.md
+++ b/guides/documentation/service-sse.md
@@ -36,7 +36,7 @@ requests to an interceptor returned from the
 _io.pedestal.http.sse/start-event-stream_ function. The
 resulting SSE interceptor processes a request by:
 
-- pausing interceptor execution (see [Service Async](/guides/documentation/service-async.md))
+- pausing interceptor execution (see [Service Async](service-async.md))
 
 - sending the appropriate HTTP response headers to tell the client that
   an event stream is starting.
@@ -108,7 +108,7 @@ send.
 
 It is important to understand that the server-sent events
 infrastructure uses the low-level streaming mechanism described
-[here](/guides/documentation/service-streaming.md). As such, it is subject to the major
+[here](service-streaming.md). As such, it is subject to the major
 limitation of that approach: once events have been streamed, any
 interceptors that post-process the response from the SSE interceptor
 will not be able change what was sent on the wire. Interceptor paths

--- a/guides/documentation/service-streaming.md
+++ b/guides/documentation/service-streaming.md
@@ -55,7 +55,7 @@ The thread completing the interceptor path will write the body out to
 the HTTP response stream. If the request is processed synchronously,
 the work will be done on the Web server thread. If the request is
 processed asynchronously, the work will be done on whatever thread
-resumed processing (see [Service Async](/guides/documentation/service-async.md)).
+resumed processing (see [Service Async](service-async.md)).
 
 Here is an example of an interceptor that returns an arbitrarily large
 volume of data.
@@ -111,5 +111,5 @@ determine whether a response has already been sent by an SSE (or
 equivalent) interceptor.
 
 This functionality is used to implement Server-Sent Events,
-documented [here](/guides/documentation/service-sse.md).
+documented [here](service-sse.md).
 


### PR DESCRIPTION
The current links in the documentation that link to other documentation pages are broken. This pull request simply adds the guides/ subdirectory to the front of the links and the .md file extension to the end of the links.
