### PR TITLE
Revert "allow-origin arg as a map with :allowed-origins as seq of strings fix"

### DIFF
--- a/service/src/io/pedestal/http/cors.clj
+++ b/service/src/io/pedestal/http/cors.clj
@@ -45,13 +45,11 @@
     (assoc context :response {:status 200
                               :headers cors-headers})))
 
-
 (defn- normalize-args
   [arg]
   (if (map? arg)
-    (update-in arg [:allowed-origins] #(if (fn? %) % (fn [origin] (some #{origin} (seq %)))))
-    (normalize-args {:allowed-origins arg})))
-
+    arg
+    {:allowed-origins (if (fn? arg) arg (fn [origin] (some #(= % origin) (seq arg))))}))
 
 (defn allow-origin
   "Builds a CORS interceptor that allows calls from the specified `allowed-origins`, which is one of the following:

--- a/service/test/io/pedestal/http/cors_test.clj
+++ b/service/test/io/pedestal/http/cors_test.clj
@@ -54,31 +54,3 @@
   (let [response (response-for app :get "/hello-world" :headers {"origin" "https://bar.org"})]
     (is (= 403 (:status response)))
     (is (= nil (get-in response [:headers "Origin"])))))
-
-
-;; regression test when allowed-origins options is represented as a map
-(def allowed-origins-as-map-app
-  (::service/service-fn (-> {::service/routes routes
-                             ::service/allowed-origins {:allowed-origins ["http://foo.com:8080"]}}
-                            service/default-interceptors
-                            service/service-fn)))
-
-(deftest allowed-origins-as-map-no-origin-test
-  (let [response (response-for allowed-origins-as-map-app :get "/hello-world")]
-    (is (= 200 (:status response)))
-    (is (= nil (get-in response [:headers "Origin"])))))
-
-(deftest allowed-origins-as-map-good-origin-test
-  (let [response (response-for allowed-origins-as-map-app :get "/hello-world" :headers {"origin" "http://foo.com:8080"})]
-    (is (= 200 (:status response)))
-    (is (= "http://foo.com:8080" (get-in response [:headers "Access-Control-Allow-Origin"])))))
-
-(deftest allowed-origins-as-map-good-origin-patch-test
-  (let [response (response-for allowed-origins-as-map-app :patch "/hello-world" :headers {"origin" "http://foo.com:8080"})]
-    (is (= 200 (:status response)))
-    (is (= "http://foo.com:8080" (get-in response [:headers "Access-Control-Allow-Origin"])))))
-
-(deftest allowed-origins-as-map-bad-origin-test
-  (let [response (response-for allowed-origins-as-map-app :get "/hello-world" :headers {"origin" "https://bar.org"})]
-    (is (= 403 (:status response)))
-    (is (= nil (get-in response [:headers "Origin"])))))


### PR DESCRIPTION
After discussion with @ohpauleez, we think this change should be made in a different place. Moving it back for further review.