### PR TITLE
Route table syntax

### DIFF
--- a/guides/documentation/routing-terse-syntax.md
+++ b/guides/documentation/routing-terse-syntax.md
@@ -1,0 +1,635 @@
+<!--
+ Copyright 2013 Relevance, Inc.
+ Copyright 2014 Cognitect, Inc.
+
+ The use and distribution terms for this software are covered by the
+ Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+ which can be found in the file epl-v10.html at the root of this distribution.
+
+ By using this software in any fashion, you are agreeing to be bound by
+ the terms of this license.
+
+ You must not remove this notice, or any other, from this software.
+-->
+
+# Service Routing
+
+Pedestal's HTTP service plumbing provides a mechanism for routing
+requests through an ordered list of interceptors that handle them. The
+same infrastructure supports generating URLs that, when used with the
+appropriate HTTP verb, cause a request to be routed to a particular
+interceptor list. This document describes how routing and URL generation
+work.
+
+# Routing Tables
+
+Pedestal's HTTP routing and URL generation features are driven by a
+route table. A route table is a sequence of routes. A route is a map
+containing criteria for matching an HTTP request and an ordered list
+of interceptors to invoke on a request that matches a particular
+route.
+
+A route matching is based on:
+
+* URL scheme
+* HTTP method
+* Host header
+* URL path
+* Constraints on param values in URL path and/or query string
+
+## Defining route tables
+
+A route table is simply a data structure; in our case, it is a
+sequence of maps. The structure caters to the needs of matching and
+dispatching of requests, and as such has a great deal of repeated
+and derived data intended for use in that process. Creating the
+data structure in its final, verbose form by hand would be very tedious.
+
+We've built a simpler, terse form for route tables. The
+terse form is also a data structure, albeit more explicitly hierarchical; Writing
+a route table in the terse form is easier because information is not
+explicitly duplicated. Instead, child nodes implicitly inherit
+relevant route data from their ancestors.
+
+It is important to note that the terse form is a convenient way to
+define route tables, nothing more. It is always expanded to the
+more verbose structure - a sequence of maps - before use. While a
+convenient authoring format, it is not
+directly used to route requests or generate URLs.
+
+## The terse format
+
+In the terse format, a route table is a vector of vectors, each
+describing an application. Each application vector can contain the
+following optional elements:
+
+- a keyword identifying the application by name (optional)
+- a URL scheme (optional)
+- a host name (optional)
+- one or more nested vectors specifying routes (required)
+
+Here is a simple "Hello World" example:
+
+```clojure
+[[:hello-world :http "example.com"
+  ["/hello-world" {:get hello-world}]]]
+```
+
+In this case, the following HTTP request:
+
+```
+GET /hello-world HTTP/1.1
+Host: example.com
+```
+
+would be routed to the `hello-world` interceptor.
+
+A request to a different host (either DNS name or IP
+address) or using HTTPS would not be routed, unless the application's
+specification were loosened, like so:
+
+```clojure
+[[:hello-world
+  ["/hello-world" {:get hello-world}]]]
+```
+
+The application's name, `:hello-world`, is optionally used during URL
+generation, and can also be omitted, leaving this:
+
+```clojure
+[[["/hello-world" {:get hello-world}]]]
+```
+
+This is the smallest possible example of a useful route table.
+
+### Verb maps
+
+In most cases, a nested vector specifying routes contains a path and a verb
+map (there are exceptions, explained below). The verb map contains
+keys corresponding to HTTP verbs. All verbs are supported, along with
+the special value `:any`, indicating a match to any HTTP verb. Each
+verb represents a different route. The values in the verb map
+represent the "destination interceptor". Additional intermediate
+interceptors may also be invoked, as described below.
+
+The value for a key in a route's verb map specifies a route's
+destination interceptor. The value can be:
+
+- a symbol that resolves to one of:
+
+    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
+
+    - an interceptor
+
+    - a function that returns an interceptor and is marked with metadata ^{:interceptorfn true}
+
+- a vector containing the following:
+
+    - an optional keyword that names the route, for use in URL generation
+
+    - a value that is either:
+
+        - a symbol interpreted as described above
+
+        - a list that evaluates to either:
+
+            - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
+
+            - an interceptor
+
+    - an optional vector of interceptors, described below
+
+    - an optional map of constraints, described below
+
+The following sections explains how these values are used.
+
+### Terse format expansion
+
+A terse route definition must be expanded to a full route table
+before it can be used. There are two ways to do this:
+
+- the `io.pedestal.http.route.definition/expand-routes` function
+
+- the `io.pedestal.http.route.definition/defroutes` macro
+
+The `expand-routes` function takes a terse route definition data
+structure as input and returns a route table. For example:
+
+```clojure
+(defn hello-world [req] {:status 200 :body "Hello World!"})
+
+(def route-table
+  (expand-routes '[[["/hello-world" {:get hello-world}]]]))
+```
+
+Note that the terse data structure is quoted, making `hello-world` a
+symbol. It resolves the `hello-world` function, which takes a Ring
+request and returns a Ring response.
+
+The `defroutes` macro is equivalent to calling `expand-routes` with a
+quoted data structure:
+
+```clojure
+(defroutes route-table
+  [[["/hello-world" {:get hello-world}]]])
+```
+
+A quoted terse route definition is read at load time and is static
+after that. In some cases, you may need to dynamically generate
+routes. Here is an example:
+
+```clojure
+(defn hello-fn [who]
+  (fn [req] (ring.util.response/response (str "Hello " who)))
+
+(defn make-routes-for-who [who]
+  (expand-routes
+    `[[["/hello" {:get [:hello-who (hello-fn ~who)]}]]]))
+
+(def route-table (make-routes-for-who "World"))
+```
+
+In this case, the `make-routes-for-who` function takes an argument,
+`who`, that it uses to configure the resulting routes. It generates
+the terse route data structure using Clojure's syntax quote mechanism,
+splicing in the value of `who` where it is needed.
+
+In some cases, you may want to assemble the terse data structure
+without quoting it at all. Here is an example:
+
+```clojure
+(defn hello-world [req] {:status 200 :body "Hello World!"})
+
+(def route-table
+  (expand-routes
+    [[["/hello-world"
+ {:get [(handler ::hello-world hello-world)]}]]]))
+```
+
+In this case, the `hello-world` symbol is resolved to the
+`hello-world` function as the data structure is built. The `handler`
+function (defined in `io.pedestal.interceptor`) takes the
+function and builds an interceptor from it, to meet the requirement
+that a value in a verb map must be a symbol, an interceptor, or a list.
+
+Alternatively, `hello-world` can be defined as an interceptor
+directly, using the `io.pedestal.interceptor.helpers/defhandler` macro:
+
+```clojure
+(defhandler hello-world [req] {:status 200 :body "Hello World!"})
+
+(def route-table
+  (expand-routes
+    [[["/hello-world" {:get hello-world}]]]))
+```
+
+Or, `hello-world` can be quoted, making it a symbol again:
+
+```clojure
+(defn hello-world [req] {:status 200 :body "Hello World!"})
+
+(def route-table
+  (expand-routes
+    [[["/hello-world" {:get 'hello-world]}]]]))
+```
+
+The `expand-routes` function is more flexible, but also harder to use
+than the `defroutes` macro. The latter is preferred in most cases.
+
+## Advanced route definitions
+
+This section describes path parameters, hierarchical route
+definitions, intermediate interceptors and constraints.
+
+### Path parameters
+
+Segments of a route's path may be parameterized simply by
+prepending ':' to the segment's name:
+
+```clojure
+(defn hello-who [req]
+  (let [who (get-in req [:path-params :who])]
+    (ring.util.response/response (str "Hello " who))))
+
+(defroutes route-table [[["/hello/:who" {:get hello-who}]]])
+```
+As with Ring, Rails, etc, the path parameters are parsed and added to
+the request's param map.
+
+Splat parameters are also supported. They are defined using a final
+path segment prepended with '*', like this:
+
+```clojure
+[[["/hello/:who" {:get hello-who}]
+  ["/*other" {:get get-other-stuff}]]]
+```
+
+### Hierarchical route definitions
+
+Route definitions in the terse form are hierarchical. A route
+definition may contain zero or more child routes. A child route
+inherits information from it's ancestors.
+
+Here is an example showing how a path is inherited:
+
+```clojure
+[[["/order" {:get list-orders
+             :post create-order}
+   ["/:id" {:get view-order
+            :put update-order}]]]]
+```
+This defines these four routes:
+
+- GET /order
+
+- POST /order
+
+- GET /order/:id
+
+- PUT /order/:id
+
+The "/order" path segment is inherited by the child routes.
+
+It is worth noting that this same structure could be defined without
+hierarchy:
+
+```clojure
+[[["/order" {:get list-orders
+             :post create-order}]
+  ["/order/:id" {:get view-order
+                 :put update-order}]]]
+```
+This would produce the same four routes.
+
+### Interceptors
+
+Every route definition includes an interceptor path that will be
+executed for any request that matches the route. By default, a route's
+interceptor path contains one interceptor, the route's handler. For
+instance, the four routes defined in the previous section have the
+following interceptor paths:
+
+- GET /order => [list-orders]
+
+- POST /order => [create-order]
+
+- GET /order/:id => [view-order]
+
+- PUT /order/:id => [update-order]
+
+Route definitions can specify additional interceptors to include in
+the interceptor path for a given route. These interceptors function as
+before, after or around filters for specific routes. They are
+specified using a vector marked with `^:interceptors` metadata. The
+values specified in the interceptors vector may be:
+
+- a symbol that resolves to one of:
+
+    - an interceptor
+
+    - a function that returns an interceptor and is marked with metadata ^{:interceptorfn true}
+
+    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
+
+- a list that evaluates to either:
+
+    - an interceptor
+
+    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
+
+Here is an example:
+
+```clojure
+[[["/order" {:get list-orders
+             :post create-order}
+   ["/:id" ^:interceptors [load-order-from-db]
+    {:get view-order
+     :put update-order}]]]]
+```
+With this additional interceptor specified for the second two routes,
+the interceptor paths become:
+
+- GET /order => [list-orders]
+
+- POST /order => [create-order]
+
+- GET /order/:id => [load-order-from-db view-order]
+
+- PUT /order/:id => [load-order-from-db update-order]
+
+Any number of interceptors may be specified as an order sequence:
+
+```clojure
+[[["/order" {:get list-orders
+             :post create-order}
+   ["/:id" ^:interceptors [load-order-from-db
+                           verify-order-ownership]
+    {:get view-order
+     :put update-order}]]]]
+```
+
+In this case, for requests that match the "/order/:id" route, the
+`load-order-from-db` interceptor will run before the
+`verify-order-ownership` interceptor, then the appropriate handler,
+`view-order` or `update-order`, will run.
+
+Interceptors may be specified at multiple levels of the hierarchy.
+Like paths, interceptors are inherited. Inherited interceptors always
+come first in the interceptor path for a given route.
+
+```clojure
+[[["/order" ^:interceptors [verify-request]
+   {:get list-orders
+    :post create-order}
+   ["/:id" ^:interceptors [verify-order-ownership
+                           load-order-from-db]
+    {:get view-order
+     :put update-order}]]]]
+```
+
+This definition produces the following routes and interceptor paths:
+
+- GET /order => [verify-request list-orders]
+
+- POST /order => [verify-request create-order]
+
+- GET /order/:id => [verify-request verify-order-ownership load-order-from-db view-order]
+
+- PUT /order/:id => [verify-request verify-order-ownership load-order-from-db update-order]
+
+Inherited interceptors always precede a route definition's own handlers
+in its interceptor path.
+
+### Constraints
+
+A route may specify constraints on path parameters and query string
+parameters. Constraints are tested when a request is being matched
+against a route. If the request does not satisfy a route's constraints, it
+is not considered a match.
+
+Constraints are specified as a map marked with `^:constraints`
+metadata. The keys in the map are path parameters or query string
+parameters. The values are regular expressions used for testing
+parameter values.
+
+Here is an example of how constraints can be used:
+
+```clojure
+["/user" {:get list-users
+          :post add-user}
+ ["/:user-id"
+ ^:constraints {:user-id #"[0-9]+"}
+  {:put update-user}
+  [^:constraints {:view #"long|short"}
+   {:get view-user}]]]
+```
+
+This defines four routes:
+
+- GET /user => [list-users]
+
+- POST /user => [add-user]
+
+- PUT /user/:user-id => [update-user],
+  but only if :user-id matches [0-9]+
+
+- GET /user/:user-id => [view-user],
+  but only if :user-id matches [0-9]+ and there is a "view" query param whose value is either "long" or "short"
+
+Note that constraints can be used in addition to or in place of a path
+when defining a child route. In that case, they must appear as the
+first item in the child route vector.
+
+Like intermediate interceptors, constraints are inherited by child routes.
+
+# Routing
+
+Once a route table is defined, it can be used to create a router. The
+`io.pedestal.http.route/router` function takes a route table as
+input and returns an interceptor that handles routing.
+
+```clojure
+(defn hello-world [req] {:status 200 :body "Hello World!"})
+
+(defroutes route-table
+    [[["/hello-world" {:get hello-world}]]])
+
+(def router (router route-table))
+```
+
+When a routing interceptor's enter function is invoked, it attempts to
+match the incoming request against each route in the route table in
+turn. If a route matches, the routing interceptor adds all the
+interceptors for the given route to the current interceptor path. They
+will be invoked by the interceptor engine after the router's function
+completes. It also adds the selected route to the interceptor context
+map so that other interceptors can know which route was selected.
+
+If no route matches, the router simply returns the current interceptor
+context without modification.
+
+During development it is useful to be able to reprocess route
+definitions without restarting your server. If you call the `router`
+function and pass a function that returns a route table, it will be
+called every time the routing interceptor is used. This allows your
+Web server to use the latest compiled routes without restarting.
+
+```clojure
+(def router (router #(deref #'route-table)))
+```
+
+If you are using the Pedestal service template for lein, it provides a
+default route table and handles setting up a routing interceptor as
+one of the steps of building a service. It also configures use of the
+latest compiled routes when running in the repl.
+
+# URL generation
+
+In addition to routing, route tables are also used for URL
+generation. You can request a URL for a given route by name and
+specify parameter values to fill in. This section describes URL
+generation, starting with how routes are named.
+
+## Route names
+
+Every route has a name, represented as a keyword. Route names are
+implicit, where possible. For routes that specify destination
+interceptors using symbols, the name is the fully-qualified symbol
+name expressed as a keyword.
+
+For routes that specify destination interceptors directly as
+interceptor values, the route-name is the name of the interceptor.
+
+For interceptors defined using the `defbefore`, `defafter`,
+`defaround`, `defon-request`, `defhandler` and `defon-response` macros
+in the `io.pedestal.interceptor` namespace, the name is the
+interceptor's fully-qualified symbol name expressed as a keyword.
+
+For interceptors defined using the `before`, `after`, `around`,
+`on-request`, `handler` and `on-response` functions in the
+`io.pedestal.interceptor` namespace, the name is the keyword
+passed to the function, if any.
+
+For routes that specify interceptors indirectly as lists to be
+evaluated, no route name can be implicitly assigned.
+
+You can specify an explicit route name for any route by adding a
+keyword as the first item in the vector specified as the value of a
+given HTTP verb for a given route. Explicit route names take
+precedence over implicit names. *For routes that cannot be given an
+implicit name, an explicit name must be provided or an exception will
+be thrown during route expansion.*
+
+Here is an example.
+
+```clojure
+(require '[orders :as o])
+
+(defroutes routes
+  [[["/order" {:get o/list-orders
+               :post [:make-an-order o/create-order]}
+              ^:interceptors [verify-request]
+     ["/:id" {:get o/view-order
+              :put o/update-order}
+             ^:interceptors [o/verify-order-ownership
+                             o/load-order-from-db]]]]])
+```
+
+In this case, the destination interceptors are all specified as
+symbols in the `orders` namespace. The route names are listed below:
+
+- GET /order => :orders/list-orders
+
+- POST /order => :make-an-order
+
+- GET /order/:id => :orders/view-order
+
+- POST /order/:id => :orders/update-order
+
+The second route specified an explicit route name, `:make-an-order`,
+which takes precedence over the implicit name for that route,
+`:orders/create-order`.
+
+The `io.pedestal.http.route/print-routes` helper function prints
+route verbs, paths and names at the repl. When in doubt, you can use
+it to find route names.
+
+## URL generation
+
+The `io.pedestal.http.route/url-for-routes` function takes a
+route table and returns a function that accepts a route-name (and optional
+arguments) and returns a URL that can be used in a hyperlink.
+
+```clojure
+(def url-for (route/url-for-routes route-table))
+
+(url-for ::o/list-orders) ;; use keyword derived from symbol to name route
+;; => "/order"
+
+(url-for :make-an-order) ;; use specified route name
+;; => "/order"
+```
+
+An `url-for` function can populate parameters in a route. Parameter values
+are passed as additional arguments:
+
+```clojure
+(url-for :view-order :params {:id 10})
+;; => "/order/10"
+```
+
+Entries in the `:params` map that do not correspond to parameter values
+in a route's path are added to the returned URL as query string
+parameters. Alternatively, `:path-params` and `:query-params` can be
+used to specify parameter values independently.
+
+## Request-specific URL generation
+
+A route table provides the basis for URL generation. A request map can
+act as an additional basis. This allows for the generation of absolute
+vs relative URLs, depending on the URL a request was sent to and how
+specific a route-table is about an application's host name and
+supported schemes.
+
+When the routing interceptor matches a request to a route, it creates
+a new URL generator function that closes over the request. It adds the
+function to the interceptor context and the Ring request map, using
+the key `:url-for`.
+
+The request-specific URL generator function is also dynamically bound
+to a private var in the `io.pedestal.http.route` namespace. The
+`io.pedestal.http.route/url-for` function calls the dynamically
+bound function.
+
+The `io.pedestal.http.route/url-for` function can be called from
+any thread that is currently executing an interceptor. If you need to
+use a request-specific URL generator function elsewhere, extract
+`:url-for` from the context or request map and propagate it as needed.
+
+## Verb smuggling
+
+The `url-for` functions only return URLs. The
+`io.pedestal.http.route/form-action-for-routes` function takes a
+route table and returns a function that accepts a route-name (and optional
+arguments) and returns a map containing a URL and an HTTP verb.
+
+```clojure
+(def form-action (route/form-action-for-routes routes-table))
+
+(form-action :make-an-order)
+;; => {:action "/order" :method :post}
+```
+
+A form action function will (by default) convert verbs other than GET
+or POST to POST, with the actual verb added as a query string
+parameter named `method`:
+
+```clojure
+(form-action ::o/update-order :params {:id 20})
+;; => {:action "/order/20?`method=put" :method :post}
+```
+
+This behavior can be disabled (or enabled for `url-for` functions) and
+the query string parameter name can be changed. All of these settings
+can be modified when an `url-for` or `form-action` function is created
+or when it is invoked.

--- a/guides/documentation/service-routing.md
+++ b/guides/documentation/service-routing.md
@@ -253,7 +253,7 @@ You tell the router about constraints by supplying a map from
 parameter name to regular expression:
 
 ```clojure
-["/user/:user-id" :get view-user :constraints {:user-id #"[0-9]+"}
+["/user/:user-id" :get view-user :constraints {:user-id #"[0-9]+"}]
 ```
 
 If the constraint doesn't match, then the router keeps considering

--- a/guides/documentation/service-routing.md
+++ b/guides/documentation/service-routing.md
@@ -12,601 +12,360 @@
  You must not remove this notice, or any other, from this software.
 -->
 
-# Service Routing
+# Quick Reference
 
-Pedestal's HTTP service plumbing provides a mechanism for routing
-requests through an ordered list of interceptors that handle them. The
-same infrastructure supports generating URLs that, when used with the
-appropriate HTTP verb, cause a request to be routed to a particular
-interceptor list. This document describes how routing and URL generation
-work.
+Route vector format:
 
-# Routing Tables
+   1. Path string
+   2. Verb. One of :any, :get, :put, :post, :delete, :patch, :options,
+      :head
+   3. Handler or vector of interceptors
+   4. Optional route name clause
+   5. Optional constraint clause
 
-Pedestal's HTTP routing and URL generation features are driven by a
-route table. A route table is a sequence of routes. A route is a map
-containing criteria for matching an HTTP request and an ordered list
-of interceptors to invoke on a request that matches a particular
-route.
-
-A route matching is based on:
-
-* URL scheme
-* HTTP method
-* Host header
-* URL path
-* Constraints on param values in URL path and/or query string
-
-## Defining route tables
-
-A route table is simply a data structure; in our case, it is a
-sequence of maps. The structure caters to the needs of matching and
-dispatching of requests, and as such has a great deal of repeated
-and derived data intended for use in that process. Creating the
-data structure in its final, verbose form by hand would be very tedious.
-
-We've built a simpler, terse form for route tables. The
-terse form is also a data structure, albeit more explicitly hierarchical; Writing
-a route table in the terse form is easier because information is not
-explicitly duplicated. Instead, child nodes implicitly inherit
-relevant route data from their ancestors.
-
-It is important to note that the terse form is a convenient way to
-define route tables, nothing more. It is always expanded to the
-more verbose structure - a sequence of maps - before use. While a
-convenient authoring format, it is not
-directly used to route requests or generate URLs.
-
-## The terse format
-
-In the terse format, a route table is a vector of vectors, each
-describing an application. Each application vector can contain the
-following optional elements:
-
-- a keyword identifying the application by name (optional)
-- a URL scheme (optional)
-- a host name (optional)
-- one or more nested vectors specifying routes (required)
-
-Here is a simple "Hello World" example:
+Syntax for calling `route-table`
 
 ```clojure
-[[:hello-world :http "example.com"
-  ["/hello-world" {:get hello-world}]]]
+(ns myapp.service
+  (:require [io.pedestal.http.route.table :as table]))
+
+(def application-routes
+  (table/route-table
+    {:host "example.com" :scheme :https}
+    [["/user"          :get user-search-form]
+     ["/user/:user-id" :get view-user        :constraints {:user-id #"[0-9]+"}]
+     ,,,
+     ]))
 ```
-
-In this case, the following HTTP request:
-
-```
-GET /hello-world HTTP/1.1
-Host: example.com
-```
-
-would be routed to the `hello-world` interceptor.
-
-A request to a different host (either DNS name or IP
-address) or using HTTPS would not be routed, unless the application's
-specification were loosened, like so:
-
-```clojure
-[[:hello-world
-  ["/hello-world" {:get hello-world}]]]
-```
-
-The application's name, `:hello-world`, is optionally used during URL
-generation, and can also be omitted, leaving this:
-
-```clojure
-[[["/hello-world" {:get hello-world}]]]
-```
-
-This is the smallest possible example of a useful route table.
-
-### Verb maps
-
-In most cases, a nested vector specifying routes contains a path and a verb
-map (there are exceptions, explained below). The verb map contains
-keys corresponding to HTTP verbs. All verbs are supported, along with
-the special value `:any`, indicating a match to any HTTP verb. Each
-verb represents a different route. The values in the verb map
-represent the "destination interceptor". Additional intermediate
-interceptors may also be invoked, as described below.
-
-The value for a key in a route's verb map specifies a route's
-destination interceptor. The value can be:
-
-- a symbol that resolves to one of:
-
-    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
-
-    - an interceptor
-
-    - a function that returns an interceptor and is marked with metadata ^{:interceptorfn true}
-
-- a vector containing the following:
-
-    - an optional keyword that names the route, for use in URL generation
-
-    - a value that is either:
-
-        - a symbol interpreted as described above
-
-        - a list that evaluates to either:
-
-            - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
-
-            - an interceptor
-
-    - an optional vector of interceptors, described below
-
-    - an optional map of constraints, described below
-
-The following sections explains how these values are used.
-
-### Terse format expansion
-
-A terse route definition must be expanded to a full route table
-before it can be used. There are two ways to do this:
-
-- the `io.pedestal.http.route.definition/expand-routes` function
-
-- the `io.pedestal.http.route.definition/defroutes` macro
-
-The `expand-routes` function takes a terse route definition data
-structure as input and returns a route table. For example:
-
-```clojure
-(defn hello-world [req] {:status 200 :body "Hello World!"})
-
-(def route-table
-  (expand-routes '[[["/hello-world" {:get hello-world}]]]))
-```
-
-Note that the terse data structure is quoted, making `hello-world` a
-symbol. It resolves the `hello-world` function, which takes a Ring
-request and returns a Ring response.
-
-The `defroutes` macro is equivalent to calling `expand-routes` with a
-quoted data structure:
-
-```clojure
-(defroutes route-table
-  [[["/hello-world" {:get hello-world}]]])
-```
-
-A quoted terse route definition is read at load time and is static
-after that. In some cases, you may need to dynamically generate
-routes. Here is an example:
-
-```clojure
-(defn hello-fn [who]
-  (fn [req] (ring.util.response/response (str "Hello " who)))
-
-(defn make-routes-for-who [who]
-  (expand-routes
-    `[[["/hello" {:get [:hello-who (hello-fn ~who)]}]]]))
-
-(def route-table (make-routes-for-who "World"))
-```
-
-In this case, the `make-routes-for-who` function takes an argument,
-`who`, that it uses to configure the resulting routes. It generates
-the terse route data structure using Clojure's syntax quote mechanism,
-splicing in the value of `who` where it is needed.
-
-In some cases, you may want to assemble the terse data structure
-without quoting it at all. Here is an example:
-
-```clojure
-(defn hello-world [req] {:status 200 :body "Hello World!"})
-
-(def route-table
-  (expand-routes
-    [[["/hello-world"
- {:get [(handler ::hello-world hello-world)]}]]]))
-```
-
-In this case, the `hello-world` symbol is resolved to the
-`hello-world` function as the data structure is built. The `handler`
-function (defined in `io.pedestal.interceptor`) takes the
-function and builds an interceptor from it, to meet the requirement
-that a value in a verb map must be a symbol, an interceptor, or a list.
-
-Alternatively, `hello-world` can be defined as an interceptor
-directly, using the `io.pedestal.interceptor.helpers/defhandler` macro:
-
-```clojure
-(defhandler hello-world [req] {:status 200 :body "Hello World!"})
-
-(def route-table
-  (expand-routes
-    [[["/hello-world" {:get hello-world}]]]))
-```
-
-Or, `hello-world` can be quoted, making it a symbol again:
-
-```clojure
-(defn hello-world [req] {:status 200 :body "Hello World!"})
-
-(def route-table
-  (expand-routes
-    [[["/hello-world" {:get 'hello-world]}]]]))
-```
-
-The `expand-routes` function is more flexible, but also harder to use
-than the `defroutes` macro. The latter is preferred in most cases.
-
-## Advanced route definitions
-
-This section describes path parameters, hierarchical route
-definitions, intermediate interceptors and constraints.
-
-### Path parameters
-
-Segments of a route's path may be parameterized simply by
-prepending ':' to the segment's name:
-
-```clojure
-(defn hello-who [req]
-  (let [who (get-in req [:path-params :who])]
-    (ring.util.response/response (str "Hello " who))))
-
-(defroutes route-table [[["/hello/:who" {:get hello-who}]]])
-```
-As with Ring, Rails, etc, the path parameters are parsed and added to
-the request's param map.
-
-Splat parameters are also supported. They are defined using a final
-path segment prepended with '*', like this:
-
-```clojure
-[[["/hello/:who" {:get hello-who}]
-  ["/*other" {:get get-other-stuff}]]]
-```
-
-### Hierarchical route definitions
-
-Route definitions in the terse form are hierarchical. A route
-definition may contain zero or more child routes. A child route
-inherits information from it's ancestors.
-
-Here is an example showing how a path is inherited:
-
-```clojure
-[[["/order" {:get list-orders
-             :post create-order}
-   ["/:id" {:get view-order
-            :put update-order}]]]]
-```
-This defines these four routes:
-
-- GET /order
-
-- POST /order
-
-- GET /order/:id
-
-- PUT /order/:id
-
-The "/order" path segment is inherited by the child routes.
-
-It is worth noting that this same structure could be defined without
-hierarchy:
-
-```clojure
-[[["/order" {:get list-orders
-             :post create-order}]
-  ["/order/:id" {:get view-order
-                 :put update-order}]]]
-```
-This would produce the same four routes.
-
-### Interceptors
-
-Every route definition includes an interceptor path that will be
-executed for any request that matches the route. By default, a route's
-interceptor path contains one interceptor, the route's handler. For
-instance, the four routes defined in the previous section have the
-following interceptor paths:
-
-- GET /order => [list-orders]
-
-- POST /order => [create-order]
-
-- GET /order/:id => [view-order]
-
-- PUT /order/:id => [update-order]
-
-Route definitions can specify additional interceptors to include in
-the interceptor path for a given route. These interceptors function as
-before, after or around filters for specific routes. They are
-specified using a vector marked with `^:interceptors` metadata. The
-values specified in the interceptors vector may be:
-
-- a symbol that resolves to one of:
-
-    - an interceptor
-
-    - a function that returns an interceptor and is marked with metadata ^{:interceptorfn true}
-
-    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
-
-- a list that evaluates to either:
-
-    - an interceptor
-
-    - a function that accepts a Ring request map and returns a Ring response map (i.e. a Ring handler)
-
-Here is an example:
-
-```clojure
-[[["/order" {:get list-orders
-             :post create-order}
-   ["/:id" ^:interceptors [load-order-from-db]
-    {:get view-order
-     :put update-order}]]]]
-```
-With this additional interceptor specified for the second two routes,
-the interceptor paths become:
-
-- GET /order => [list-orders]
-
-- POST /order => [create-order]
-
-- GET /order/:id => [load-order-from-db view-order]
-
-- PUT /order/:id => [load-order-from-db update-order]
-
-Any number of interceptors may be specified as an order sequence:
-
-```clojure
-[[["/order" {:get list-orders
-             :post create-order}
-   ["/:id" ^:interceptors [load-order-from-db
-                           verify-order-ownership]
-    {:get view-order
-     :put update-order}]]]]
-```
-
-In this case, for requests that match the "/order/:id" route, the
-`load-order-from-db` interceptor will run before the
-`verify-order-ownership` interceptor, then the appropriate handler,
-`view-order` or `update-order`, will run.
-
-Interceptors may be specified at multiple levels of the hierarchy.
-Like paths, interceptors are inherited. Inherited interceptors always
-come first in the interceptor path for a given route.
-
-```clojure
-[[["/order" ^:interceptors [verify-request]
-   {:get list-orders
-    :post create-order}
-   ["/:id" ^:interceptors [verify-order-ownership
-                           load-order-from-db]
-    {:get view-order
-     :put update-order}]]]]
-```
-
-This definition produces the following routes and interceptor paths:
-
-- GET /order => [verify-request list-orders]
-
-- POST /order => [verify-request create-order]
-
-- GET /order/:id => [verify-request verify-order-ownership load-order-from-db view-order]
-
-- PUT /order/:id => [verify-request verify-order-ownership load-order-from-db update-order]
-
-Inherited interceptors always precede a route definition's own handlers
-in its interceptor path.
-
-### Constraints
-
-A route may specify constraints on path parameters and query string
-parameters. Constraints are tested when a request is being matched
-against a route. If the request does not satisfy a route's constraints, it
-is not considered a match.
-
-Constraints are specified as a map marked with `^:constraints`
-metadata. The keys in the map are path parameters or query string
-parameters. The values are regular expressions used for testing
-parameter values.
-
-Here is an example of how constraints can be used:
-
-```clojure
-["/user" {:get list-users
-          :post add-user}
- ["/:user-id"
- ^:constraints {:user-id #"[0-9]+"}
-  {:put update-user}
-  [^:constraints {:view #"long|short"}
-   {:get view-user}]]]
-```
-
-This defines four routes:
-
-- GET /user => [list-users]
-
-- POST /user => [add-user]
-
-- PUT /user/:user-id => [update-user],
-  but only if :user-id matches [0-9]+
-
-- GET /user/:user-id => [view-user],
-  but only if :user-id matches [0-9]+ and there is a "view" query param whose value is either "long" or "short"
-
-Note that constraints can be used in addition to or in place of a path
-when defining a child route. In that case, they must appear as the
-first item in the child route vector.
-
-Like intermediate interceptors, constraints are inherited by child routes.
 
 # Routing
 
-Once a route table is defined, it can be used to create a router. The
-`io.pedestal.http.route/router` function takes a route table as
-input and returns an interceptor that handles routing.
+A key problem in any backend service is directing requests to the
+right bit of code. As an industry, we've settled on the term "routing"
+to describe how a service understands a request's URL and invokes the
+right function.
+
+There's a flip side to routing, though, which is generating URLs to
+put into links and hrefs. If we're not careful, link generation can
+create hard-to-find coupling between different parts of a service.
+
+Pedestal addresses both parts of this problem with the same feature.
+
+This guide will teach you how to:
+
+   * Define routes
+   * Parse parameters from URLs
+   * Connect routes to handlers
+   * Apply interceptors along a route
+   * Use constraints to ensure a route is invoked correctly
+   * Generate links for a route during a request to that route
+   * Generate links for _other_ routes
+
+# A note about routing syntax
+
+Since Pedestal was first unveiled, we've gone through a couple of
+iterations on the routing syntax. So far, these iterations have all
+been additive. Previous guides have used the "terse" syntax, which is
+written as a triply-nested vector. The terse syntax is powerful but
+not easy.
+
+This release introduces a new syntax we're calling the "table"
+syntax. It is more wordy and has some repetition from row to row, but
+it also has some advantages:
+
+   1. The parser is simpler and produces better error messages when
+      the input is not right. (This includes some work to make stack
+      traces more helpful.)
+   2. The table does not have hierarchic nesting, so the rows are
+      independent.
+   3. The input is just data, so you can read it from an EDN file or
+      compose it with regular functions. No more syntax-quoting to
+      create interceptors with parameters.
+
+The "terse" and "verbose" syntaxes are both still supported, until we
+hear from the community. We've also put some effort into better error
+messages when dealing with the terse format.
+
+# Defining a route
+
+## The Bare Minimum
+
+The simplest route has just a URL, an HTTP verb, and a handler:
 
 ```clojure
-(defn hello-world [req] {:status 200 :body "Hello World!"})
-
-(defroutes route-table
-    [[["/hello-world" {:get hello-world}]]])
-
-(def router (router route-table))
+["/users" :get view-users]
 ```
 
-When a routing interceptor's enter function is invoked, it attempts to
-match the incoming request against each route in the route table in
-turn. If a route matches, the routing interceptor adds all the
-interceptors for the given route to the current interceptor path. They
-will be invoked by the interceptor engine after the router's function
-completes. It also adds the selected route to the interceptor context
-map so that other interceptors can know which route was selected.
+In this case, view-users is anything that can be resolved as an
+interceptor:
 
-If no route matches, the router simply returns the current interceptor
-context without modification.
+   * An interceptor record
+   * A function that returns an interceptor (the function must be
+     annotated as `^:interceptor-fn`)
+   * A request handler (really a special case of interceptor)
 
-During development it is useful to be able to reprocess route
-definitions without restarting your server. If you call the `router`
-function and pass a function that returns a route table, it will be
-called every time the routing interceptor is used. This allows your
-Web server to use the latest compiled routes without restarting.
+## Building handlers
+
+There's nothing special about using a symbol in the handler's
+position. You could call a function that returns an interceptor:
 
 ```clojure
-(def router (router #(deref #'route-table)))
+["/users" :get (make-view-users-handler db-conn)]
 ```
 
-If you are using the Pedestal service template for lein, it provides a
-default route table and handles setting up a routing interceptor as
-one of the steps of building a service. It also configures use of the
-latest compiled routes when running in the repl.
+In previous versions of Pedestal, we did some magic to treat that
+function call as a list and defer evaluation. This led to a lot of
+confusion and some questions like, "When should I syntax-quote?" and
+"How do I inject context into request handling?"
 
-# URL generation
+In contrast, that call to `make-view-users-handler` is nothing
+special. Clojure will evaluate it when you build the route table. Just
+make sure it returns something that can be resolved as an interceptor.
+
+## Path Parameters
+
+The URL in a route is really a pattern that can match or generate
+URLs. In the simple case above, `/users` just matches itself as a
+literal string.
+
+The pattern can include any number of segments to capture as
+parameters. Any segment that looks like a keyword will be captured in
+the :path-params map in the request.
+
+So the route:
+
+```clojure
+["/users/:user-id" :get view-users]
+```
+
+will match any of the following requests:
+
+   - `/users/abacab`
+   - `/users/miken`
+   - `/users/12345`
+   - `/users/mike%20n`
+
+When the request reaches our `view-users` handler, it will include a
+map like this:
+
+```clojure
+{:path-params {:user-id "miken"}}
+```
+
+The path parameters are always delivered as strings. The strings are
+HTTP decoded for you, but are not otherwise converted.
+
+A single path parameter only matches one segment of a URL. One segment
+is just the part between '/' characters. So the route above will _not_
+match `/users/miken/profile/photos/blue-wig.jpg`.
+
+What if our user IDs are all numeric? It would be convenient if the
+route would only match when the URL meets a valid pattern in the path
+parameters. That's the job of [Constraints](#constraints), discussed below.
+
+## Catch-all Parameters
+
+What if you actually do want to match any number of segments after a
+path? In that case, you use a "catch-all" parameter. It looks like a
+path parameter, except it has an asterisk instead of a colon:
+
+```clojure
+["/users/:user-id/profile/*subpage" :get view-user-profile]
+```
+
+This is still delivered as a path parameter in the request map:
+
+```clojure
+{:path-params {:user-id "miken" :subpage "photos/blue-wig.jpg"}}
+```
+
+## Query Parameters
+
+You don't need to do anything in the route to capture query
+parameters. They are automatically parsed and passed in the request
+map, under the :query-params key. Like path parameters, query
+parameters are always delivered as HTTP-decoded strings.
+
+## Verbs
+
+So far, all our examples have used :get as the HTTP verb. Pedestal
+supports the following verbs:
+
+   - :get
+   - :put
+   - :post
+   - :delete
+   - :patch
+   - :options
+   - :head
+   - :any
+
+These should look familiar, with the exception of `:any`. `:any` is a
+wildcard verb that allows a route to match any request method. That
+gives a handler the opportunity to decide whether a request method is
+allowed or not.
+
+## Interceptors
+
+So far, all our examples have used just one handler function. But one
+of Pedestal's key features is the ability to create a chain of
+interceptors. The route table allows you to put a vector of
+interceptors (or things that resolve to interceptors) in that third
+position.
+
+```clojure
+["/user/:user-id/private" :post [inject-connection auth-required (body-params/body-params) view-user]
+```
+
+In this example, `inject-connection` and `auth-required` are
+interceptors. `body-params` is a builtin function (from
+io.pedestal.http.body-params) that returns an interceptor. `view-user`
+is a request-handling function.
+
+When a request matches this route, the whole vector of interceptors
+gets pushed onto the context.
+
+### Common interceptors
+
+The "terse" syntax used hierarchically nested routes to reuse
+interceptors on subtrees. The table based syntax gives up that
+feature, but allows you to compose interceptors like this:
+
+```clojure
+;; Make a var with the common stuff
+(def common-interceptors [inject-connection auth-required (body-params/body-params)])
+
+;; inside a call to route-table
+["/user/:user-id/private" :post (conj common-interceptors view-user)]
+```
+
+This puts you in charge of composing interceptors using ordinary
+Clojure data manipulation.
+
+## Constraints
+
+As a convenience, you can supply a map of constraints, in the form of
+regular expressions, that must match in order for the whole route to
+match. This handles that case from [before](#path-parameters), where
+we wanted to say that user IDs must be numeric.
+
+You tell the router about constraints by supplying a map from
+parameter name to regular expression:
+
+```clojure
+["/user/:user-id" :get view-user :constraints {:user-id #"[0-9]+"}
+```
+
+If the constraint doesn't match, then the router keeps considering
+other routes. If none match, then it's a 404.
+
+Notice the `:constraints` keyword. That is required to tell the router
+that the following map is to be treated as constraints. (The terse
+syntax used a boolean flag in metadata for this purpose.)
+
+Like the interceptor vector, the constraint map is just data. Feel
+free to build it up however you like... it doesn't have to be a map
+literal in the route vector:
+
+```clojure
+(def numeric #"[0-9]+")
+(def user-id {:user-id numeric})
+
+["/user/:user-id" :get  view-user   :constraints user-id]
+["/user/:user-id" :post update-user :constraints user-id]
+```
+
+## Route names
+
+Every route must have a name. Pedestal uses those names for the flip
+side of route matching: URL generation. You can supply a route name in
+the route vector:
+
+```clojure
+["/user" :get view-user :route-name :view-user-profile]
+```
+
+A route name must be a keyword.
+
+The route name comes before `:constraints`, so if you have both, the
+order is as follows
+
+   1. Path
+   2. Verb
+   3. Interceptors
+   4. Route name clause (:route-name :your-route-name)
+   5. Constraints clause (:constraints _constraint-map_)
+
+### Default Route Names
+
+You'll notice that none of the examples before now have a
+`:route-name` section. If you don't explicitly specify a route name,
+Pedestal will pick one for you. It uses the `:name` of the last
+interceptor in the interceptor vector (after resolving functions to
+interceptors.) Most of the time, you'll have different handler
+functions in that terminal position. But, if you reuse an interceptor
+as the final step of the chain, you will have to assign unique route
+names to distinguish them.
+
+## Generating URLs
 
 In addition to routing, route tables are also used for URL
 generation. You can request a URL for a given route by name and
 specify parameter values to fill in. This section describes URL
 generation, starting with how routes are named.
 
-## Route names
-
-Every route has a name, represented as a keyword. Route names are
-implicit, where possible. For routes that specify destination
-interceptors using symbols, the name is the fully-qualified symbol
-name expressed as a keyword.
-
-For routes that specify destination interceptors directly as
-interceptor values, the route-name is the name of the interceptor.
-
-For interceptors defined using the `defbefore`, `defafter`,
-`defaround`, `defon-request`, `defhandler` and `defon-response` macros
-in the `io.pedestal.interceptor` namespace, the name is the
-interceptor's fully-qualified symbol name expressed as a keyword.
-
-For interceptors defined using the `before`, `after`, `around`,
-`on-request`, `handler` and `on-response` functions in the
-`io.pedestal.interceptor` namespace, the name is the keyword
-passed to the function, if any.
-
-For routes that specify interceptors indirectly as lists to be
-evaluated, no route name can be implicitly assigned.
-
-You can specify an explicit route name for any route by adding a
-keyword as the first item in the vector specified as the value of a
-given HTTP verb for a given route. Explicit route names take
-precedence over implicit names. *For routes that cannot be given an
-implicit name, an explicit name must be provided or an exception will
-be thrown during route expansion.*
-
-Here is an example.
-
-```clojure
-(require '[orders :as o])
-
-(defroutes routes
-  [[["/order" {:get o/list-orders
-               :post [:make-an-order o/create-order]}
-              ^:interceptors [verify-request]
-     ["/:id" {:get o/view-order
-              :put o/update-order}
-             ^:interceptors [o/verify-order-ownership
-                             o/load-order-from-db]]]]])
-```
-
-In this case, the destination interceptors are all specified as
-symbols in the `orders` namespace. The route names are listed below:
-
-- GET /order => :orders/list-orders
-
-- POST /order => :make-an-order
-
-- GET /order/:id => :orders/view-order
-
-- POST /order/:id => :orders/update-order
-
-The second route specified an explicit route name, `:make-an-order`,
-which takes precedence over the implicit name for that route,
-`:orders/create-order`.
-
-The `io.pedestal.http.route/print-routes` helper function prints
-route verbs, paths and names at the repl. When in doubt, you can use
-it to find route names.
 
 ## URL generation
 
-The `io.pedestal.http.route/url-for-routes` function takes a
-route table and returns a function that accepts a route-name (and optional
-arguments) and returns a URL that can be used in a hyperlink.
+The `io.pedestal.http.route/url-for-routes` function takes the parsed
+route table and returns a URL generating function. The generator
+accepts a route name and optional arguments and returns a URL that can
+be used in a hyperlink.
 
 ```clojure
-(def url-for (route/url-for-routes route-table))
+(def app-routes
+   (table/route-table
+     {}
+     [["/user"                   :get  user-search-form]
+      ["/user/:user-id"          :get  view-user        :route-name :show-user-profile]
+      ["/user/:user-id/timeline" :post post-timeline    :route-name :timeline]
+      ["/user/:user-id/profile"  :put  update-profile]]))
 
-(url-for ::o/list-orders) ;; use keyword derived from symbol to name route
-;; => "/order"
+(def url-for (route/url-for-routes app-routes))
 
-(url-for :make-an-order) ;; use specified route name
-;; => "/order"
+(url-for :user-search-form)
+;; => "/user"
+
+(url-for :view-user :params {:user-id "12345"})
+;; => "/user/12345"
 ```
 
-An `url-for` function can populate parameters in a route. Parameter values
-are passed as additional arguments:
-
-```clojure
-(url-for :view-order :params {:id 10})
-;; => "/order/10"
-```
-
-Entries in the `:params` map that do not correspond to parameter values
-in a route's path are added to the returned URL as query string
-parameters. Alternatively, `:path-params` and `:query-params` can be
-used to specify parameter values independently.
+Any leftover entries in the `:params` map that do not correspond to
+path parameters get turned into query string parameters. If you want
+more control, you can give the generator the specific arguments
+`:path-params` and `:query-params`.
 
 ## Request-specific URL generation
 
-A route table provides the basis for URL generation. A request map can
-act as an additional basis. This allows for the generation of absolute
-vs relative URLs, depending on the URL a request was sent to and how
-specific a route-table is about an application's host name and
-supported schemes.
+The `url-for-routes` function provides a global URL generator. Within
+a single request, the request map itself can provide a URL
+generator. This generator allows you to create absolute or relative
+URLs depending on how the request was matched.
 
 When the routing interceptor matches a request to a route, it creates
-a new URL generator function that closes over the request. It adds the
-function to the interceptor context and the Ring request map, using
-the key `:url-for`.
+a new URL generator function that closes over the request map. It adds
+the function to the interceptor context and the request map, using the
+key `:url-for`.
 
-The request-specific URL generator function is also dynamically bound
+The routing interceptor also binds this request-specific URL generator
 to a private var in the `io.pedestal.http.route` namespace. The
-`io.pedestal.http.route/url-for` function calls the dynamically
-bound function.
-
-The `io.pedestal.http.route/url-for` function can be called from
+`io.pedestal.http.route/url-for` function calls the dynamically bound
+function. This way, you can call `io.pedestal.http.route/url-for` from
 any thread that is currently executing an interceptor. If you need to
 use a request-specific URL generator function elsewhere, extract
 `:url-for` from the context or request map and propagate it as needed.
 
-## Verb smuggling
+### Verb smuggling
 
 The `url-for` functions only return URLs. The
 `io.pedestal.http.route/form-action-for-routes` function takes a
@@ -614,22 +373,91 @@ route table and returns a function that accepts a route-name (and optional
 arguments) and returns a map containing a URL and an HTTP verb.
 
 ```clojure
-(def form-action (route/form-action-for-routes routes-table))
+(def form-action (route/form-action-for-routes app-routes))
 
-(form-action :make-an-order)
-;; => {:action "/order" :method :post}
+(form-action :timeline :params {:user-id 12345)
+;; => {:method "post", :action "/user/:user-id/timeline"}
 ```
 
 A form action function will (by default) convert verbs other than GET
 or POST to POST, with the actual verb added as a query string
-parameter named `method`:
+parameter named `_method`:
 
 ```clojure
-(form-action ::o/update-order :params {:id 20})
-;; => {:action "/order/20?`method=put" :method :post}
+(form-action :update-profile :params {:user-id 12345})
+;; => {:method "post", :action "/user/12345/profile?_method=put"}
 ```
 
 This behavior can be disabled (or enabled for `url-for` functions) and
 the query string parameter name can be changed. All of these settings
 can be modified when an `url-for` or `form-action` function is created
 or when it is invoked.
+
+## Using the Routes in a Service
+
+Up until now, we've looked at individual routes or a small handful of
+them. Now let's see how to connect them to a Pedestal service.
+
+We'll start with the `app-routes` definition from
+[earlier](#url-generation). We can use that value in the service map:
+
+```clojure
+(ns myapp.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.route.table :as table]))
+
+;; definition of app-routes from above
+
+(defn service
+  []
+  {:env :prod
+   ::http/routes app-routes
+   ::http/resource-path "/public"
+   ::http/type :jetty
+   ::http/port 8080})
+
+(defn start
+  []
+  (-> service
+      http/create-server
+      http/start))
+```
+
+## Debugging Routes
+
+The `io.pedestal.http.route/print-routes` helper function prints
+route verbs, paths and names at the repl. When in doubt, you can use
+it to find route names.
+
+The function `io.pedestal.http.route/try-routing-for` lets you explore
+routing decisions from a REPL. It will return the chosen route or nil
+if nothing matched. Using the definition of `app-routes`
+from before:
+
+```clojure
+(route/try-routing-for app-routes :prefix-tree "/user" :get)
+;; => {:path "/user", :method :get, :path-re #"/\Quser\E", :path-parts ["user"], :interceptors [#Interceptor{:name :user-search-form}], :route-name :user-search-form, :path-params {}, :io.pedestal.http.route.prefix-tree/satisfies-constraints? #function[clojure.core/constantly/fn--4608]}
+
+(route/try-routing-for app-routes :prefix-tree "/foo-bar-baz" :get)
+;; => nil
+```
+
+Sometimes your routes will look right, but you still get a 404
+response. This can happen if the final interceptor doesn't attach a
+response. The easiest way to debug that is to add a `println` inside
+the interceptor that you think should be called.
+
+You can also call one of an interceptor's functions directly to see if
+it behaves as expected. Suppose you are debugging the `view-user`
+interceptor. Since it is the final interceptor in its chain, the
+context must have a response after calling it. To call the `:enter`
+function on `view-user`:
+
+```clojure
+((:enter view-user) {})
+;; => {:response {:status 200 :body ,,, :headers {,,,}}}
+```
+
+Here we can see that `view-user` does indeed attach a response to the
+resulting context.

--- a/service/src/io/pedestal/http/route.clj
+++ b/service/src/io/pedestal/http/route.clj
@@ -141,12 +141,6 @@
           (dissoc-in param-path))
       request)))
 
-(defn print-routes
-  "Prints route table `routes` in easier to read format."
-  [routes]
-  (doseq [r (map (fn [{:keys [method path route-name]}] [method path route-name]) routes)]
-    (println r)))
-
 ;;; Linker
 
 (defn- merge-param-options
@@ -452,3 +446,17 @@
                                 (not (= :get method)))
                          :post
                          method))}))))
+
+;;; Help for debugging
+(defn print-routes
+  "Prints route table `routes` in easier to read format."
+  [routes]
+  (doseq [r (map (fn [{:keys [method path route-name]}] [method path route-name]) routes)]
+    (println r)))
+
+(defn try-routing-for [spec router-type query-string verb]
+  (let [router  (router spec router-type)
+        context {:request {:path-info query-string
+                           :request-method verb}}
+        context ((:enter router) context)]
+    (:route context)))

--- a/service/src/io/pedestal/http/route.clj
+++ b/service/src/io/pedestal/http/route.clj
@@ -22,6 +22,8 @@
             [io.pedestal.http.route.prefix-tree :as prefix-tree])
   (:import (java.net URLEncoder URLDecoder)))
 
+(def allowed-keys #{:route-name :app-name :path :method :scheme :host :port :interceptors :path-re :path-parts :path-params :path-constraints :query-constraints :matcher})
+
 (comment
   ;; Structure of a route. 'tree' returns a list of these.
   {:route-name :new-user

--- a/service/src/io/pedestal/http/route/path.clj
+++ b/service/src/io/pedestal/http/route/path.clj
@@ -40,7 +40,7 @@
          (reduce parse-path-token
                  accumulated-info
                  (str/split path #"/")))
-       (throw (ex-info "Invalid route pattern" {:pattern pattern})))))
+       (throw (ex-info "Routes must start from the root, so they must begin with a '/'" {:pattern pattern})))))
 
 (defn path-regex [route]
   (let [{:keys [path-parts path-constraints]} route

--- a/service/src/io/pedestal/http/route/table.clj
+++ b/service/src/io/pedestal/http/route/table.clj
@@ -1,0 +1,97 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.route.table
+  (:require [io.pedestal.interceptor :as i]
+            [io.pedestal.http.route :as route]))
+
+(defn- syntax-error
+  [{:keys [row original]} posn expected was]
+  (format  "In row %d, %s should have been %s but was %s.\nThe whole route was was: %s"
+           (inc row) posn expected (or was "nil") (or original "nil")))
+
+(defn- surplus-declarations
+  [{:keys [row original remaining]}]
+  (format "In row %s, there were unused elements %s.\nThe input was: %s"
+          (inc row) remaining original))
+
+(def ^:private known-options [:app-name :host :port :scheme])
+(def ^:private known-verb    #{:any :get :put :post :delete :patch :options :head})
+(def ^:private default-port  {:http 80 :https 443})
+
+(defn apply-defaults
+  [{:keys [port scheme] :as opts}]
+  (if-not port
+    (assoc opts :port (default-port (or scheme :http)))
+    opts))
+
+(defn take-next-pair
+  [argname expected-pred expected-str ctx]
+  (let [[param arg & more] (:remaining ctx)]
+    (if (= argname param)
+      (do
+        (assert (expected-pred arg) (syntax-error ctx (str "the parameter after" argname) expected-str arg))
+        (assoc ctx argname arg :remaining more))
+      ctx)))
+
+(def parse-constraints (partial take-next-pair :constraints map? "a map"))
+(def parse-route-name  (partial take-next-pair :route-name  keyword? "a keyword"))
+
+(defn parse-path
+  [ctx]
+  (let [[path & more] (:remaining ctx)]
+    (assert (string? path) (syntax-error ctx "the path (first element)" "a string" path))
+    (assoc ctx :path path :remaining more)))
+
+(defn parse-verb
+  [ctx]
+  (let [[verb & more] (:remaining ctx)]
+    (assert (known-verb verb) (syntax-error ctx "the verb (second element)" (str "one of " known-verb) verb))
+    (assoc ctx :method verb :remaining more)))
+
+(defn parse-handlers
+  [ctx]
+  (let [[handlers & more] (:remaining ctx)]
+    (if (vector? handlers)
+      (assert (every? i/interceptor? handlers) (syntax-error ctx "the vector of handlers" "a bunch of interceptors" handlers))
+      (assert (i/interceptor? handlers)        (syntax-error ctx "the handler" "an interceptor" handlers)))
+    (assoc ctx :interceptors handlers :remaining more)))
+
+(defn parse-context
+  [opts row route]
+  (assert (vector? route) (syntax-error row nil "the element" "a vector" route))
+  (merge {:row       row
+          :original  route
+          :remaining route}
+         (select-keys opts known-options)))
+
+(defn finalize
+  [ctx]
+  (assert (empty? (:remaining ctx)) (surplus-declarations ctx))
+  (select-keys ctx route/allowed-keys))
+
+(defn route-table-row
+  [opts row route]
+  (-> opts
+      apply-defaults
+      (parse-context row route)
+      parse-path
+      parse-verb
+      parse-handlers
+      parse-route-name
+      parse-constraints
+      finalize))
+
+(defn route-table
+  [opts routes]
+  {:pre [(map? opts) (sequential? routes)]}
+  (map-indexed (partial route-table-row opts) routes))

--- a/service/src/io/pedestal/interceptor.clj
+++ b/service/src/io/pedestal/interceptor.clj
@@ -17,6 +17,10 @@
 
 (defrecord Interceptor [name enter leave error])
 
+(defmethod print-method Interceptor
+  [^Interceptor i ^java.io.Writer w]
+  (.write w (str "#Interceptor{:name " (.name i) "}")))
+
 (defprotocol IntoInterceptor
   (-interceptor [t] "Given a value, produce an Interceptor Record."))
 
@@ -83,5 +87,3 @@
            true)]
    :post [valid-interceptor?]}
   (-interceptor t))
-
-

--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -278,32 +278,32 @@
 (def id #"[0-9]+")
 
 (def tabular-routes
-  (concat
-   (route-table
-    {:app-name :public :host "example.com"}
-    [["/"                           :get    [home-page]]
-     ["/child-path"                 :get    trailing-slash]
-     ["/user"                       :get    list-users]
-     ["/user"                       :post   add-user]
-     ["/:user-id"                   :put    update-user  :constraints {:user-id id}]
-     ["/:user-id"                   :get    view-user    :constraints {:view #"long|short"}]])
-   (route-table
-    {:app-name :admin :scheme :https :host "admin.example.com" :port 9999}
-    [["/demo/site-one/*site-path"   :get    (site-demo "one")                                           :route-name :site-one-demo]
-     ["/demo/site-two/*site-path"   :get    (site-demo "two")                                           :route-name :site-two-demo]
-     ["/user/:user-id/delete"       :delete delete-user]])
-   (route-table
-    {}
-    [["/logout"                     :any    logout]
-     ["/search"                     :get    search-id    :constraints {:id id}]
-     ["/search"                     :get    search-query :constraints {:q #".+"}]
-     ["/search"                     :get    search-form]
-     ["/intercepted"                :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :intercepted]
-     ["/intercepted-by-fn-symbol"   :get    [(interceptor-3) request-inspection]                        :route-name :intercepted-by-fn-symbol]
-     ["/intercepted-by-fn-list"     :get    [(interceptor-3 ::fn-called-explicitly) request-inspection] :route-name :intercepted-by-fn-list]
-     ["/trailing-slash/child-path"  :get    trailing-slash                                              :route-name :admin-trailing-slash]
-     ["/hierarchical/intercepted"   :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :hierarchical-intercepted]
-     ["/terminal/intercepted"       :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :terminal-intercepted]])))
+  (doall (concat
+    (route-table
+     {:app-name :public :host "example.com"}
+     [["/"                           :get    [home-page]]
+      ["/child-path"                 :get    trailing-slash]
+      ["/user"                       :get    list-users]
+      ["/user"                       :post   add-user]
+      ["/user/:user-id"              :put    update-user  :constraints {:user-id id}]
+      ["/user/:user-id"              :get    view-user    :constraints {:user-id id :view #"long|short"}]])
+    (route-table
+     {:app-name :admin :scheme :https :host "admin.example.com" :port 9999}
+     [["/demo/site-one/*site-path"   :get    (site-demo "one")                                           :route-name :site-one-demo]
+      ["/demo/site-two/*site-path"   :get    (site-demo "two")                                           :route-name :site-two-demo]
+      ["/user/:user-id/delete"       :delete delete-user]])
+    (route-table
+     {}
+     [["/logout"                     :any    logout]
+      ["/search"                     :get    search-id    :constraints {:id id}]
+      ["/search"                     :get    search-query :constraints {:q #".+"}]
+      ["/search"                     :get    search-form]
+      ["/intercepted"                :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :intercepted]
+      ["/intercepted-by-fn-symbol"   :get    [(interceptor-3) request-inspection]                        :route-name :intercepted-by-fn-symbol]
+      ["/intercepted-by-fn-list"     :get    [(interceptor-3 ::fn-called-explicitly) request-inspection] :route-name :intercepted-by-fn-list]
+      ["/trailing-slash/child-path"  :get    trailing-slash                                              :route-name :admin-trailing-slash]
+      ["/hierarchical/intercepted"   :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :hierarchical-intercepted]
+      ["/terminal/intercepted"       :get    [interceptor-1 interceptor-2 request-inspection]            :route-name :terminal-intercepted]]))))
 
 ;; HTTP verb-smuggling in query string is disabled here:
 (defn make-linker
@@ -408,7 +408,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest fire-interceptors
   (test-fire-interceptors :prefix-tree)
@@ -429,7 +430,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest fire-hierarchical-interceptors
   (test-fire-hierarchical-interceptors :prefix-tree)
@@ -450,7 +452,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest fire-terminal-interceptors
   (test-fire-terminal-interceptors :prefix-tree)
@@ -488,7 +491,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest fire-interceptor-fn-list
   (test-fire-interceptor-fn-list :prefix-tree)
@@ -511,7 +515,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-update-user
   (test-match-update-user :prefix-tree)
@@ -523,7 +528,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-logout
   (test-match-logout :prefix-tree)
@@ -532,6 +538,7 @@
 (defn test-match-non-root-trailing-slash [router-impl-key]
   (are [routes] (= {:route-name :admin-trailing-slash :path "/trailing-slash/child-path"}
                    (-> routes
+
                        (test-query-execute
                         router-impl-key
                         {:request {:request-method :get
@@ -541,7 +548,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-non-root-trailing-slash
   (test-match-non-root-trailing-slash :prefix-tree)
@@ -560,11 +568,12 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-root-trailing-slash
-  (test-match-non-root-trailing-slash :prefix-tree)
-  (test-match-non-root-trailing-slash :linear-search))
+  (test-match-root-trailing-slash :prefix-tree)
+  (test-match-root-trailing-slash :linear-search))
 
 (defn test-check-host [router-impl-key]
   (are [routes] (nil? (test-match
@@ -572,7 +581,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest check-host
   (test-check-host :prefix-tree)
@@ -588,7 +598,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-demo-one
   (test-match-demo-one :prefix-tree)
@@ -600,31 +611,36 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= nil
                    (test-match routes router-impl-key :put "/user/abc" :host "example.com"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= {:path-params {:user-id "123"} :query-params {:view "long"} :route-name ::view-user}
                    (test-match routes router-impl-key :get "/user/123" :scheme :http :host "example.com" :query "view=long"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= nil
                    (test-match routes router-impl-key :get "/user/123" :scheme :http :host "example.com" :query "view=none"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= nil
                    (test-match routes router-impl-key :get "/user/abc" :scheme :http :host "example.com" :query "view=long"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest match-user-constraints
   (test-match-user-constraints :prefix-tree)
@@ -636,25 +652,29 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= ::search-query
                    (test-linear-query-match routes "/search" "q=foo"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= ::search-form
                    (test-linear-query-match routes "/search" nil))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)
+       syntax-quote-data-routes
+       tabular-routes)
   (are [routes] (= ::search-form
                    (test-linear-query-match routes "/search" "id=not-a-number"))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest trailing-slash-link
   (are [routes] (= "/child-path" ((make-linker routes)
@@ -664,14 +684,16 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest logout-link
   (are [routes] (= "/logout" ((make-linker routes) ::logout :app-name :public))
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest view-user-link
   (are [routes] (= "//example.com/user/456"
@@ -679,7 +701,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest view-user-link-on-non-standard-port
   (are [routes] (= "http://example.com:8080/user/456"
@@ -691,7 +714,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-link
   (are [routes] (= "https://admin.example.com:9999/user/456/delete"
@@ -699,7 +723,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-action
   (are [routes] (= {:action "https://admin.example.com:9999/user/456/delete?_method=delete"
@@ -708,7 +733,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-action-without-verb-smuggling
   (are [routes] (= {:action "https://admin.example.com:9999/user/456/delete"
@@ -720,7 +746,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-action-with-alternate-verb-param
   (are [routes] (= {:action "https://admin.example.com:9999/user/456/delete?verb=delete"
@@ -732,7 +759,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-link-with-scheme
   (are [routes] (= "//admin.example.com:9999/user/456/delete"
@@ -743,7 +771,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-link-with-host
   (are [routes] (= "/user/456/delete"
@@ -754,7 +783,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-link-with-overrides
   (are [routes] (= "http://admin-staging.example.com:8080/user/456/delete"
@@ -768,7 +798,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-link-absolute
   (are [routes] (= "https://admin.example.com:9999/user/456/delete"
@@ -780,7 +811,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest delete-user-action-with-host
   (are [routes] (= {:action "/user/456/delete?_method=delete"
@@ -792,7 +824,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest search-id-link
   (are [routes] (= "/search?id=456"
@@ -800,7 +833,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest search-id-with-host
   (are [routes] (= "/search?id=456"
@@ -809,7 +843,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest search-id-link-with-extra-params
   (are [routes] (let [s ((make-linker routes) ::search-id :params {:id 456 :limit 100})]
@@ -818,7 +853,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes)) ; order is undefined
+       syntax-quote-data-routes
+       tabular-routes)) ; order is undefined
 
 (deftest search-id-link-with-extra-params-and-fragment
   (are [routes] (let [s ((make-linker routes) ::search-id :params {:id 456 :limit 100} :fragment "foo")]
@@ -827,7 +863,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest search-query-link
   (are [routes] (= "/search?q=Hello%2C+World%21"
@@ -835,7 +872,8 @@
        verbose-routes
        terse-routes
        data-routes
-       syntax-quote-data-routes))
+       syntax-quote-data-routes
+       tabular-routes))
 
 (deftest query-encoding
   (are [s] (= s (decode-query-part (encode-query-part s)))
@@ -958,10 +996,12 @@
   (let [verbose-route-names (set (map :route-name verbose-routes))
         terse-route-names (set (map :route-name terse-routes))
         data-route-names (set (map :route-name data-routes))
-        syntax-quote-data-route-names (set (map :route-name syntax-quote-data-routes))]
+        syntax-quote-data-route-names (set (map :route-name syntax-quote-data-routes))
+        tabular-route-names (set (map :route-name tabular-routes))]
     (is (and (empty? (set/difference verbose-route-names terse-route-names))
              (empty? (set/difference terse-route-names data-route-names))
-             (empty? (set/difference data-route-names syntax-quote-data-route-names)))
+             (empty? (set/difference data-route-names syntax-quote-data-route-names))
+             (empty? (set/difference syntax-quote-data-route-names tabular-route-names)))
         "Route names for all routing syntaxes match")))
 
 (deftest url-for-without-*url-for*-should-error-properly


### PR DESCRIPTION
Table routing should be documented.

* Moved old routing guide to reflect that it is specific to the terse syntax.
* Wrote a new routing guide for the table based syntax. The style is very different. The new guide starts with the simplest possible thing and builds up from there.
* Added a section on debugging routes, including reference to a new function `io.pedestal.http.route/try-routing-for` that lets the user try routes out from REPL without involving all the HTTP plumbing.