### PR TITLE
Handle empty transit body params

### DIFF
--- a/service/src/io/pedestal/http/body_params.clj
+++ b/service/src/io/pedestal/http/body_params.clj
@@ -122,10 +122,12 @@
   body of that request with `transit/read`. options is a sequence to
   pass to transit/reader along with the body of the request."
   [& options]
-  (fn [request]
-    (assoc request
-      :transit-params
-      (transit/read (apply transit/reader (:body request) options)))))
+  (fn [{:keys [body] :as request}]
+    (if (zero? (.available body))
+      request
+      (assoc request
+             :transit-params
+             (transit/read (apply transit/reader body options))))))
 
 (def transit-parser
   "Take a request and parse its body as transit."

--- a/service/test/io/pedestal/http/body_params_test.clj
+++ b/service/test/io/pedestal/http/body_params_test.clj
@@ -105,10 +105,16 @@
   (is (thrown? Exception (i (as-context "application/edn" "#=(eval (println 1234)")))))
 
 (deftest empty-body-does-nothing
-  (let [empty-body  (as-context "application/edn" "")
-        new-context (i empty-body)
-        new-request (:request new-context)]
-      (is (= (:edn-params new-request) nil))))
+  (doseq [[content-type params]
+          {"application/edn" :edn-params
+           "application/json" :json-params
+           "application/transit+json" :transit-params
+           "application/transit+msgpack" :transit-params
+           "application/x-www-form-urlencoded" :form-params}]
+    (let [context (byte-context content-type (byte-array []))
+          new-context (i context)
+          new-request (:request new-context)]
+      (is (empty? (get new-request params))))))
 
 ;; Translation: "Today is a good day to die."
 (def klingon "Heghlu'meH QaQ jajvam")


### PR DESCRIPTION
When sending a request with a `Content-Type` header of
`application/transit+json` or `application/transit+msgpack` and an empty
body, Pedestal throws a `java.io.EOFException` exception. This happens
because the Transit library doesn't read from an empty
ByteArrayInputStream. This does not happen with EDN, JSON or form
params. This patch fixes that problem by checking the available bytes of
the input stream and makes the behaviour consistent with the other
content types.