### PR TITLE
InputStream should be closed (Fix #266)

### DIFF
--- a/service/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/service/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -23,7 +23,7 @@
             [ring.util.response :as ring-response])
   (:import (javax.servlet Servlet ServletRequest ServletConfig)
            (javax.servlet.http HttpServletRequest HttpServletResponse)
-           (java.io OutputStreamWriter OutputStream)))
+           (java.io OutputStreamWriter OutputStream InputStream)))
 
 (defn channel?
   [obj]
@@ -70,7 +70,8 @@
   java.io.InputStream
   (default-content-type [_] "application/octet-stream")
   (write-body-to-stream [input-stream output-stream]
-    (io/copy input-stream output-stream))
+    (with-open [^InputStream is input-stream]
+      (io/copy is output-stream)))
 
   nil
   (default-content-type [_] nil)

--- a/service/test/io/pedestal/http_test.clj
+++ b/service/test/io/pedestal/http_test.clj
@@ -19,7 +19,7 @@
             [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [io.pedestal.http.route.definition :refer [defroutes]]
             [ring.util.response :as ring-resp])
-  (:import (java.io ByteArrayOutputStream)))
+  (:import (java.io ByteArrayOutputStream FileInputStream File)))
 
 (defn about-page
   [request]
@@ -160,6 +160,11 @@
 
 ;; data response fn tests
 
+(defn- slurp-output-stream [output-stream]
+  (.flush output-stream)
+  (.close output-stream)
+  (.toString output-stream "UTF-8"))
+
 (deftest edn-response-test
   (let [obj {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
@@ -169,9 +174,7 @@
                     service/edn-response
                     :body)
                 output-stream)
-               (.flush output-stream)
-               (.close output-stream)
-               (.toString output-stream "UTF-8"))))))
+               (slurp-output-stream output-stream))))))
 
 (deftest default-edn-output-test
   (let [obj {:a 1 :b 2 :c [1 2 3]}
@@ -182,9 +185,7 @@
                     ring-resp/response
                     :body)
                 output-stream)
-               (.flush output-stream)
-               (.close output-stream)
-               (.toString output-stream "UTF-8"))))))
+               (slurp-output-stream output-stream))))))
 
 (deftest default-edn-response-test
   (let [edn-resp (response-for app :get "/edn")]
@@ -201,9 +202,33 @@
                     service/json-response
                     :body)
                 output-stream)
-               (.flush output-stream)
-               (.close output-stream)
-               (.toString output-stream "UTF-8"))))))
+               (slurp-output-stream output-stream))))))
+
+(defn- create-temp-file [content]
+  (let [f (File/createTempFile "pedestal-" nil)]
+    (.deleteOnExit f)
+    (spit f content)
+    f))
+
+(deftest input-stream-body-test
+  (let [body-content "Hello Input Stream"
+        body-stream (-> body-content
+                        create-temp-file
+                        FileInputStream.)
+        output-stream (ByteArrayOutputStream.)]
+    (is (= body-content
+           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream body-stream output-stream)
+               (slurp-output-stream output-stream))))
+    (is (thrown? java.io.IOException
+                 (.available body-stream)))))
+
+(deftest file-body-test
+  (let [body-content "Hello File"
+        body-file (create-temp-file body-content)
+        output-stream (ByteArrayOutputStream.)]
+    (is (= body-content
+           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream body-file output-stream)
+               (slurp-output-stream output-stream))))))
 
 (def anti-forgery-app-interceptors
   (service/default-interceptors {::service/routes app-routes
@@ -218,4 +243,3 @@
     (is (> (count body) 5))
     (is (= "HELLO" (subs body 0 5)))
     (is (not-empty (subs body 4)))))
-


### PR DESCRIPTION
When InputStream or File was given as a :body then it was consumed but
never closed causing "Too many open files" errors.

I have also added two new tests:
- check if InputStream is read and closed
- check if File is read

This pull request replaces #267 
