### PR TITLE
Pass through response if missing token when using double-submit cookies.

### DIFF
--- a/service/src/io/pedestal/http/csrf.clj
+++ b/service/src/io/pedestal/http/csrf.clj
@@ -48,10 +48,11 @@
 ;; This must be run after the session token setting
 (defn- assoc-double-submit-cookie [request response]
   ;; The token should also be in a cookie for JS (proper double submit)
-  (when-let [token (or (existing-token request)
+  (if-let [token (or (existing-token request)
                        (get-in response [:session anti-forgery-token-str]))]
     (assoc-in response
-              [:cookies anti-forgery-token-str] token)))
+              [:cookies anti-forgery-token-str] token)
+    response))
 
 (defn- form-params [request]
   (merge (:form-params request)

--- a/service/test/io/pedestal/http/csrf_test.clj
+++ b/service/test/io/pedestal/http/csrf_test.clj
@@ -174,3 +174,10 @@
     (testing "custom read token is respected"
      (is (= "foo"
             (get-in (i request) [:response :cookies "__anti-forgery-token"]))))))
+
+(deftest sessionless-cookie-token
+  (let [i (standalone-anti-forgery-interceptor {:cookie-token true})
+        request {:request {}}]
+    (testing "get 403 if missing both session and cookie"
+     (is (= 403
+            (get-in (i request) [:response :status]))))))


### PR DESCRIPTION
The missing token will already fail on entering the csrf/anti-forgery
interceptor, and there may be no token to find when leaving. Keep
the 403 Forbidden response intact rather than returning nil, which
will be interpreted as a 404.

Change-Id: I99f07735eedaefb6fd9e1d20946075e1395c7857