### PR TITLE
Service should always keywordize keys in :params key of context

### DIFF
--- a/service/src/io/pedestal/http/body_params.clj
+++ b/service/src/io/pedestal/http/body_params.clj
@@ -15,6 +15,7 @@
             [cheshire.core :as json]
             [cheshire.parse :as parse]
             [clojure.string :as str]
+            [io.pedestal.http.params :as pedestal-params]
             [io.pedestal.interceptor.helpers :as interceptor]
             [io.pedestal.log :as log]
             [cognitect.transit :as transit]
@@ -133,8 +134,9 @@
 (defn form-parser
   "Take a request and parse its body as a form."
   [request]
-  (let [encoding (or (:character-encoding request) "UTF-8")]
-    (params/assoc-form-params request encoding)))
+  (let [encoding (or (:character-encoding request) "UTF-8")
+        request  (params/assoc-form-params request encoding)]
+    (update request :form-params pedestal-params/keywordize-keys)))
 
 (defn default-parser-map
   "Return a map of MIME-type to parsers. Included types are edn, json and

--- a/service/src/io/pedestal/http/params.clj
+++ b/service/src/io/pedestal/http/params.clj
@@ -1,0 +1,46 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.params
+  (:require [io.pedestal.interceptor :as interceptor]))
+
+(defn keywordize-keys
+  [x]
+  (if (map? x)
+    (persistent!
+     (reduce-kv
+      (fn [m k v]
+        (assoc! m
+                (if (string? k) (keyword k) k)
+                (keywordize-keys v)))
+      (transient {})
+      x))
+    x))
+
+(defn keywordize-request-element
+  [element context]
+  (update-in context [:request element] keywordize-keys))
+
+(def keywordize-request-params (partial keywordize-request-element :params))
+(def keywordize-request-body-params (partial keywordize-request-element :body-params))
+
+(def keyword-params
+  "Interceptor that converts the :params map to be keyed by keywords"
+  (interceptor/-interceptor
+   {:name ::keyword-params
+    :enter keywordize-request-params}))
+
+(def keyword-body-params
+  "Interceptor that converts the :body-params map to be keyed by keywords"
+  (interceptor/-interceptor
+   {:name ::keyword-body-params
+    :enter keywordize-request-body-params}))

--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -12,7 +12,8 @@
 
 (ns io.pedestal.http.ring-middlewares
   "This namespace creates interceptors for ring-core middlewares."
-  (:require [io.pedestal.interceptor :refer [interceptor]]
+  (:require [io.pedestal.http.params :as pedestal-params]
+            [io.pedestal.interceptor :refer [interceptor]]
             [io.pedestal.interceptor.helpers :as interceptor]
             [ring.middleware.cookies :as cookies]
             [ring.middleware.file :as file]
@@ -22,8 +23,8 @@
             [ring.middleware.keyword-params :as keyword-params]
             [ring.middleware.multipart-params :as multipart-params]
             [ring.middleware.nested-params :as nested-params]
-            [ring.middleware.params :as params]
             [ring.middleware.not-modified :as not-modified]
+            [ring.middleware.params :as params]
             [ring.middleware.resource :as resource]
             [ring.middleware.session :as session]
             [ring.util.mime-type :as mime]))
@@ -99,10 +100,8 @@
                            ctx))}))
 
 (def keyword-params
-  "Interceptor for keyword-params ring middleware."
-  (interceptor/on-request
-    ::keyword-params
-    keyword-params/keyword-params-request))
+  "Retained for backward compatibility. io.pedestal.http.params/keyword-params is recommended"
+  pedestal-params/keyword-params)
 
 (defn multipart-params
   "Interceptor for multipart-params ring middleware."

--- a/service/test/io/pedestal/http/body_params_test.clj
+++ b/service/test/io/pedestal/http/body_params_test.clj
@@ -74,7 +74,7 @@
   (let [form-context (as-context  "application/x-www-form-urlencoded" "foo=BAR")
         new-context  (i form-context)
         new-request  (:request new-context)]
-    (is (= (:form-params new-request) {"foo" "BAR"}))))
+    (is (= (:form-params new-request) {:foo "BAR"}))))
 
 (deftest parses-edn
   (let [edn-context (as-context "application/edn" "(i wish i [was in] eden)")

--- a/service/test/io/pedestal/http/default_interceptors_test.clj
+++ b/service/test/io/pedestal/http/default_interceptors_test.clj
@@ -16,7 +16,8 @@
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition.table :as table]
             [io.pedestal.interceptor.chain :as chain]
-            [ring.util.io :as ringio]))
+            [ring.util.io :as ringio]
+            [io.pedestal.http.params :as params]))
 
 (defn resp [s b & {:as headers}]
   (assoc {:status s :body b} :headers headers))
@@ -86,7 +87,7 @@
   (table/table-routes
    {}
    [["/echo"  :any  echo :route-name :echo]
-    ["/fecho" :post [(body-params/body-params) echo] :route-name :echo-form]]))
+    ["/fecho" :post [(body-params/body-params) params/keyword-params echo] :route-name :echo-form]]))
 
 (defn- test-query
   [req query-params params form-params]
@@ -103,10 +104,10 @@
 (defn- param-post [u b q] (form-post u b :query-string q))
 
 (deftest query-params
-  (test-query (param-get "/echo" "q=searchterm")        {:q "searchterm"} {:q "searchterm"}   nil)
-  (test-query (param-get "/echo" "c=%20&b=2")           {:b "2" :c " "}   {:b "2" :c " "}     nil)
-  (test-query (param-post "/fecho" nil           "a=b") {:a "b"}          {:a "b"}            {})
-  (test-query (param-post "/fecho" "foo=bar" "c=d")     {:c "d"}          {:c "d" :foo "bar"} {:foo "bar"}))
+  (test-query (param-get "/echo" "q=searchterm")     {:q "searchterm"} {:q "searchterm"}   nil)
+  (test-query (param-get "/echo" "c=%20&b=2")        {:b "2" :c " "}   {:b "2" :c " "}     nil)
+  (test-query (param-post "/fecho" nil       "a=b")  {:a "b"}          {:a "b"}            {})
+  (test-query (param-post "/fecho" "foo=bar" "c=d")  {:c "d"}          {:c "d" :foo "bar"} {:foo "bar"}))
 
 (defn- test-method-params
   [m u b q p v]

--- a/service/test/io/pedestal/http/default_interceptors_test.clj
+++ b/service/test/io/pedestal/http/default_interceptors_test.clj
@@ -1,0 +1,119 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.default-interceptors-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.http :as http]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.http.route.definition.table :as table]
+            [io.pedestal.interceptor.chain :as chain]
+            [ring.util.io :as ringio]))
+
+(defn resp [s b & {:as headers}]
+  (assoc {:status s :body b} :headers headers))
+
+(defn okpage      [req] (resp 200 "OK"))
+(defn okpage-html [req] (resp 200 "OK" "Content-Type" "text/html"))
+(defn echo        [req] (resp 200 req))
+
+(defn default-interceptors [routes]
+  (http/default-interceptors {:io.pedestal.http/routes routes}))
+
+(defn app [routes request]
+  (chain/execute
+   (chain/enqueue {:request request}
+          (::http/interceptors (default-interceptors routes)))))
+
+(defn request [method uri & {:as params}]
+  (merge
+   {:uri            uri
+    :path-info      uri
+    :request-method method
+    :headers        {}
+    :scheme         "do-not-match-scheme"
+    :server-name    "do-not-match-host"
+    :server-port    -1}
+   params))
+
+(defn form-post [u b & {:as params}]
+  (let [b (or b "")]
+    (merge
+     (request :post u
+              :headers {"content-type" "application/x-www-form-urlencoded"
+                        "content-length" (str (count b))}
+              :content-type "application/x-www-form-urlencoded"
+              :body (ringio/string-input-stream b))
+     params)))
+
+(def not-found-routes
+  (table/table-routes
+   {}
+   [["/users" :get (fn [req] (resp 200 "OK")) :route-name :users]]))
+
+(deftest not-found
+  (is (= 404 (-> (app not-found-routes (request :get "no-such-url")) (get-in [:response :status])))))
+
+(def content-type-routes
+  (table/table-routes
+   {}
+   [["/users"                            :get okpage      :route-name :users]
+    ["/content-type-from-extension.json" :get okpage      :route-name :json-index]
+    ["/content-type-from-extension.edn"  :get okpage      :route-name :edn-index]
+    ["/content-type-from-handler"        :get okpage-html :route-name :page-html]]))
+
+(defn- test-content-type
+  [m u s c]
+  (let [r (:response (app content-type-routes (request m u)))]
+    (is (= c (some-> r :headers (get "Content-Type"))))
+    (is (= s (:status r)))))
+
+(deftest content-type
+  (test-content-type :get "/content-type-from-extension.json" 200 "application/json")
+  (test-content-type :get "/no-such-url"                      404 nil)
+  (test-content-type :get "/content-type-from-extension.edn"  200 "application/edn")
+  (test-content-type :get "/content-type-from-handler"        200 "text/html"))
+
+(def params-routes
+  (table/table-routes
+   {}
+   [["/echo"  :any  echo :route-name :echo]
+    ["/fecho" :post [(body-params/body-params) echo] :route-name :echo-form]]))
+
+(defn- test-query
+  [req query-params params form-params]
+  (let [r (:response (app params-routes req))]
+    (when query-params
+      (is (= query-params (-> r :body :query-params))))
+    (when params
+      (is (= params (-> r :body :params))))
+    (when form-params
+      (is (= form-params (-> r :body :form-params))))
+    (is (= 200 (:status r)))))
+
+(defn- param-get  [u q]   (request :get u :query-string q))
+(defn- param-post [u b q] (form-post u b :query-string q))
+
+(deftest query-params
+  (test-query (param-get "/echo" "q=searchterm")        {:q "searchterm"} {:q "searchterm"}   nil)
+  (test-query (param-get "/echo" "c=%20&b=2")           {:b "2" :c " "}   {:b "2" :c " "}     nil)
+  (test-query (param-post "/fecho" nil           "a=b") {:a "b"}          {:a "b"}            {})
+  (test-query (param-post "/fecho" "foo=bar" "c=d")     {:c "d"}          {:c "d" :foo "bar"} {:foo "bar"}))
+
+(defn- test-method-params
+  [m u b q p v]
+  (let [req (request m u :query-string q)
+        r   (:response (app params-routes req))]
+    (is (= p (-> r :body :query-params)))
+    (is (= v (-> r :body :request-method)))))
+
+(deftest method-params
+  (test-method-params :post "/echo" nil "_method=put&q=searchterm" {:q "searchterm"} :put))

--- a/service/test/io/pedestal/http/params_test.clj
+++ b/service/test/io/pedestal/http/params_test.clj
@@ -1,0 +1,56 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.params-test
+  (:require [io.pedestal.http.params :as params]
+            [clojure.test :refer :all]))
+
+(defn valid-interceptor? [interceptor]
+  (and (every? fn? (remove nil? (vals (select-keys interceptor [:enter :leave :error]))))
+       (or (nil? (:name interceptor)) (keyword? (:name interceptor)))
+       (some #{:enter :leave} (keys interceptor))))
+
+(defn app [{:keys [response request] :as context}]
+  (assoc context :response (or response (merge request {:status 200 :body "OK"}))))
+
+(defn context [req]
+  {:request (merge {:headers {}  :request-method :get} req)})
+
+(deftest keywordization
+  (are [v e] (= e (params/keywordize-keys v))
+    "xyz"                 "xyz"
+    "io.pedestal.http/kw" "io.pedestal.http/kw"
+    "not a keyword"       "not a keyword"
+    "2nu"                 "2nu"
+    {"a" 1 "b" 2}         {:a 1 :b 2}
+    {"a" {"b" 1}}         {:a {:b 1}}
+    {"a" {"b" "val"}}     {:a {:b "val"}}))
+
+(deftest keyword-params-is-valid
+  (is (valid-interceptor? params/keyword-params))
+  (is (= {:a "1" :b "2"}
+         (->
+          (context {:params {"a" "1" "b" "2"}})
+          ((:enter params/keyword-params))
+          app
+          (get-in [:request :params])))))
+
+(deftest keyword-body-params-is-valid
+  (is (valid-interceptor? params/keyword-body-params))
+  (is (= {:a "1" :b "2"}
+         (->
+          (context {:body-params {"a" "1" "b" "2"}})
+          ((:enter params/keyword-body-params))
+          app
+          (get-in [:request :body-params])))))
+
+(run-tests)


### PR DESCRIPTION
* Parameters are keywordized, whether from query string, form params, or
  body params.

This change became bigger than intended. In particular, we've been
leveraging the Ring middleware for keywordization. There are two
challenges there. First, the syntax doesn't support namespaced
keywords. Second, the key function is not public.

Taking a longer view, I think we need to reduce Pedestal's reliance on
Ring middleware, migrating instead to Pedestal-native interceptors for
equivalent functionality. This commit does that for the `keyword-params`
interceptor. The var `io.pedestal.http.ring-middlewares/keyword-params`
is now an alias to `io.pedestal.http.params/keyword-params`

Fixes #240 