### PR TITLE
response-for should wait for the resp to be realized

### DIFF
--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -143,7 +143,7 @@
                  (setContentType [this content-type] (swap! headers-map assoc :content-type content-type))
                  (setContentLength [this content-length] (swap! headers-map assoc :content-length content-length))
                  (flushBuffer [this] (deliver committed true))
-                 (isCommitted [this] (deref committed 10 false))
+                 (isCommitted [this] (realized? committed))
 
                  ;; Force all async NIO behaviors to be sync
                  container/WriteNIOByteBody


### PR DESCRIPTION
This is a potential resolution for #316.

There are some magic numbers in this commit that hard-code how long to wait for the response. I think it would be good to make these parameters that the testing code can provide. I didn't add that to this commit, because that would change the api. Let me know if you think we should do that.