### PR TITLE
Split SSE serialisation from dispatch, allowing interceptors to work with events

### DIFF
--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -21,6 +21,7 @@
             [io.pedestal.http.servlet :as servlet]
             [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [io.pedestal.http.cors :as cors]
+            [io.pedestal.http.sse :as sse]
             [ring.util.mime-type :as ring-mime]
             [ring.util.response :as ring-response]
             [clojure.string :as string]
@@ -223,6 +224,7 @@
                      (or enable-session enable-csrf) (conj (middlewares/session (or enable-session {})))
                      enable-csrf (conj (csrf/anti-forgery enable-csrf))
                      true (conj (middlewares/content-type {:mime-types ext-mime-types}))
+                     true (conj sse/serialise-event-stream)
                      true (conj route/query-params)
                      true (conj (route/method-param method-param-name))
                      (not (nil? resource-path)) (conj (middlewares/resource resource-path))
@@ -321,4 +323,3 @@
 
 (defn servlet-service [service servlet-req servlet-resp]
   (.service ^javax.servlet.Servlet (::servlet service) servlet-req servlet-resp))
-


### PR DESCRIPTION
Hi,
I've made a change to split the SSE interceptor into two interceptors:
- `start-event-stream` - creates the channels, dispatch loop and response
- `serialise-event-stream` - serialises events on the SSE response body channel into the SSE format

The reason for the split is to allow other interceptors to collaborate on the events broadcast on an SSE stream before they are serialised (after which they are difficult to work with), in the same way the `json-body` interceptor allows other interceptors to work with Clojure data structures before serialising to a JSON string at the last moment.

My use case is for validating and serialising events in [pedestal-api](https://github.com/oliyh/pedestal-api) as described in [#5](https://github.com/oliyh/pedestal-api/issues/5).

To detect if the response is an SSE stream it currently stores and reads `::sse? true` on the context. I wasn't aware of a better way to work out which interceptor actually handled the request - something along the lines of how exceptions contain the throwing interceptor would have been useful, i.e. explicitly storing the name of the handling interceptor in the context. 

I've improved the SSE tests to check the events themselves to make sure this didn't break anything.

Let me know if you have any other suggestions and I'll gladly make adjustments.
Thanks!
