### PR TITLE
CSRF should use keywordized form-params

### DIFF
--- a/service/src/io/pedestal/http/csrf.clj
+++ b/service/src/io/pedestal/http/csrf.clj
@@ -56,7 +56,7 @@
          (:multipart-params request)))
 
 (defn- default-request-token [request]
-  (or (-> request form-params (get "__anti-forgery-token"))
+  (or (-> request form-params :__anti-forgery-token)
       (-> request :headers (get "x-csrf-token"))
       (-> request :headers (get "x-xsrf-token"))))
 
@@ -125,4 +125,3 @@
            (assoc context
                   :response (cond-> (assoc-session-token response req token)
                               cookie-token? (#(assoc-double-submit-cookie req %))))))))))
-

--- a/service/test/io/pedestal/http/csrf_test.clj
+++ b/service/test/io/pedestal/http/csrf_test.clj
@@ -100,8 +100,9 @@
 
 (deftest forms
   (let [i (standalone-anti-forgery-interceptor)
-        k    "__anti-forgery-token"
-        form {:request {:session {k "foo"}}}
+        s    "__anti-forgery-token"
+        k    :__anti-forgery-token
+        form {:request {:session {s "foo"}}}
         good-form (assoc-in form [:request :form-params] {k "foo"})
         bad-form  (assoc-in form [:request :form-params] {k "XXX"})
         good-mp-form (assoc-in form [:request :multipart-params] {k "foo"})


### PR DESCRIPTION
Since 0.5.0, form-params now use keywords instead of string keys.