### PR TITLE
HEAD requests should not return a body.

### DIFF
--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -88,7 +88,7 @@
   []
   (interceptor {:name ::head
                 :enter (fn [ctx]
-                         (if (= :head (-> ctx :request :request-method))
+                         (if (= :head (get-in ctx [:request :request-method]))
                            (-> ctx
                                (assoc :head-request? true)
                                (assoc-in [:request :request-method] :get))

--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -83,12 +83,20 @@
                 :leave (response-fn-adapter flash/flash-response)}))
 
 (defn head
-  "Interceptor for head ring middleware. If used with defroutes, it will not work
+  "Interceptor to handle head requests. If used with defroutes, it will not work
   if specified in an interceptors meta-key."
   []
   (interceptor {:name ::head
-                :enter #(update-in % [:request] head/head-request)
-                :leave (response-fn-adapter head/head-response)}))
+                :enter (fn [ctx]
+                         (if (= :head (-> ctx :request :request-method))
+                           (-> ctx
+                               (assoc :head-request? true)
+                               (assoc-in [:request :request-method] :get))
+                           ctx))
+                :leave (fn [{:keys [request response] :as ctx}]
+                         (if (and response (:head-request? ctx))
+                           (update ctx :response assoc :body nil)
+                           ctx))}))
 
 (def keyword-params
   "Interceptor for keyword-params ring middleware."
@@ -135,4 +143,3 @@
        (interceptor {:name ::session
                      :enter (fn [context] (update-in context [:request] #(session/session-request % options)))
                      :leave (response-fn-adapter session/session-response options)}))))
-

--- a/service/test/io/pedestal/http/ring_middlewares_test.clj
+++ b/service/test/io/pedestal/http/ring_middlewares_test.clj
@@ -90,6 +90,7 @@
              (get-in [:request :request-method]))))
   (is (= {:body nil :status 200}
          (-> (context {:request-method :head})
+             ((:enter (head)))
              app
              ((:leave (head)))
              (#(select-keys (:response %) [:status :body]))))))


### PR DESCRIPTION
* This change removes Pedestal's use of the Ring head middleware.
* When the request method is :head, it will be replaced with :get during
  processing.
* During processing the context will also have a key :head-request? with
  value true.

Fixes #372 