### PR TITLE
Correctly 404 when no match.

### DIFF
--- a/service/src/io/pedestal/http/route/prefix_tree.clj
+++ b/service/src/io/pedestal/http/route/prefix_tree.clj
@@ -28,7 +28,8 @@
   "Return the single character child key for the string started at
   index i."
   [s i]
-  (subs s i (inc i)))
+  (when (< i (count s))
+    (subs s i (inc i))))
 
 (defn- wild? [s]
   (contains? #{\: \*} (first s)))
@@ -316,9 +317,9 @@
   router/Router
   (find-route [this req]
     ;; find a result in the prefix-tree - payload could contains mutiple routes
-    (when-let [result (lookup tree (:path-info req))]
+    (when-let [{:keys [payload] :as result} (lookup tree (:path-info req))]
       ;; call payload function to find specific match based on method, host, scheme and port
-      (when-let [route ((:payload result) req)]
+      (when-let [route (when payload (payload req))]
         ;; return a match only if path and query constraints are satisfied
         (when ((::satisfies-constraints? route) req (:path-params result))
           (assoc route :path-params (:path-params result)))))))
@@ -505,3 +506,4 @@
   ;;=> {:rest "one/two", :x "bar"}
 
   )
+

--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1030,3 +1030,31 @@
        map-routes
        data-map-routes))
 
+;; Issue #340 - correctly 404 non-matching routes
+;; https://github.com/pedestal/pedestal/issues/340
+(defhandler echo-request
+  [request]
+  {:status 200
+   :body (pr-str request)
+   :headers {}})
+
+(defroutes routes-with-params
+  [[["/a/:a/b/:b" {:any echo-request}]]])
+
+(deftest non-matching-routes-should-404
+  (are [path]
+    (-> (test-query-execute routes-with-params
+                            :prefix-tree
+                            {:request
+                             {:request-method :get
+                              :path-info path}})
+      :route
+      nil?)
+    "/a"
+    "/a/"
+    "/a/a"
+    "/a/a/b"
+    "/a/a/b/"
+    "/a/a/b/b/"
+    "/a/a/b/b/c"))
+


### PR DESCRIPTION
Added checks to handle nils that would NPE during route lookup,
especially in the face of trailing slashes.

Fixes #340. Probably addresses #352, too.