### PR TITLE
Bump core.async dependency to 0.2.391

### DIFF
--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -16,7 +16,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.2.385"]
+                 [org.clojure/core.async "0.2.391"]
                  [io.pedestal/pedestal.log "0.5.2-SNAPSHOT"]
 
                  ;; Error interceptor tooling

--- a/route/project.clj
+++ b/route/project.clj
@@ -16,7 +16,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.2.385"]
+                 [org.clojure/core.async "0.2.391"]
                  [io.pedestal/pedestal.log "0.5.2-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.2-SNAPSHOT"]
                  [org.clojure/core.incubator "0.1.4"]]

--- a/service/project.clj
+++ b/service/project.clj
@@ -23,7 +23,7 @@
                  [io.pedestal/pedestal.route "0.5.2-SNAPSHOT"]
 
                  ;; channels
-                 [org.clojure/core.async "0.2.385"]
+                 [org.clojure/core.async "0.2.391"]
 
                  ;; interceptors
                  [ring/ring-core "1.4.0" :exclusions [[org.clojure/clojure]


### PR DESCRIPTION
This fixes the remaining shadowed function warning mentioned in https://github.com/pedestal/pedestal/issues/456