### PR TITLE
Add AJP support to immutant 2.0

### DIFF
--- a/immutant/src/io/pedestal/http/immutant.clj
+++ b/immutant/src/io/pedestal/http/immutant.clj
@@ -53,7 +53,7 @@
    (let [server (-> (merge options (:container-options options))
                     (select-keys [:trust-managers :key-managers :keystore :buffer-size :buffers-per-region :worker-threads
                                   :port :host :ssl-context :io-threads :client-auth :direct-buffers? :trust-password :key-password
-                                  :truststore :configuration :ssl-port])
+                                  :truststore :configuration :ssl-port :ajp-port])
                     undertow/options
                     (select-keys [:path :virtual-host :configuration])
                     (assoc :auto-start false)


### PR DESCRIPTION
Add AJP support to immutant 2.0. (:ajp-port option)