### PR TITLE
Remove dead website link mentioned in #254.

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -16,7 +16,6 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for our contribution guidelines.
 
 ## Find out more
 
-* Visit [our website](http://pedestal.io/)
 * Follow [@pedestal_team on Twitter](http://twitter.com/pedestal_team)
 * Subscribe to [pedestal-users](https://groups.google.com/d/forum/pedestal-users) and [pedestal-dev](https://groups.google.com/d/forum/pedestal-dev)
 


### PR DESCRIPTION
Dead link to pedestal.io. See pedestal/pedestal#254.
