### PR TITLE
remove unneeded (locking ...) around SSE channels

### DIFF
--- a/service/src/io/pedestal/http/sse.clj
+++ b/service/src/io/pedestal/http/sse.clj
@@ -60,7 +60,9 @@
     (.append sb CRLF)
 
     (doseq [part (string/split data #"\r?\n")]
-      (.append sb (str "data:" part "\r\n")))
+      (.append sb "data:")
+      (.append sb part)
+      (.append sb "\r\n"))
 
     (.append sb CRLF)
     (.toString sb)))


### PR DESCRIPTION
The current code locks channels in order to preserve ordering when sending SSE events. This patch removes these locks and instead uses `mk-data` to construct a single large message that contains all data. There really should never be a time when we'd need to lock a channel. 

Eventually this could possibly be improved by using a transducer in the channel that contains a call to `flat-map`. This would allow for vector messages to be spliced in, while preserving ordering. But for now this patch should be good enough. 
