### PR TITLE
Bring samples up to date in style and dependencies

### DIFF
--- a/samples/chain-providers/project.clj
+++ b/samples/chain-providers/project.clj
@@ -30,13 +30,7 @@
                  [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
-  :plugins [[info.sunng/lein-bootclasspath-deps "0.2.0"]]
-  :boot-dependencies [;; See: https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.4.v20150727"] ;; JDK 1.8.0_51
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"] ;; JDK 1.8.0_31/40/45
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.2.v20141202"] ;; JDK 1.8.0_25
-                      [org.mortbay.jetty.alpn/alpn-boot "8.1.0.v20141016" :prepend true] ;; JDK 1.8.0_20 (1.8 up to _20)
-                      ]
+  :java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.3"]]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "chain-providers.server/run-dev"]}
                    :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}
              :uberjar {:aot [chain-providers.server]}}

--- a/samples/chain-providers/project.clj
+++ b/samples/chain-providers/project.clj
@@ -1,16 +1,16 @@
-(defproject chain-providers "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject chain-providers "0.5.1"
+  :description "Demonstration of alternative chain providers in Pedestal"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.0"]
-                 ;; [io.pedestal/pedestal.immutant "0.4.2-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.tomcat "0.4.2-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.1"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.1"]
 
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
@@ -26,7 +26,6 @@
                       [org.mortbay.jetty.alpn/alpn-boot "8.1.0.v20141016" :prepend true] ;; JDK 1.8.0_20 (1.8 up to _20)
                       ]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "chain-providers.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.0"]]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}
              :uberjar {:aot [chain-providers.server]}}
   :main ^{:skip-aot true} chain-providers.server)
-

--- a/samples/chain-providers/project.clj
+++ b/samples/chain-providers/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject chain-providers "0.5.1"
   :description "Demonstration of alternative chain providers in Pedestal"
   :url "http://pedestal.io/samples/index"

--- a/samples/chain-providers/src/chain_providers/service.clj
+++ b/samples/chain-providers/src/chain_providers/service.clj
@@ -30,13 +30,13 @@
 (def routes #{["/" :get (conj common-interceptors `home-page)]
               ["/about" :get (conj common-interceptors `about-page)]})
 
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 (defn my-custom-provider
@@ -118,5 +118,3 @@
               ;                          ;:ssl-port 8443
               ;                          :ssl? false}
               })
-
-

--- a/samples/chain-providers/src/chain_providers/service.clj
+++ b/samples/chain-providers/src/chain_providers/service.clj
@@ -1,8 +1,5 @@
 (ns chain-providers.service
-  (:require [io.pedestal.http :as http]
-            [io.pedestal.http.route :as route]
-            [io.pedestal.http.body-params :as body-params]
-            [ring.util.response :as ring-resp])
+  (:require [io.pedestal.http :as http])
   (:import (java.nio ByteBuffer)
            (java.net InetSocketAddress)
            (org.eclipse.jetty.server Request
@@ -10,34 +7,6 @@
            (org.eclipse.jetty.server.handler AbstractHandler)
            (javax.servlet.http HttpServletRequest
                                HttpServletResponse)))
-
-(defn about-page
-  [request]
-  (ring-resp/response (format "Clojure %s - served from %s"
-                              (clojure-version)
-                              (route/url-for ::about-page))))
-
-(defn home-page
-  [request]
-  (ring-resp/response "Hello World!"))
-
-
-;; Defines "/" and "/about" routes with their associated :get handlers.
-;; The interceptors defined after the verb map (e.g., {:get home-page}
-;; apply to / and its children (/about).
-(def common-interceptors [(body-params/body-params) http/html-body])
-
-(def routes #{["/" :get (conj common-interceptors `home-page)]
-              ["/about" :get (conj common-interceptors `about-page)]})
-
-;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
-;                   :get home-page
-;                   "/about" {:get about-page}}})
-
-;(def routes
-;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) http/html-body]
-;      ["/about" {:get about-page}]]]])
 
 (defn my-custom-provider
   "Given a service-map,
@@ -84,37 +53,24 @@
                 (.stop server)
                 server)}))
 
-;; Consumed by peddemo.server/create-server
-;; See http/default-interceptors for additional options you can configure
-(def service {:env :prod
-              ;; You can bring your own non-default interceptors. Make
-              ;; sure you include routing and set it up right for
-              ;; dev-mode. If you do, many other keys for configuring
-              ;; default interceptors will be ignored.
-              ;; ::http/interceptors []
-              ::http/routes routes
+(def service {:env                  :prod
 
-              ;; Uncomment next line to enable CORS support, add
-              ;; string(s) specifying scheme, host and port for
-              ;; allowed source(s):
+              ;; This provider doesn't use a routing interceptor
+              ::http/routes         (constantly nil)
+
+              ;; This would normally be a keyword for :jetty, :tomcat,
+              ;; etc.
               ;;
-              ;; "http://localhost:8080"
+              ;; When it is a function, that function is the server function
+              ::http/type           my-custom-server-fn
+
+              ;; In the default template, this key is left blank to
+              ;; get the default chain provider (the
+              ;; servlet-interceptor).
               ;;
-              ;;::http/allowed-origins ["scheme://host:port"]
-
-              ;; Root for resource interceptor that is available by default.
-              ::http/resource-path "/public"
-
-              ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
-              ::http/type my-custom-server-fn
+              ;; Here we override it to a custom-written chain
+              ;; provider
               ::http/chain-provider my-custom-provider
-              ;;::http/host "localhost"
-              ::http/port 8080
-              ;; Container options are being ignored by the server implementation above
-              ;::http/container-options {:h2c? true
-              ;                          :h2? false
-              ;                          ;:keystore "test/hp/keystore.jks"
-              ;                          ;:key-password "password"
-              ;                          ;:ssl-port 8443
-              ;                          :ssl? false}
+
+              ::http/port           8080
               })

--- a/samples/chain-providers/test/chain_providers/service_test.clj
+++ b/samples/chain-providers/test/chain_providers/service_test.clj
@@ -1,11 +1,11 @@
 (ns chain-providers.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [chain-providers.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -31,4 +31,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-

--- a/samples/cors/project.clj
+++ b/samples/cors/project.clj
@@ -10,23 +10,22 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject cors "0.0.1-SNAPSHOT"
+(defproject cors "0.5.1"
   :description "pedestal demo demonstrating CORS support"
-  :url "http://example.com/FIXME"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [io.pedestal/pedestal.service "0.3.1"]
-                 [io.pedestal/pedestal.jetty "0.3.1"]
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]
-                 [ring-cors/ring-cors "0.1.4"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.391"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]
+                 [ring-cors/ring-cors "0.1.8"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "cors.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.3.1"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main ^{:skip-aot true} cors.server)
-

--- a/samples/cors/project.clj
+++ b/samples/cors/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/cors/src/cors/service.clj
+++ b/samples/cors/src/cors/service.clj
@@ -14,7 +14,7 @@
   (:require [clojure.java.io :as io]
             [clojure.core.async :as async]
             [io.pedestal.log :as log]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -53,12 +53,12 @@
   [[["/"   {:get [::send-stuff (sse/start-event-stream sse-stream-ready)]}]]])
 
 (def service {:env :prod
-              ::bootstrap/routes routes
+              ::http/routes routes
               ;; Allow services that are accessing this
               ;; service from a http-referer[sic] of http://localhost:8080.
               ;; All others are denied.
-              ::bootstrap/allowed-origins ["http://localhost:8080"]
-              ::bootstrap/resource-path "/public"
-              ::bootstrap/type :jetty
+              ::http/allowed-origins ["http://localhost:8080"]
+              ::http/resource-path "/public"
+              ::http/type :jetty
               ;; Run this service on port 8081 (not default).
-              ::bootstrap/port 8081})
+              ::http/port 8081})

--- a/samples/fast-pedestal/README.md
+++ b/samples/fast-pedestal/README.md
@@ -23,6 +23,11 @@ In general:
  * If you need a `resources` interceptor, use `io.pedestal.http.ring-middlewares.fast-resource`,
    which optimizes responses based on the HTTP buffer
 
+## Requirements
+
+Note that this sample uses features of Oracle's commercial JVM that
+are not available in the OpenJDK VM.
+
 ## Configuration
 
 To configure logging see config/logback.xml. By default, the app logs to stdout and logs/.
@@ -30,4 +35,3 @@ To learn more about configuring Logback, read its [documentation](http://logback
 
 ## Links
 * [Other examples](https://github.com/pedestal/samples)
-

--- a/samples/fast-pedestal/project.clj
+++ b/samples/fast-pedestal/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject fast-pedestal "0.5.1"
   :description "Demonstrate high performance Pedestal with direct Jetty APIs"
   :url "http://pedestal.io/samples/index"

--- a/samples/fast-pedestal/project.clj
+++ b/samples/fast-pedestal/project.clj
@@ -29,13 +29,7 @@
                 *assert* true}
   :pedantic? :abort
   :resource-paths ["config", "resources"]
-  :plugins [[info.sunng/lein-bootclasspath-deps "0.1.1"]]
-  :boot-dependencies [;; See: https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.4.v20150727"] ;; JDK 1.8.0_51
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"] ;; JDK 1.8.0_31/40/45
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.2.v20141202"] ;; JDK 1.8.0_25
-                      [org.mortbay.jetty.alpn/alpn-boot "8.1.0.v20141016" :prepend true] ;; JDK 1.8.0_20 (1.8 up to _20)
-                      ]
+  :java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.3"]]
   :profiles {:dev {:aliases {"run-fastjetty" ["trampoline" "run" "-m" "fast-pedestal.fastjetty-service/-main"]
                              "run-fasterjetty" ["trampoline" "run" "-m" "fast-pedestal.fasterjetty-service/-main"]}}
              :uberjar {:aot [fast-pedestal.server]}}

--- a/samples/fast-pedestal/project.clj
+++ b/samples/fast-pedestal/project.clj
@@ -1,11 +1,11 @@
-(defproject fast-pedestal "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject fast-pedestal "0.5.1"
+  :description "Demonstrate high performance Pedestal with direct Jetty APIs"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
-                 [io.pedestal/pedestal.jetty "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
                  [org.slf4j/jcl-over-slf4j "1.7.21"]
@@ -17,7 +17,7 @@
                 *assert* true}
   :pedantic? :abort
   :resource-paths ["config", "resources"]
-  :plugins [[info.sunng/lein-bootclasspath-deps "0.2.0"]]
+  :plugins [[info.sunng/lein-bootclasspath-deps "0.1.1"]]
   :boot-dependencies [;; See: https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
                       ;[org.mortbay.jetty.alpn/alpn-boot "8.1.4.v20150727"] ;; JDK 1.8.0_51
                       ;[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"] ;; JDK 1.8.0_31/40/45
@@ -43,4 +43,3 @@
                        ;-XX:+UseLargePages
                        "-XX:+UseCompressedOops"]
   )
-

--- a/samples/fast-pedestal/src/fast_pedestal/fasterjetty_service.clj
+++ b/samples/fast-pedestal/src/fast_pedestal/fasterjetty_service.clj
@@ -37,13 +37,13 @@
 (def routes #{["/" :get (conj common-interceptors `home-page)]
               ["/about" :get (conj common-interceptors `about-page)]})
 
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 (defn direct-jetty-provider
@@ -146,4 +146,3 @@
   (-> service
       http/create-server
       http/start))
-

--- a/samples/fast-pedestal/src/fast_pedestal/fastjetty_service.clj
+++ b/samples/fast-pedestal/src/fast_pedestal/fastjetty_service.clj
@@ -25,14 +25,14 @@
               ["/about" :get (conj common-interceptors `about-page)]})
 
 ;; Map-based routes
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;; Terse/Vector-based routes
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 
@@ -71,4 +71,3 @@
       (assoc ::http/join? true)
       http/create-server
       http/start))
-

--- a/samples/fast-pedestal/src/fast_pedestal/service.clj
+++ b/samples/fast-pedestal/src/fast_pedestal/service.clj
@@ -24,14 +24,14 @@
               ["/about" :get (conj common-interceptors `about-page)]})
 
 ;; Map-based routes
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;; Terse/Vector-based routes
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 
@@ -77,4 +77,3 @@
       (assoc ::http/join? true)
       http/create-server
       http/start))
-

--- a/samples/fast-pedestal/test/fast_pedestal/service_test.clj
+++ b/samples/fast-pedestal/test/fast_pedestal/service_test.clj
@@ -1,11 +1,11 @@
 (ns fast-pedestal.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [fast-pedestal.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -31,4 +31,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-

--- a/samples/hello-world/project.clj
+++ b/samples/hello-world/project.clj
@@ -10,14 +10,14 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject hello-world "0.1.0-SNAPSHOT"
+(defproject hello-world "0.5.1"
   :description "Simple hello-world service in Pedestal"
-  :url "https://github.com/pedestal/pedestal/tree/master/guides"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
-                 [io.pedestal/pedestal.jetty "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
                  [org.slf4j/jcl-over-slf4j "1.7.21"]
@@ -25,5 +25,5 @@
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hello-world.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.0"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main hello-world.server)

--- a/samples/hello-world/test/hello_world/service_test.clj
+++ b/samples/hello-world/test/hello_world/service_test.clj
@@ -13,11 +13,11 @@
 (ns hello-world.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [hello-world.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=

--- a/samples/helloworld-metrics/project.clj
+++ b/samples/helloworld-metrics/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject helloworld-metrics "0.5.1"
   :description "Demonstration of metrics support"
   :url "http://pedestal.io/samples/index"

--- a/samples/helloworld-metrics/project.clj
+++ b/samples/helloworld-metrics/project.clj
@@ -1,26 +1,25 @@
-(defproject helloworld-metrics "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject helloworld-metrics "0.5.1"
+  :description "Demonstration of metrics support"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.0"]
-                 ;; [io.pedestal/pedestal.immutant "0.4.2-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.tomcat "0.4.2-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.1"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.1"]
 
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
                  [org.slf4j/jcl-over-slf4j "1.7.21"]
                  [org.slf4j/log4j-over-slf4j "1.7.21"]
-                 [com.readytalk/metrics3-statsd "4.1.0"]]
+                 [com.readytalk/metrics3-statsd "4.1.2"]]
   :repositories [["jcenter" "http://jcenter.bintray.com"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "helloworld-metrics.server/run-dev"]}}
              :uberjar {:aot [helloworld-metrics.server]}}
   :main ^{:skip-aot true} helloworld-metrics.server)
-

--- a/samples/helloworld-metrics/test/helloworld_metrics/service_test.clj
+++ b/samples/helloworld-metrics/test/helloworld_metrics/service_test.clj
@@ -1,11 +1,11 @@
 (ns helloworld-metrics.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [helloworld-metrics.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -28,4 +28,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-

--- a/samples/http2/project.clj
+++ b/samples/http2/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject hp "0.5.1"
   :description "HTTP2 support"
   :url "http://pedestal.io/samples/index"

--- a/samples/http2/project.clj
+++ b/samples/http2/project.clj
@@ -1,11 +1,11 @@
-(defproject hp "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject hp "0.5.1"
+  :description "HTTP2 support"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
-                 [io.pedestal/pedestal.jetty "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
 
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
@@ -17,4 +17,3 @@
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hp.server/run-dev"]}}
              :uberjar {:aot [hp.server]}}
   :main ^{:skip-aot true} hp.server)
-

--- a/samples/immutant/project.clj
+++ b/samples/immutant/project.clj
@@ -10,21 +10,20 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject hello-world "0.0.1-SNAPSHOT"
-  :description "Simple hello-world service in Pedestal"
-  :url "https://github.com/pedestal/pedestal/tree/master/guides"
+(defproject immutant-hello-world "0.5.1"
+  :description "Hello world service for Immutant"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.4.0"]
-                 [io.pedestal/pedestal.immutant "0.4.0"]
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.immutant "0.5.1"]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hello-world.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.4.0"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main hello-world.server)
-

--- a/samples/immutant/project.clj
+++ b/samples/immutant/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/immutant/src/hello_world/service.clj
+++ b/samples/immutant/src/hello_world/service.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns hello-world.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -27,8 +27,7 @@
       ["/hello" {:get hello-world}]]]])
 
 (def service {:env :prod
-              ::bootstrap/routes routes
-              ::bootstrap/resource-path "/public"
-              ::bootstrap/type :immutant
-              ::bootstrap/port 8080})
-
+              ::http/routes routes
+              ::http/resource-path "/public"
+              ::http/type :immutant
+              ::http/port 8080})

--- a/samples/immutant/test/hello_world/service_test.clj
+++ b/samples/immutant/test/hello_world/service_test.clj
@@ -13,15 +13,13 @@
 (ns hello-world.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [hello-world.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
        (:body (response-for service :get "/hello"))
        "Hello World!\n")))
-
-

--- a/samples/jetty-web-sockets/project.clj
+++ b/samples/jetty-web-sockets/project.clj
@@ -1,17 +1,17 @@
-(defproject jetty-web-sockets "0.0.1-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject jetty-web-sockets "0.5.1"
+  :description "Sample of web sockets with Jetty"
+  :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
-                 [org.clojure/core.async "0.2.374"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [org.clojure/core.async "0.2.391"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.0"]
-                 ;; [io.pedestal/pedestal.immutant "0.4.1-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.tomcat "0.4.1-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.1"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.1"]
 
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
@@ -23,4 +23,3 @@
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "jetty-web-sockets.server/run-dev"]}}
              :uberjar {:aot [jetty-web-sockets.server]}}
   :main ^{:skip-aot true} jetty-web-sockets.server)
-

--- a/samples/jetty-web-sockets/project.clj
+++ b/samples/jetty-web-sockets/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject jetty-web-sockets "0.5.1"
   :description "Sample of web sockets with Jetty"
   :url "http://pedestal.io/samples/index"

--- a/samples/jetty-web-sockets/test/jetty_web_sockets/service_test.clj
+++ b/samples/jetty-web-sockets/test/jetty_web_sockets/service_test.clj
@@ -1,11 +1,11 @@
 (ns jetty-web-sockets.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [jetty-web-sockets.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -31,4 +31,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-

--- a/samples/nio/project.clj
+++ b/samples/nio/project.clj
@@ -10,26 +10,25 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject nio "0.0.1-SNAPSHOT"
+(defproject nio "0.5.1"
   :description "a pedestal sample taking advantage of NIO with ByteBuffer"
-  :url "https://github.com/pedestal/pedestal/tree/master/samples/nio"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.3.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.3.1"]
-                 ;; [io.pedestal/pedestal.immutant "0.3.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.1"]
 
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "nio.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.3.1"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main ^{:skip-aot true} nio.server)
-

--- a/samples/nio/project.clj
+++ b/samples/nio/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/nio/src/nio/service.clj
+++ b/samples/nio/src/nio/service.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns nio.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -36,18 +36,18 @@
 (defroutes routes
   [[["/" {:get nio-home}
      ;; Set default interceptors for /about and any other paths under /
-     ^:interceptors [(body-params/body-params) bootstrap/html-body]
+     ^:interceptors [(body-params/body-params) http/html-body]
      ["/about" {:get about-page}]]]])
 
 ;; Consumed by nio.server/create-server
-;; See bootstrap/default-interceptors for additional options you can configure
+;; See http/default-interceptors for additional options you can configure
 (def service {:env :prod
               ;; You can bring your own non-default interceptors. Make
               ;; sure you include routing and set it up right for
               ;; dev-mode. If you do, many other keys for configuring
               ;; default interceptors will be ignored.
-              ;; :bootstrap/interceptors []
-              ::bootstrap/routes routes
+              ;; :http/interceptors []
+              ::http/routes routes
 
               ;; Uncomment next line to enable CORS support, add
               ;; string(s) specifying scheme, host and port for
@@ -55,13 +55,12 @@
               ;;
               ;; "http://localhost:8080"
               ;;
-              ;;::bootstrap/allowed-origins ["scheme://host:port"]
+              ;;::http/allowed-origins ["scheme://host:port"]
 
               ;; Root for resource interceptor that is available by default.
-              ::bootstrap/resource-path "/public"
+              ::http/resource-path "/public"
 
               ;; Either :jetty or :immutant (see comments in project.clj)
-              ::bootstrap/type :jetty
-              ;;::bootstrap/host "localhost"
-              ::bootstrap/port 8080})
-
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080})

--- a/samples/nio/test/nio/service_test.clj
+++ b/samples/nio/test/nio/service_test.clj
@@ -13,11 +13,11 @@
 (ns nio.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [nio.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -43,4 +43,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-

--- a/samples/nio/test/nio/service_test.clj
+++ b/samples/nio/test/nio/service_test.clj
@@ -35,7 +35,7 @@
 (deftest about-page-test
   (is (.contains
        (:body (response-for service :get "/about"))
-       "Clojure 1.6"))
+       "Clojure 1.8"))
   (is (=
        (:headers (response-for service :get "/about"))
        {"Content-Type" "text/html;charset=UTF-8"

--- a/samples/project.clj
+++ b/samples/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/samples "0.5.0"
+(defproject io.pedestal/samples "0.5.2-SNAPSHOT"
   :plugins [[lein-sub "0.2.3"]]
   :sub ["hello-world"
         "server-sent-events"
@@ -18,4 +18,3 @@
         "cors"
         "ring-middleware"
         "server-with-links"])
-

--- a/samples/ring-middleware/README.md
+++ b/samples/ring-middleware/README.md
@@ -6,15 +6,6 @@ that stores your name in the session via setting a session token
 in the cookie store. We are depending on `ring.middleware.session.cookie`
 for this functionality.
 
-To make this work, we use `definterceptor` to define the interceptor
-we'll need in the processing list to store a value in a cookie. From
-`services.clj`:
-
-```clojure
-(definterceptor session-interceptor
-  (middlewares/session {:store (cookie/cookie-store)}))
-```
-
 For further enlightenment, take a look at:
 
 *  The pedestal ring-middlewares package: `io.pedestal.http.ring-middlewares`

--- a/samples/ring-middleware/project.clj
+++ b/samples/ring-middleware/project.clj
@@ -10,21 +10,20 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject ring-middleware "0.0.1-SNAPSHOT"
+(defproject ring-middleware "0.5.1"
   :description "pedestal sample demonstrating the use of ring middleware"
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.3.1"]
-                 [io.pedestal/pedestal.jetty "0.3.1"]
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "ring-middleware.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.3.1"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main ^{:skip-aot true} ring-middleware.server)
-

--- a/samples/ring-middleware/project.clj
+++ b/samples/ring-middleware/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/ring-middleware/src/ring_middleware/service.clj
+++ b/samples/ring-middleware/src/ring_middleware/service.clj
@@ -12,7 +12,7 @@
 
 (ns ring-middleware.service
   (:require [clojure.java.io :as io]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -82,14 +82,14 @@
      {:get hello}]]])
 
 ;; Consumed by ring-middleware.server/create-server
-;; See bootstrap/default-interceptors for additional options you can configure
+;; See http/default-interceptors for additional options you can configure
 (def service {:env :prod
               ;; You can bring your own non-default interceptors. Make
               ;; sure you include routing and set it up right for
               ;; dev-mode. If you do, many other keys for configuring
               ;; default interceptors will be ignored.
-              ;; :bootstrap/interceptors []
-              ::bootstrap/routes routes
+              ;; :http/interceptors []
+              ::http/routes routes
 
               ;; Uncomment next line to enable CORS support, add
               ;; string(s) specifying scheme, host and port for
@@ -97,13 +97,12 @@
               ;;
               ;; "http://localhost:8080"
               ;;
-              ;;::bootstrap/allowed-origins ["scheme://host:port"]
+              ;;::http/allowed-origins ["scheme://host:port"]
 
               ;; Root for resource interceptor that is available by default.
-              ::bootstrap/resource-path "/public"
+              ::http/resource-path "/public"
 
               ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
-              ::bootstrap/type :jetty
-              ;;::bootstrap/host "localhost"
-              ::bootstrap/port 8080})
-
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080})

--- a/samples/ring-middleware/test/ring_middleware/service_test.clj
+++ b/samples/ring-middleware/test/ring_middleware/service_test.clj
@@ -12,11 +12,11 @@
 (ns ring-middleware.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [ring-middleware.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-renders-correctly
   (is (.contains

--- a/samples/server-sent-events/dev/dev.clj
+++ b/samples/server-sent-events/dev/dev.clj
@@ -12,28 +12,27 @@
 
 ;; dev mode in repl (can get prod mode by passing prod options to dev-init
 (ns dev
-  (:require [io.pedestal.service.http :as bootstrap]
+  (:require [io.pedestal.service.http :as http]
             [server-sent-events.service :as service]
             [server-sent-events.server :as server]))
 
 (def service (-> service/service
                  (merge  {:env :dev
-                          ::bootstrap/join? false
-                          ::bootstrap/routes #(deref #'service/routes)})
-                 (bootstrap/default-interceptors)
-                 (bootstrap/dev-interceptors)))
+                          ::http/join? false
+                          ::http/routes #(deref #'service/routes)})
+                 (http/default-interceptors)
+                 (http/dev-interceptors)))
 
 (defn start
   [& [opts]]
   (server/create-server (merge service opts))
-  (bootstrap/start server/service-instance))
+  (http/start server/service-instance))
 
 (defn stop
   []
-  (bootstrap/stop server/service-instance))
+  (http/stop server/service-instance))
 
 (defn restart
   []
   (stop)
   (start))
-

--- a/samples/server-sent-events/project.clj
+++ b/samples/server-sent-events/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/server-sent-events/project.clj
+++ b/samples/server-sent-events/project.clj
@@ -10,18 +10,18 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject server-sent-events "0.0.1-SNAPSHOT"
+(defproject server-sent-events "0.5.1"
   :description "a sample to demonstrate server sent events"
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  ;; Remove this line and uncomment the next line to
                  ;; use Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.0"]
-                 ;; [io.pedestal/pedestal.tomcat "0.1.2"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.1"]
 
                  ;; Logging
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [[org.slf4j/slf4j-api]]]
@@ -30,18 +30,18 @@
                  [org.slf4j/log4j-over-slf4j "1.7.21"]
 
                  ;; Deps cleanup
-                 [org.clojure/tools.analyzer.jvm "0.6.9"]
-                 [org.clojure/tools.reader "1.0.0-alpha1"]
+                 [org.clojure/tools.analyzer.jvm "0.6.10"]
+                 [org.clojure/tools.reader "1.0.0-beta2"]
 
                  ;; Example CLJS client
-                 [org.clojure/core.async "0.2.374"]
-                 [org.clojure/clojurescript "1.8.40" :exclusions [org.clojure/tools.reader]]]
+                 [org.clojure/core.async "0.2.391"]
+                 [org.clojure/clojurescript "1.9.229" :exclusions [org.clojure/tools.reader]]]
   :plugins [[lein-cljsbuild "1.1.3"]]
   :min-lein-version "2.0.0"
+  :pedantic? :abort
   :resource-paths ["resources" "config"]
   :global-vars  {*warn-on-reflection* true
                  *assert* true}
-  :pedantic? :abort
   :main ^{:skip-aot true} server-sent-events.server
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "server-sent-events.server/run-dev"]}
                    :dependencies []
@@ -53,4 +53,3 @@
                      :output-to "resources/public/js/app.js"
                      :pretty-print false
                      :optimizations :advanced}}}})
-

--- a/samples/server-sent-events/src/server_sent_events/service.clj
+++ b/samples/server-sent-events/src/server_sent_events/service.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns server-sent-events.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.sse :as sse]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -110,11 +110,11 @@
               ;; sure you include routing and set it up right for
               ;; dev-mode. If you do, many other keys for configuring
               ;; default interceptors will be ignored.
-              ;; :bootstrap/interceptors []
-              ::bootstrap/routes routes
+              ;; :http/interceptors []
+              ::http/routes routes
               ;; Root for resource interceptor that is available by default.
-              ::bootstrap/resource-path "/public"
+              ::http/resource-path "/public"
               ;; Either :jetty or :tomcat (see comments in project.clj
               ;; to enable Tomcat)
-              ::bootstrap/type :jetty
-              ::bootstrap/port 8080})
+              ::http/type :jetty
+              ::http/port 8080})

--- a/samples/server-sent-events/test/server_sent_events/service_test.clj
+++ b/samples/server-sent-events/test/server_sent_events/service_test.clj
@@ -13,11 +13,11 @@
 (ns server-sent-events.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [server-sent-events.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest service-comes-up-test
   (is (.contains

--- a/samples/server-with-links/project.clj
+++ b/samples/server-with-links/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/server-with-links/project.clj
+++ b/samples/server-with-links/project.clj
@@ -10,20 +10,20 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject server-with-links "0.0.1-SNAPSHOT"
+(defproject server-with-links "0.5.1"
   :description "Demonstrates generating a link from the routes."
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.3.1"]
-                 [io.pedestal/pedestal.jetty "0.3.1"]
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "server-with-links.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.3.1"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main server-with-links.server)

--- a/samples/server-with-links/src/server_with_links/service.clj
+++ b/samples/server-with-links/src/server_with_links/service.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns server-with-links.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -42,10 +42,9 @@
     ["/that" {:get [:that linked-page]}]]])  ; Name a route to be able to generate its path later
 
 ;; Consumed by server-with-links.server/create-server
-;; See bootstrap/default-interceptors for additional options you can configure
+;; See http/default-interceptors for additional options you can configure
 (def service {:env :prod
-              ::bootstrap/routes routes
-              ::bootstrap/resource-path "/public"
-              ::bootstrap/type :jetty
-              ::bootstrap/port 8080})
-
+              ::http/routes routes
+              ::http/resource-path "/public"
+              ::http/type :jetty
+              ::http/port 8080})

--- a/samples/server-with-links/test/server_with_links/service_test.clj
+++ b/samples/server-with-links/test/server_with_links/service_test.clj
@@ -13,16 +13,13 @@
 (ns server-with-links.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [server-with-links.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest link-generates-correct-link
   (is (.contains
        (:body (response-for service :get "/"))
        "<a href='/that'>that</a>")))
-
-
-

--- a/samples/servlet-filters-gzip/project.clj
+++ b/samples/servlet-filters-gzip/project.clj
@@ -10,17 +10,17 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject gzip "0.0.1-SNAPSHOT"
+(defproject gzip "0.5.1"
   :description "a sample demonstrating container-specific configuration"
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  ;; This samples is specific to jetty, so
                  ;; other options don't appear here.
-                 [io.pedestal/pedestal.jetty "0.5.0"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
                  [org.eclipse.jetty/jetty-servlets "9.3.8.v20160314"]
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
@@ -31,4 +31,3 @@
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "gzip.server/run-dev"]}}}
   :main ^{:skip-aot true} gzip.server)
-

--- a/samples/servlet-filters-gzip/project.clj
+++ b/samples/servlet-filters-gzip/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/servlet-filters-gzip/src/gzip/service.clj
+++ b/samples/servlet-filters-gzip/src/gzip/service.clj
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns gzip.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
             [io.pedestal.http.route.definition :refer [defroutes]]
@@ -32,18 +32,18 @@
 (defroutes routes
   [[["/" {:get home-page}
      ;; Set default interceptors for /about and any other paths under /
-     ^:interceptors [(body-params/body-params) bootstrap/html-body]
+     ^:interceptors [(body-params/body-params) http/html-body]
      ["/about" {:get about-page}]]]])
 
 ;; Consumed by gzip.server/create-server
-;; See bootstrap/default-interceptors for additional options you can configure
+;; See http/default-interceptors for additional options you can configure
 (def service {:env :prod
               ;; You can bring your own non-default interceptors. Make
               ;; sure you include routing and set it up right for
               ;; dev-mode. If you do, many other keys for configuring
               ;; default interceptors will be ignored.
-              ;; :bootstrap/interceptors []
-              ::bootstrap/routes routes
+              ;; ::http/interceptors []
+              ::http/routes routes
 
               ;; Uncomment next line to enable CORS support, add
               ;; string(s) specifying scheme, host and port for
@@ -51,21 +51,20 @@
               ;;
               ;; "http://localhost:8080"
               ;;
-              ;;::bootstrap/allowed-origins ["scheme://host:port"]
+              ;; ::http/allowed-origins ["scheme://host:port"]
 
               ;; Root for resource interceptor that is available by default.
-              ::bootstrap/resource-path "/public"
-              ::bootstrap/type :jetty
+              ::http/resource-path "/public"
+              ::http/type :jetty
 
               ;; Add our filter-fn a the context configurator
-              ::bootstrap/container-options {:context-configurator (fn [c]
-                                                                     (let [gzip-handler (GzipHandler.)]
-                                                                       (.setGzipHandler c gzip-handler)
-                                                                       ;; You can also add Servlet Filters...
-                                                                       (jetty-util/add-servlet-filter c {:filter DoSFilter})
-                                                                       c))}
+              ::http/container-options {:context-configurator (fn [c]
+                                                                (let [gzip-handler (GzipHandler.)]
+                                                                  (.setGzipHandler c gzip-handler)
+                                                                  ;; You can also add Servlet Filters...
+                                                                  (jetty-util/add-servlet-filter c {:filter DoSFilter})
+                                                                  c))}
               ; If you have a just a Servlet Filter...
               ;:container-options {:context-configurator #(jetty-util/add-servlet-filter % {:filter DoSFilter})}
-              ;;::bootstrap/host "localhost"
-              ::bootstrap/port 8080})
-
+              ;; ::http/host "localhost"
+              ::http/port 8080})

--- a/samples/servlet-filters-gzip/test/gzip/service_test.clj
+++ b/samples/servlet-filters-gzip/test/gzip/service_test.clj
@@ -10,10 +10,10 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns gzip.service-test
-  (:require [clj-http.client :as http]
+  (:require [clj-http.client :as http-cl]
             [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [io.pedestal.http.jetty :as jetty]
             [io.pedestal.http.servlet :as servlet]
             [io.pedestal.http.impl.servlet-interceptor :as incept]
@@ -21,7 +21,7 @@
             [gzip.server :as server]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (defn jetty-server
   [app opts]
@@ -34,7 +34,7 @@
 
 (defn get-response [addy]
   (try
-    (http/get addy)
+    (http-cl/get addy)
     (catch clojure.lang.ExceptionInfo ex
       (prn "BOOM!\n\n")
       (prn ex)
@@ -43,7 +43,7 @@
 (deftest home-page-test
   (let [jetty (server/run-dev)
         response (get-response "http://localhost:8080")
-        _ (bootstrap/stop jetty)]
+        _ (http/stop jetty)]
     (testing "service response"
       (is (=
            (:body response)
@@ -52,5 +52,3 @@
       (is (.startsWith
            (:orig-content-encoding response)
            "gzip")))))
-
-

--- a/samples/template-server/project.clj
+++ b/samples/template-server/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014 Cognitect, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/samples/template-server/project.clj
+++ b/samples/template-server/project.clj
@@ -10,25 +10,25 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject template-server "0.0.1-SNAPSHOT"
+(defproject template-server "0.5.1"
   :description "a sample that demonstrates using template libraries with pedestal"
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.3.1"]
-                 [io.pedestal/pedestal.jetty "0.3.1"]
-                 [ch.qos.logback/logback-classic "1.1.2" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.7"]
-                 [org.slf4j/jcl-over-slf4j "1.7.7"]
-                 [org.slf4j/log4j-over-slf4j "1.7.7"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
+                 [io.pedestal/pedestal.jetty "0.5.1"]
+                 [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.21"]
+                 [org.slf4j/jcl-over-slf4j "1.7.21"]
+                 [org.slf4j/log4j-over-slf4j "1.7.21"]
 
                  [hiccup "1.0.5"]
-                 [enlive "1.1.5"]
+                 [enlive "1.1.6"]
                  [comb "0.1.0"]
                  [org.antlr/stringtemplate "4.0.2"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [selmer "0.7.7"]
+                 [selmer "1.0.9"]
 ]
 
 
@@ -36,6 +36,5 @@
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "template-server.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.3.1"]]}}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.1"]]}}
   :main ^{:skip-aot true} template-server.server)
-

--- a/samples/template-server/src/template_server/service.clj
+++ b/samples/template-server/src/template_server/service.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns template-server.service
-  (:require [io.pedestal.http :as bootstrap]
+  (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.route.definition :refer [defroutes]]
             [ring.util.response :as ring-resp]
@@ -42,10 +42,10 @@
 ;; https://github.com/weavejester/hiccup
 (defn hiccup-page
   [request]
-  (ring-resp/response (hiccup/html5 
+  (ring-resp/response (hiccup/html5
     [:body
       [:h1 {:id "the-title"} (title-as "Hiccup")]
-      [:hr] 
+      [:hr]
       [:p "This page was rendered with Hiccup!"]
       [:br]
       [:p {:id "the-text"}   "Hello from the Hiccup demo. Do you need a glass of water?"]
@@ -61,8 +61,8 @@
 
 (defn enlive-page
   [request]
-  (ring-resp/response 
-   (apply str 
+  (ring-resp/response
+   (apply str
           (enlive-template {:title (title-as   "Enlive")
                             :text  "This is a special message from Enlive."
                             :date  (current-date)}))))
@@ -71,7 +71,7 @@
 ;; https://github.com/fhd/clostache
 (defn clostache-page
   [request]
-  (ring-resp/response 
+  (ring-resp/response
     (clostache/render-resource "public/clostache-template.html"
                                {:title (title-as   "Clostache")
                                 :text  "With Clostache, it's November every month."
@@ -83,7 +83,7 @@
   [request]
   (let [template (slurp (io/resource "public/comb-template.html"))]
     (ring-resp/response
-      (comb/eval template 
+      (comb/eval template
                  {:title (title-as   "Comb")
                   :text  "You might be able to tame hairy markup with Comb."
                   :date  (current-date)}))))
@@ -111,7 +111,7 @@
 
 ;; Define the routes that pull everything together.
 (defroutes routes
-  [[["/" {:get home-page} ^:interceptors [bootstrap/html-body]
+  [[["/" {:get home-page} ^:interceptors [http/html-body]
       ["/hiccup" {:get hiccup-page}]
       ["/enlive" {:get enlive-page}]
       ["/clostache" {:get clostache-page}]
@@ -120,9 +120,9 @@
       ["/selmer" {:get selmer-page}]]]])
 
 ;; Consumed by template-server.server/create-server
-;; See bootstrap/default-interceptors for additional options you can configure
+;; See http/default-interceptors for additional options you can configure
 (def service {:env :prod
-              ::bootstrap/routes routes
-              ::bootstrap/resource-path "/public"
-              ::bootstrap/type :jetty
-              ::bootstrap/port 8080})
+              ::http/routes routes
+              ::http/resource-path "/public"
+              ::http/type :jetty
+              ::http/port 8080})

--- a/samples/template-server/test/template_server/service_test.clj
+++ b/samples/template-server/test/template_server/service_test.clj
@@ -13,11 +13,11 @@
 (ns template-server.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [template-server.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest test-templates-generate-correct-bodies
   (are [url partial-body-string]

--- a/samples/war-example/README.md
+++ b/samples/war-example/README.md
@@ -34,7 +34,7 @@ TODO
 2. Go to [localhost:8080](http://localhost:8080/) to see: `Hello World!`
 3. Read your app's source code at src/war_example/service.clj. Explore the docs of functions
    that define routes and responses.
-4. Run your app's tests with `lein test`. Read the tests at test/war_example/service_test.clj.
+4. Run your app's tests with `lein test`. Read the tests at `test/war_example/service_test.clj`.
 5. Learn more! See the [Links section below](#links).
 
 
@@ -68,4 +68,3 @@ Once the image it built, it's cached.  To delete the image and build a new one:
 
 ## Links
 * [Other examples](https://github.com/pedestal/samples)
-

--- a/samples/war-example/project.clj
+++ b/samples/war-example/project.clj
@@ -1,10 +1,10 @@
-(defproject war-example "0.0.1-SNAPSHOT"
+(defproject war-example "0.5.1"
   :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.0"]
+                 [io.pedestal/pedestal.service "0.5.1"]
 
                  [ch.qos.logback/logback-classic "1.1.7" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.21"]
@@ -20,7 +20,7 @@
                       [org.mortbay.jetty.alpn/alpn-boot "8.1.0.v20141016" :prepend true] ;; JDK 1.8.0_20 (1.8 up to _20)
                       ]
   :profiles {:dev {:aliases {"run-dev" ["with-profiles" "dev,jetty" "trampoline" "run" "-m" "war-example.server/run-dev"]}
-                   :dependencies [ [io.pedestal/pedestal.service-tools "0.5.0"]]
+                   :dependencies [ [io.pedestal/pedestal.service-tools "0.5.1"]]
                    :plugins [[ohpauleez/lein-pedestal "0.1.0-beta10"]]
                    :pedestal {;:web-xml "war-resources/WEB-INF/web.xml" ;; use this instead of generating
                               :servlet-name "PedestalWarExample"
@@ -28,7 +28,6 @@
                               :servlet-description "An example of how to build WARs of Pedestal services"
                               :server-ns "war-example.server"}}
              :test {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
-             :jetty {:dependencies [[io.pedestal/pedestal.jetty "0.5.0"]]}
+             :jetty {:dependencies [[io.pedestal/pedestal.jetty "0.5.1"]]}
              :uberjar {:aot [war-example.server]}}
   :main ^{:skip-aot true} war-example.server)
-

--- a/samples/war-example/project.clj
+++ b/samples/war-example/project.clj
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 (defproject war-example "0.5.1"
-  :description "FIXME: write description"
+  :description "Demonstrate packaging a Pedestal app in a war file"
   :url "https://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -24,13 +24,7 @@
                  [org.slf4j/log4j-over-slf4j "1.7.21"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
-  :plugins [[info.sunng/lein-bootclasspath-deps "0.2.0"]]
-  :boot-dependencies [;; See: https://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.4.v20150727"] ;; JDK 1.8.0_51
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.3.v20150130"] ;; JDK 1.8.0_31/40/45
-                      ;[org.mortbay.jetty.alpn/alpn-boot "8.1.2.v20141202"] ;; JDK 1.8.0_25
-                      [org.mortbay.jetty.alpn/alpn-boot "8.1.0.v20141016" :prepend true] ;; JDK 1.8.0_20 (1.8 up to _20)
-                      ]
+  :java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.3"]]
   :profiles {:dev {:aliases {"run-dev" ["with-profiles" "dev,jetty" "trampoline" "run" "-m" "war-example.server/run-dev"]}
                    :dependencies [ [io.pedestal/pedestal.service-tools "0.5.1"]]
                    :plugins [[ohpauleez/lein-pedestal "0.1.0-beta10"]]

--- a/samples/war-example/project.clj
+++ b/samples/war-example/project.clj
@@ -1,3 +1,15 @@
+; Copyright 2013 Relevance, Inc.
+; Copyright 2014-2016 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (defproject war-example "0.5.1"
   :description "FIXME: write description"
   :url "https://pedestal.io/samples/index"

--- a/samples/war-example/src/war_example/service.clj
+++ b/samples/war-example/src/war_example/service.clj
@@ -24,14 +24,14 @@
               ["/about" :get (conj common-interceptors `about-page)]})
 
 ;; Map-based routes
-;(def routes `{"/" {:interceptors [(body-params/body-params) bootstrap/html-body]
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
 ;                   :get home-page
 ;                   "/about" {:get about-page}}})
 
 ;; Terse/Vector-based routes
 ;(def routes
 ;  `[[["/" {:get home-page}
-;      ^:interceptors [(body-params/body-params) bootstrap/html-body]
+;      ^:interceptors [(body-params/body-params) http/html-body]
 ;      ["/about" {:get about-page}]]]])
 
 
@@ -67,4 +67,3 @@
                                         ;:key-password "password"
                                         ;:ssl-port 8443
                                         :ssl? false}})
-

--- a/samples/war-example/test/war_example/service_test.clj
+++ b/samples/war-example/test/war_example/service_test.clj
@@ -1,11 +1,11 @@
 (ns war-example.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
+            [io.pedestal.http :as http]
             [war-example.service :as service]))
 
 (def service
-  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+  (::http/service-fn (http/create-servlet service/service)))
 
 (deftest home-page-test
   (is (=
@@ -31,4 +31,3 @@
         "X-Frame-Options" "DENY"
         "X-Content-Type-Options" "nosniff"
         "X-XSS-Protection" "1; mode=block"})))
-


### PR DESCRIPTION
- Use 'http' as a namespace alias everywhere instead of the old, deprecated 'bootstrap' alias.
- Update dependencies to Pedestal 0.5.1
- Update some other dependencies, including logback and slf4j where needed
- Remove some vestigial code from the chain-provider sample to clarify what is needed and what isn't
- Replace the use of the boot-classpath-deps plugin with a :java-agents field in project.clj
- Update copyright notices and bring them up to date
- Point all `:url` fields in samples' project.clj files to http://pedestal.io/samples/index
