### PR TITLE
Avoid double-catch in go block bug when SSE client disconnects

### DIFF
--- a/service/test/io/pedestal/http/impl/servlet_interceptor_test.clj
+++ b/service/test/io/pedestal/http/impl/servlet_interceptor_test.clj
@@ -1,0 +1,10 @@
+(ns io.pedestal.http.impl.servlet-interceptor-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]))
+
+(deftest closes-async-body-channel-on-error
+  (let [body (async/chan 1)
+        write-loop (servlet-interceptor/write-body-async body nil nil nil)]
+    (async/>!! body "hello")
+    (is (nil? (async/<!! write-loop)))))


### PR DESCRIPTION
Hi,

It looks like the recent change to quietly shutdown the async response loop when a client disconnects (SSE streams in particular) is falling into the trap laid by http://dev.clojure.org/jira/browse/ASYNC-169, namely there are two `catch` blocks inside a `go` block which sends everything into a tailspin.

On a deployed webserver you will see that async-macro-threads never get cleaned up, and eventually you will eat up all the async dispatchers and everything will lock up. This was made much more likely to happen by the decrease of the default pool size to 8 in the 0.2.385 release of core.async (this is when we came across it).

In the unit test, you will find that with the old source code it will lock up and hang your VM as described in ASYNC-169. With the fixed source code, you will find that it errors instantly as expected.

Hope this helps
Oliy