### PR TITLE
Use context's execution-id instead of global.

### DIFF
--- a/service/src/io/pedestal/impl/interceptor.clj
+++ b/service/src/io/pedestal/impl/interceptor.clj
@@ -236,9 +236,12 @@
       (assoc context ::execution-id execution-id))))
 
 (defn- end [context]
-  (log/debug :in 'end :execution-id execution-id)
-  (log/trace :context context)
-  context)
+  (if (contains? context ::execution-id)
+    (do
+      (log/debug :in 'end :execution-id (::execution-id context) :context-keys (keys context))
+      (log/trace :context context)
+      (dissoc context ::stack ::execution-id))
+    context))
 
 (defn execute
   "Executes a queue of Interceptors attached to the context. Context
@@ -272,9 +275,7 @@
                         enter-all
                         (dissoc ::queue)
                         leave-all
-                        (dissoc ::stack ::execution-id)
                         end)]
     (if-let [ex (::error context)]
       (throw ex)
       context)))
-


### PR DESCRIPTION
Fixed issue #364 