### PR TITLE
Enable trailing slash test for linear search router

### DIFF
--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1011,7 +1011,7 @@
   (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
                    (-> routes
                        (test-query-execute
-                        :prefix-tree
+                        router-impl-key
                         {:request {:request-method :get
                                    :path-info "/child-path"}})
                        :route


### PR DESCRIPTION
This is a small change that enables the `test-match-root-trailing-slash-map` test for the linear search router. Previously these tests were instead run twice with the prefix tree router.

I've signed the [Clojure contributor agreement](http://clojure.org/contributing) in the past. I'm not sure if I need to sign the Pedestal-specific contributor agreement too?