### PR TITLE
Fix aliasing for http in service template.

### DIFF
--- a/service-template/src/leiningen/new/pedestal_service/service.clj
+++ b/service-template/src/leiningen/new/pedestal_service/service.clj
@@ -24,14 +24,14 @@
               ["/about" :get (conj common-interceptors `about-page)]})
 
 ;; Map-based routes
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;; Terse/Vector-based routes
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 


### PR DESCRIPTION
In the service template, the commented-out route definitions for terse and map routes reference the former `bootstrap` alias for `io.pedestal.http` instead of the current `http` alias.

This addresses https://github.com/pedestal/pedestal/issues/450
