### PR TITLE
Trailing slash NPE

### DIFF
--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1011,7 +1011,7 @@
   (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
                    (-> routes
                        (test-query-execute
-                        :prefix-tree
+                        router-impl-key
                         {:request {:request-method :get
                                    :path-info "/child-path"}})
                        :route

--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1008,18 +1008,26 @@
              (map-routes->vec-routes routes-under-test)))))
 
 (defn test-match-root-trailing-slash-map [router-impl-key]
-  (doseq [path-info ["/child-path" "/child-path/"]]
-    (testing path-info
-      (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
-                       (-> routes
-                           (test-query-execute
-                            router-impl-key
-                            {:request {:request-method :get
-                                       :path-info path-info}})
-                           :route
-                           (select-keys [:route-name :path])))
-        map-routes
-        data-map-routes))))
+  (testing "/child-path"
+    (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
+                     (-> routes
+                         (test-query-execute
+                          router-impl-key
+                          {:request {:request-method :get
+                                     :path-info "/child-path"}})
+                         :route
+                         (select-keys [:route-name :path])))
+      map-routes
+      data-map-routes))
+  (testing "/child-path/"
+    (are [routes] (nil? (-> routes
+                            (test-query-execute
+                             router-impl-key
+                             {:request {:request-method :get
+                                        :path-info "/child-path/"}})
+                            :route))
+      map-routes
+      data-map-routes)))
 
 (deftest match-root-trailing-slash-map
   (test-match-root-trailing-slash-map :prefix-tree)

--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1008,16 +1008,18 @@
              (map-routes->vec-routes routes-under-test)))))
 
 (defn test-match-root-trailing-slash-map [router-impl-key]
-  (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
-                   (-> routes
-                       (test-query-execute
-                        router-impl-key
-                        {:request {:request-method :get
-                                   :path-info "/child-path"}})
-                       :route
-                       (select-keys [:route-name :path])))
-       map-routes
-       data-map-routes))
+  (doseq [path-info ["/child-path" "/child-path/"]]
+    (testing path-info
+      (are [routes] (= {:route-name ::trailing-slash :path "/child-path"}
+                       (-> routes
+                           (test-query-execute
+                            router-impl-key
+                            {:request {:request-method :get
+                                       :path-info path-info}})
+                           :route
+                           (select-keys [:route-name :path])))
+        map-routes
+        data-map-routes))))
 
 (deftest match-root-trailing-slash-map
   (test-match-root-trailing-slash-map :prefix-tree)

--- a/service/test/io/pedestal/http_test.clj
+++ b/service/test/io/pedestal/http_test.clj
@@ -90,6 +90,8 @@
     ["/people" {:get [:people (page "people")]}
      ["/:id" {:get [:person (page "person")]}
       ["/friends" {:get [:friends (page "friends")]}]]]
+    ["/trailing-slash/" {:get [:trailing-slash (page "trailing-slash")]}
+     ["/:id" {:get [:trailing-slash-by-id (page "trailing-slash-by-id")]}]]
     ["/hello" {:get [^:interceptors [clobberware] hello-page]}]
     ["/token" {:get hello-token-page}]
     ["/bytebuffer" {:get hello-byte-buffer-page}]
@@ -122,10 +124,20 @@
 (def app (make-app app-interceptors))
 
 (deftest trailing-slash-in-path
-  (doseq [path ["/people" "/people/"]]
-    (testing path
-      (let [{:keys [status body]} (response-for app :get path)]
-        (is (= status 200))))))
+  (testing "GET /people"
+    (let [{:keys [status body]} (response-for app :get "/people")]
+      (is (= 200 status))
+      (is (= "people" body))))
+  (testing "GET /people/"
+    (let [{:keys [status body]} (response-for app :get "/people/")]
+      (is (= 404 status))))
+  (testing "GET /trailing-slash/"
+    (let [{:keys [status body]} (response-for app :get "/trailing-slash/")]
+      (is (= 200 status))
+      (is (= "trailing-slash" body))))
+  (testing "GET /trailing-slash"
+    (let [{:keys [status body]} (response-for app :get "/trailing-slash")]
+      (is (= 404 status)))))
 
 (deftest html-body-test
   (let [response (response-for app :get "/text-as-html")]


### PR DESCRIPTION
Given the following routes:

- `/people`
- `/people/:id`

…it was possible to get a 500 error via an NPE when visiting `/people/`, which obviously isn't what we want.

Based on an hour or so of reading lots of posts and opinion on whether URLs and RESTful routes should use trailing slashes I've concluded it's best to leave it up to the author (in this case the user of Pedestal). To support this I've made two changes to the prefix router. The first change checks a wildcard route not only contains a `/` but also that it's not the final character in the URL, and I've made sure we only ever call the `:payload` function for a route when it exists.

I can't say for sure this is the best solution, although I considered some alternatives like cleaning routes before inserting them, and enforcing certain good URL practices (forcing a trailing slash when adding a collection route) but opted for this approach because to my knowledge it will not break any existing Pedestal apps, and is relatively small/simple.

It's late here so please forgive any ambiguity. I'm happy to answer any questions you might have, and welcome feedback.

Fixes #340.

- http://googlewebmastercentral.blogspot.co.uk/2010/04/to-slash-or-not-to-slash.html
- http://programmers.stackexchange.com/questions/186959/trailing-slash-in-restful-api
- http://programmers.stackexchange.com/questions/186959/trailing-slash-in-restful-api
- http://sebastians-pamphlets.com/thou-must-not-steal-the-trailing-slash-from-my-urls/
- http://stackoverflow.com/questions/5948659/trailing-slash-in-urls-which-style-is-preferred
- http://www.bizcoder.com/the-mystery-of-the-trailing-slash-and-the-relative-url
- https://cdivilly.wordpress.com/2014/03/11/why-trailing-slashes-on-uris-are-important/
- https://github.com/nicolaiarocci/eve/issues/118
- https://www.safaribooksonline.com/library/view/rest-api-design/9781449317904/ch02s02.html (this one I particularly dislike as there's no evidence or justification for why this is the right approach)

---

**N.B.** This contains my small fix for enabling the trailing slash tests for the linear search router. I can remove that commit easily enough if necessary.