### PR TITLE
Add hello-world sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,33 +1,32 @@
 # Pedestal Samples
 
 This is a collection of examples of services using the
-[pedestal](http://pedestal.io) toolkit. They range from [very
-simple](./helloworld_app) to [quite complex](./chat).
+[pedestal](http://pedestal.io) toolkit.
 
-If you're new to pedestal, we recommend that you have a look at [our
-documentation](http://pedestal.io/documentation) and then start with the
-examples.
+If you're new to Pedestal, we recommend that you have a look at
+[our documentation](../guides) and then start
+with the examples.
 
 ## Samples
 
-* [auto-reload-server](./auto-reload-server), a **pedestal-service** that
-    uses [ns-tracker](https://github.com/weavejester/ns-tracker) to reload
-    changed code
-* [cors](./cors)
-* [jboss](./jboss), a **pedestal-service** that can be deployed in
-    [JBoss](http://jboss.org)
+* [hello-world](./hello-world) A minimal service that exhibits the
+  bare-minimum necessary to integrate Pedestal into an applicaiton.
 * [ring-middleware](./ring-middleware), shows how to use
-    [ring](https://github.com/ring-clojure/ring) middlewares with
-    **pedestal-services**
+  [ring](https://github.com/ring-clojure/ring) middlewares with
+  services
+* [server-with-links](./server-with-links), a service that
+  demonstrates generating links to routes using `url-for`
+* [template-server](./template-server), a service that shows how to
+  use different template engines
+* [cors](./cors)
+* [jboss](./jboss), a service that can be deployed in
+  [JBoss](http://jboss.org)
 * [server-sent-events](./server-sent-events)
-* [server-with-links](./server-with-links), a **pedestal-service** that
-    demonstrates links generated from routes
-* [template-server](./template-server), a **pedestal-service** that shows
-    how to use different template engines
 
 ## Contributing
 
-The Pedestal samples follow a similar procedure to Pedestal's [CONTRIBUTING.md](https://github.com/pedestal/pedestal/blob/master/CONTRIBUTING.md).
+The Pedestal samples follow a similar procedure to Pedestal's
+[CONTRIBUTING.md](https://github.com/pedestal/pedestal/blob/master/CONTRIBUTING.md).
 
 ## License
 Copyright 2013 Relevance, Inc.

--- a/samples/hello-world/.gitignore
+++ b/samples/hello-world/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/samples/hello-world/README.md
+++ b/samples/hello-world/README.md
@@ -1,0 +1,43 @@
+# hello-world
+
+A bare-minimum Pedestal service that greets visitors.
+
+## Usage
+
+Launch the application using the command `lein run`.
+
+Once the application has started, visit the following URLs via
+a browser or cURL:
+
+* <localhost:8080/hello>
+* <localhost:8080/hello?name=You>
+
+For example:
+
+```sh
+$ curl -i "localhost:8080/hello"
+HTTP/1.1 200 OK
+Date: Fri, 25 Apr 2014 14:43:34 GMT
+Content-Type: text/plain
+Transfer-Encoding: chunked
+Server: Jetty(9.1.3.v20140225)
+
+Hello, World!
+
+$ curl "localhost:8080/hello?name=You"
+Hello, You!
+```
+
+## License
+
+Copyright 2013 Relevance, Inc.
+Copyright 2014 Cognitect, Inc.
+
+The use and distribution terms for this software are covered by the
+Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+which can be found in the file epl-v10.html at the root of this distribution.
+
+By using this software in any fashion, you are agreeing to be bound by
+the terms of this license.
+
+You must not remove this notice, or any other, from this software.

--- a/samples/hello-world/project.clj
+++ b/samples/hello-world/project.clj
@@ -1,0 +1,22 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(defproject hello-world "0.1.0-SNAPSHOT"
+  :description "Simple hello-world service in Pedestal"
+  :url "https://github.com/pedestal/pedestal/tree/master/guides"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [io.pedestal/pedestal.service "0.3.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.service-tools "0.3.0-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.3.0-SNAPSHOT"]]
+  :main hello-world.core)

--- a/samples/hello-world/resources/logback.xml
+++ b/samples/hello-world/resources/logback.xml
@@ -1,0 +1,24 @@
+<!-- Simple Logback configuration for STDOUT-only -->
+<configuration scan="true" scanPeriod="10 seconds">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+</encoder>
+    <!-- Only log level INFO and above -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+</filter>
+</appender>
+
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+</root>
+
+  <!-- For loggers in the these namespaces, log at all levels. -->
+  <logger name="user" level="ALL" />
+  <logger name="io.pedestal" level="ALL" />
+
+</configuration>

--- a/samples/hello-world/src/hello_world/core.clj
+++ b/samples/hello-world/src/hello_world/core.clj
@@ -1,0 +1,22 @@
+(ns hello-world.core
+  (:require [io.pedestal.http.route.definition :refer [defroutes]]
+            [io.pedestal.http :as http]))
+
+
+(defn hello-world [req]
+  (let [name (get-in req [:params :name] "World")]
+    {:status 200
+     :body (str "Hello, " name "!")
+     :headers {}}))
+
+(defroutes routes
+  [[["/"
+     ["/hello" {:get hello-world}]]]])
+
+(def service {::http/routes routes
+              ::http/port 8080})
+
+(defn -main [& args]
+  (-> service
+      http/create-server
+      http/start))


### PR DESCRIPTION
This pull request adds a simple hello-world sample to the samples directory. The sample _does not_ utilize the existing template, instead opting to show the bare minimum necessary to add a Pedestal service to a Clojure project.

This commit also cleans up [samples/README.md](256/files#diff-03a3756d2f8eaaf446a958595f62f98f), removing some non-existant samples and re-arranging samples in order skill level (roughly).
