### PR TITLE
allow-origin arg as a map with :allowed-origins as seq of strings fix

### DIFF
--- a/service/src/io/pedestal/http/cors.clj
+++ b/service/src/io/pedestal/http/cors.clj
@@ -45,11 +45,13 @@
     (assoc context :response {:status 200
                               :headers cors-headers})))
 
+
 (defn- normalize-args
   [arg]
   (if (map? arg)
-    arg
-    {:allowed-origins (if (fn? arg) arg (fn [origin] (some #(= % origin) (seq arg))))}))
+    (update-in arg [:allowed-origins] #(if (fn? %) % (fn [origin] (some #{origin} (seq %)))))
+    (normalize-args {:allowed-origins arg})))
+
 
 (defn allow-origin
   "Builds a CORS interceptor that allows calls from the specified `allowed-origins`, which is one of the following:


### PR DESCRIPTION
possible fix for issue #376

1. `normalize-arg` returns map whose :allowed-origins value is always a function
2. regression test for previous behaviour