### PR TITLE
Update csrf.clj

### DIFF
--- a/service/src/io/pedestal/http/csrf.clj
+++ b/service/src/io/pedestal/http/csrf.clj
@@ -45,11 +45,11 @@
           (assoc-in [:session "__anti-forgery-token"] token)))))
 
 ;; This must be run after the session token setting
-(defn- assoc-double-submit-cookie [request response]
+(defn- assoc-double-submit-cookie [response token]
   ;; The token should also be in a cookie for JS (proper double submit)
   (assoc-in response
             [:cookies "__anti-forgery-token"]
-            (existing-token request)))
+            token))
 
 (defn- form-params [request]
   (merge (:form-params request)
@@ -124,5 +124,5 @@
          (let [token (anti-forgery-token req)]
            (assoc context
                   :response (cond-> (assoc-session-token response req token)
-                              cookie-token? (#(assoc-double-submit-cookie req %))))))))))
+                              cookie-token? (#(assoc-double-submit-cookie % token))))))))))
 


### PR DESCRIPTION
Even after 'session token setting' the token will be present in :response not :request as assoc-session-token is working on response, therefore reading token from request would be null. 
Replaced to set the [:cookies "__anti-forgery-token"] explicit by parameter.