### PR TITLE
Avoid NPE because of uninitialized attribute

### DIFF
--- a/service/java/io/pedestal/servlet/ClojureVarServlet.java
+++ b/service/java/io/pedestal/servlet/ClojureVarServlet.java
@@ -65,8 +65,8 @@ public class ClojureVarServlet extends GenericServlet {
     public void init() throws ServletException {
         ServletConfig config = this.getServletConfig();
         IFn initFn = getVar(config, "init");
-        IFn serviceFn = getVar(config, "service");
-        IFn destroyFn = getVar(config, "destroy");
+        serviceFn = getVar(config, "service");
+        destroyFn = getVar(config, "destroy");
 
         if (serviceFn == null) {
             throw new ServletException("Missing required parameter 'service'");


### PR DESCRIPTION
When running a war in Jetty:

```
2014-10-24 12:20:22.650:WARN:oejs.ServletHandler:qtp1793329556-20: /api
java.lang.NullPointerException
  at io.pedestal.servlet.ClojureVarServlet.service(ClojureVarServlet.java:82)
  at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:769)
  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1667)
  at org.eclipse.jetty.servlets.UserAgentFilter.doFilter(UserAgentFilter.java:83)
  at org.eclipse.jetty.servlets.GzipFilter.doFilter(GzipFilter.java:364)
  at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1650)
  at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:583)
  at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
  at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
  at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
  at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1125)
  at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
  at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
  at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1059)
  at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
  at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
  at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
  at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
  at org.eclipse.jetty.server.Server.handle(Server.java:497)
  at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
  at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:248)
  at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
  at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:610)
  at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:539)
  at java.lang.Thread.run(Thread.java:745)
```
