### PR TITLE
Reproduce 'Async handling in 0.3.0' exception

### DIFF
--- a/samples/hello-world/src/hello_world/core.clj
+++ b/samples/hello-world/src/hello_world/core.clj
@@ -1,13 +1,16 @@
 (ns hello-world.core
   (:require [io.pedestal.http.route.definition :refer [defroutes]]
-            [io.pedestal.http :as http]))
-
+            [io.pedestal.http :as http]
+            [clojure.core.async :as async]))
 
 (defn hello-world [req]
-  (let [name (get-in req [:params :name] "World")]
-    {:status 200
-     :body (str "Hello, " name "!")
-     :headers {}}))
+  (async/go
+    (let [c (async/chan 1)
+          name (get-in req [:params :name] "World")]
+      (async/<! (async/timeout 2000))
+      (async/>! c {:status 200
+                   :body (str "Hello, " name "!")
+                   :headers {}}))))
 
 (defroutes routes
   [[["/"


### PR DESCRIPTION
I'm not sure what the problem is here, but this modification of the hello-world sample reproduces the exception Henrik is seeing in [Async handling in 0.3.0](https://groups.google.com/forum/#!topic/pedestal-users/5NA51vIzLVQ).
## DO NOT MERGE

To reproduce:
1. Run `lein run` in one tab
2. In another tab, `curl localhost:8080/hello`
3. Observe the lein tab producing this exception:

``` sh
INFO  org.eclipse.jetty.util.log - Logging initialized @12443ms
INFO  org.eclipse.jetty.server.Server - jetty-9.2.0.v20140526
INFO  o.e.j.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@a70daf4{/,null,AVAILABLE}
INFO  o.e.jetty.server.ServerConnector - Started ServerConnector@291522f1{HTTP/1.1}{0.0.0.0:8080}
INFO  org.eclipse.jetty.server.Server - Started @12818ms
INFO  io.pedestal.http - {:line 67, :msg "GET /hello"}
ERROR i.p.http.impl.servlet-interceptor - {:line 272, :msg "error-ring-response triggered", :context {:response #<ManyToManyChannel clojure.core.async.impl.channels.ManyToManyChannel@9f995a6>, :request {:io.p
edestal.http.impl.servlet-interceptor/async-supported? true, :remote-addr "127.0.0.1", :servlet-context #<Context ServletContext@o.e.j.s.ServletContextHandler@a70daf4{/,null,AVAILABLE}>, :servlet-response #<R
esponse HTTP/1.1 0
Date: Sun, 20 Jul 2014 01:54:10 GMT

>, :servlet-path "", :servlet #<FnServlet io.pedestal.http.servlet.FnServlet@43f72630>, :headers {"user-agent" "curl/7.30.0", "accept" "*/*", "host" "localhost:8080"}, :server-port 8080, :servlet-request #<Re
quest (GET /hello)@1519689411 org.eclipse.jetty.server.Request@5a949ec3>, :io.pedestal.http.impl.servlet-interceptor/protocol "HTTP/1.1", :path-info "/hello", :url-for #<route$url_for_routes$fn__6979 io.pedes
tal.http.route$url_for_routes$fn__6979@5482a8e7>, :uri "/hello", :server-name "localhost", :query-string nil, :path-params {}, :body #<HttpInputOverHTTP HttpInputOverHTTP@2da652f6>, :scheme :http, :request-me
thod :get, :context-path ""}, :bindings {#'io.pedestal.http.route/*url-for* #<route$url_for_routes$fn__6979 io.pedestal.http.route$url_for_routes$fn__6979@5482a8e7>}, :enter-async [#<servlet_interceptor$start
_servlet_async io.pedestal.http.impl.servlet_interceptor$start_servlet_async@27bb952f>], :servlet-response #<Response HTTP/1.1 0
Date: Sun, 20 Jul 2014 01:54:10 GMT

>, :route {:matcher #<route$matcher$fn__6889 io.pedestal.http.route$matcher$fn__6889@3d75213a>, :route-name :hello-world.core/hello-world, :path-re #"/\Qhello\E", :method :get, :path "/hello", :path-parts [""
 "hello"], :path-params [], :interceptors [#io.pedestal.impl.interceptor.Interceptor{:name :hello-world.core/hello-world, :enter #<interceptor$before$fn__6720 io.pedestal.interceptor$before$fn__6720@28ec5e9b>
, :leave nil, :error nil}]}, :servlet #<FnServlet io.pedestal.http.servlet.FnServlet@43f72630>, :servlet-request #<Request (GET /hello)@1519689411 org.eclipse.jetty.server.Request@5a949ec3>, :io.pedestal.impl
.interceptor/terminators (#<servlet_interceptor$terminator_inject$fn__8954 io.pedestal.http.impl.servlet_interceptor$terminator_inject$fn__8954@32d24b8b>), :io.pedestal.impl.interceptor/execution-id 1, :url-f
or #<route$url_for_routes$fn__6979 io.pedestal.http.route$url_for_routes$fn__6979@5482a8e7>, :servlet-config #<Config org.eclipse.jetty.servlet.ServletHolder$Config@6660649e>, :io.pedestal.impl.interceptor/st
ack (#io.pedestal.impl.interceptor.Interceptor{:name :io.pedestal.http.impl.servlet-interceptor/stylobate, :enter #<servlet_interceptor$enter_stylobate io.pedestal.http.impl.servlet_interceptor$enter_stylobat
e@687c6efb>, :leave #<servlet_interceptor$leave_stylobate io.pedestal.http.impl.servlet_interceptor$leave_stylobate@27914f9a>, :error #<servlet_interceptor$error_stylobate io.pedestal.http.impl.servlet_interc
eptor$error_stylobate@3ea04b6b>} #io.pedestal.impl.interceptor.Interceptor{:name :io.pedestal.http.impl.servlet-interceptor/terminator-injector, :enter #<interceptor$before$fn__6720 io.pedestal.interceptor$be
fore$fn__6720@30dd5cca>, :leave nil, :error nil})}}
java.lang.ClassCastException: clojure.core.async.impl.channels.ManyToManyChannel cannot be cast to clojure.lang.Associative
        at clojure.lang.RT.assoc(RT.java:702) ~[clojure-1.6.0.jar:na]
        at clojure.core$assoc.invoke(core.clj:187) ~[clojure-1.6.0.jar:na]
        at clojure.core$assoc_in.invoke(core.clj:5685) ~[clojure-1.6.0.jar:na]
        at clojure.core$assoc_in.invoke(core.clj:5684) ~[clojure-1.6.0.jar:na]
        at io.pedestal.http.secure_headers$secure_headers$fn__8722.invoke(secure_headers.clj:83) ~[na:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:154) [clojure-1.6.0.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) [clojure-1.6.0.jar:na]
        at clojure.core$apply.invoke(core.clj:626) [clojure-1.6.0.jar:na]
        at io.pedestal.interceptor$after$fn__6736.invoke(interceptor.clj:134) ~[na:na]
        at io.pedestal.impl.interceptor$try_f.invoke(interceptor.clj:39) ~[na:na]
        at io.pedestal.impl.interceptor$leave_all_with_binding.invoke(interceptor.clj:166) ~[na:na]
        at io.pedestal.impl.interceptor$leave_all$fn__6620.invoke(interceptor.clj:182) [na:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:152) [clojure-1.6.0.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) [clojure-1.6.0.jar:na]
        at clojure.core$apply.invoke(core.clj:624) [clojure-1.6.0.jar:na]
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1862) [clojure-1.6.0.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:425) [clojure-1.6.0.jar:na]
        at io.pedestal.impl.interceptor$leave_all.invoke(interceptor.clj:180) [na:na]
        at io.pedestal.impl.interceptor$execute.invoke(interceptor.clj:270) [na:na]
        at io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__8975.invoke(servlet_interceptor.clj:370) [na:na]
        at io.pedestal.http.servlet.FnServlet.service(servlet.clj:28) [na:na]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:751) [jetty-servlet-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:566) [jetty-servlet-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1111) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:498) [jetty-servlet-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1045) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:98) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.Server.handle(Server.java:461) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:284) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:244) [jetty-server-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:534) [jetty-io-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:607) [jetty-util-9.2.0.v20140526.jar:9.2.0.v20140526]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:536) [jetty-util-9.2.0.v20140526.jar:9.2.0.v20140526]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_05]
INFO  i.p.http.impl.servlet-interceptor - {:line 234, :msg "sending error", :message "Internal server error: exception"}
```
