### PR TITLE
Add missing index.html used in benchmarks

### DIFF
--- a/service/resources/io/pedestal/benchmark/index.html
+++ b/service/resources/io/pedestal/benchmark/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Pedestal Benchmarks</title>
+    </head>
+    <body>
+        <h1>Faster, faster!</h1>
+    </body>
+</html>


### PR DESCRIPTION
I'm working on a fix for #340 and came across a couple of small issues. This is the first, whereby when I start up a REPL, and when I try to reload namespaces I get an error because the web server benchmark namespace slurps a non-existent file when it's loaded.

My first inclination was to remove the side effect of slurping the file inside a function, but I don't know enough about this namespace to know if this will cause problems so I've gone with the more conservative solution of adding an `index.html` resource, and slurping that (I didn't see an obvious choice already in the repository). This shouldn't affect any benchmarks as the cost occurs when the namespace is loaded rather than at runtime, but please correct me if I'm missing something.

I've got a second PR incoming that enables some tests for the linear search router.