### PR TITLE
Correctly build response string for SSE

### DIFF
--- a/service/src/io/pedestal/http/sse.clj
+++ b/service/src/io/pedestal/http/sse.clj
@@ -115,7 +115,7 @@
     (async/go
      (loop []
        (when-let [event (async/<! event-channel)]
-         (send-event response-channel "event" (str event))
+         (async/>! response-channel event)
          (recur)))
      (.cancel ^ScheduledFuture heartbeat true)
      (async/close! response-channel))


### PR DESCRIPTION
This fixes two issues with the existing SSE implementation. The first is that the result of getBytes is being passed in to the StringBuilder used to build the response. The second is that `send-event` and thus `mk-data` is being called on each message twice. This results in the provided event name being overridden with "event" and the data being wrapped. For example, a client calling `(send-event ctx "my-name" "my-data")` results in

```
event: event
data: event: my-name
data: data: my-data
```
