### PR TITLE
Fix failing interceptor tests.

### DIFF
--- a/service/test/io/pedestal/interceptor_test.clj
+++ b/service/test/io/pedestal/interceptor_test.clj
@@ -144,7 +144,7 @@
   ([context] (assoc context :around :leave)))
 
 (deftest test-around-interceptor
-  (is (= (interceptor/interceptor? around-interceptor))
+  (is (true? (interceptor/interceptor? around-interceptor))
       "defaround creates an interceptor.")
   ;(is (= true (:interceptor (meta #'around-interceptor)))
   ;    "The defined interceptor is tagged as an interceptor in metadata.")
@@ -163,7 +163,7 @@
   ([response] (assoc response :middleware :leave)))
 
 (deftest test-middleware-interceptor
-  (is (= (interceptor/interceptor? middleware-interceptor))
+  (is (true? (interceptor/interceptor? middleware-interceptor))
       "defmiddleware creates an interceptor.")
   ;(is (= true (:interceptor (meta #'middleware-interceptor)))
   ;    "The defined interceptor is tagged as an interceptor in metadata.")


### PR DESCRIPTION
I was getting `java.lang.Exception: = expects more than one argument` exceptions when running the tests against `master`. This PR addresses that.