### PR TITLE
Add PATCH and OPTIONS to the list of allowed cors methods

### DIFF
--- a/service/src/io/pedestal/http/cors.clj
+++ b/service/src/io/pedestal/http/cors.clj
@@ -33,7 +33,7 @@
                               (str "Content-Type, "
                                    (when requested-headers (str requested-headers ", "))
                                    (convert-header-names (keys (:headers request))))
-                              "Access-Control-Allow-Methods" "GET, POST, PUT, DELETE, HEAD"}
+                              "Access-Control-Allow-Methods" "GET, POST, PUT, DELETE, HEAD, PATCH, OPTIONS"}
                              (when creds {"Access-Control-Allow-Credentials" (str creds)})
                              (when max-age {"Access-Control-Max-Age" (str max-age)}))]
     (log/info :msg "cors preflight"
@@ -111,5 +111,3 @@
     (if-not origin
       (assoc-in context [:request :headers "origin"] "")
       context)))
-
-


### PR DESCRIPTION
This merely adds PATCH and OPTIONS to the "Access-Control-Allow-Methods" header on CORs preflight requests. It was discussed in #235 but no action was ever taken.
