### PR TITLE
316 response for async

### DIFF
--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -126,7 +126,8 @@
                                 nil)
                               (start [this r]
                                 nil)))
-          @async-context) ;; Needed for NIO testing (see Servlet Interceptor)
+          @async-context)
+        ;; Needed for NIO testing (see Servlet Interceptor)
         (getHeaderNames [this] (enumerator (keys (get options :headers)) ::getHeaderNames))
         (getHeader [this header] (get-in options [:headers header]))
         ;;(getHeaders [this header] (enumerator (get-in options [:headers header]) ::getHeaders))

--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -17,8 +17,7 @@
             [clojure.string :as cstr]
             [clojure.java.io :as io]
             [clojure.core.async :as async]
-            [io.pedestal.http.container :as container]
-            [io.pedestal.http.sse :as sse])
+            [io.pedestal.http.container :as container])
   (:import (javax.servlet.http HttpServlet HttpServletRequest HttpServletResponse)
            (javax.servlet Servlet ServletOutputStream ServletInputStream AsyncContext)
            (java.io ByteArrayInputStream ByteArrayOutputStream InputStream)
@@ -270,36 +269,4 @@
   :headers : An optional map that are the headers"
   [interceptor-service-fn verb url & options]
   (-> (apply raw-response-for interceptor-service-fn verb url options)
-    (update-in [:body] #(.toString % "UTF-8"))))
-
-;; This is all a bit ugly, as it relies on what are essentially
-;; internal implementation details. But there isn't an obviously
-;; better way to do this, so at least we can capture it in a function
-;; so people don't have to reinvent this particular broken wheel.
-;; Hopefully we'll come up with something better at some point
-(let [original sse/send-event]
-  (defn hook-sse-events!
-    "Given a channel, hooks the SSE infrastructure so that every SSE
-  event will be copied to that channel as a map with keys :name
-  and :data. Note that all events are copied, regardless of endpoint,
-  until unhook-sse-events! is called, and Pedestal can block on sends
-  to the provided channel if events are not read nor something like a
-  dropping buffer is not used. Also note, the hook channel will NOT
-  close when the event channel is closed."
-    [hook-chan]
-    (alter-var-root #'io.pedestal.http.sse/send-event
-                    (fn [f]
-                      (when-not (= f original)
-                        (throw (ex-info "Can't call hook-sse-events! twice without first calling `unhook-sse-events!`."
-                                        {:reason ::multiple-hook-sse-events-calls})))
-                      (fn [channel name data]
-                        (async/>!! hook-chan
-                                   {:name name
-                                    :data data})
-                        (original channel name data)))))
-
-  (defn unhook-sse-events!
-    "Undoes a call to `hook-sse-events!`."
-    []
-    (alter-var-root #'io.pedestal.http.sse/send-event
-                    (constantly original))))
+      (update-in [:body] #(.toString % "UTF-8"))))

--- a/service/test/io/pedestal/http/sse_test.clj
+++ b/service/test/io/pedestal/http/sse_test.clj
@@ -13,8 +13,11 @@
 (ns io.pedestal.http.sse-test
   (:require [io.pedestal.impl.interceptor :as interceptor]
             [io.pedestal.log :as log]
+            [io.pedestal.http :as service]
             [io.pedestal.http.sse :refer :all]
-            [io.pedestal.http.cors :as cors])
+            [io.pedestal.http.cors :as cors]
+            [io.pedestal.http.route.definition :refer [defroutes]]
+            [clojure.core.async :as async])
   (:use [clojure.test]
         [io.pedestal.test]))
 
@@ -43,4 +46,30 @@
         "The client is instructed not to cache the event stream")
     (is (= "http://foo.com:8080" allow-origin)
         "The origin is allowed")))
+
+
+(defn stream-ready [event-chan context]
+  (async/>!! event-chan {:name "foo" :data "bar"})
+  (async/>!! event-chan {:name "foo" :data "bar 2"})
+  (async/close! event-chan))
+
+(defroutes route-table
+  [[["/events" {:get [::events (start-event-stream stream-ready)]}]]])
+
+(deftest sse-events
+  (try
+    (let [hook-chan (async/chan 100)
+          _         (hook-sse-events! hook-chan)
+          app       (-> {::service/routes route-table}
+                      service/default-interceptors
+                      service/service-fn
+                      ::service/service-fn)
+          response  (response-for app :get "/events")]
+      (is (= {:name "foo" :data "bar"}
+             (async/<!! hook-chan)))
+      (is (= {:name "foo" :data "bar 2"}
+             (async/<!! hook-chan))))
+    (finally
+      (unhook-sse-events!))))
+
 


### PR DESCRIPTION
Make response-for work for interceptors that return channels. response-for still returns the whole body, by blocking until the returned channel closes.