### PR TITLE
Bugfix definterceptor macro.

### DIFF
--- a/interceptor/src/io/pedestal/interceptor/helpers.clj
+++ b/interceptor/src/io/pedestal/interceptor/helpers.clj
@@ -34,7 +34,7 @@
                (first body))
         doc (when (string? (first body))
               (first body))]
-    `(def ~(with-meta name {:doc doc})  ~(interceptor init))))
+    `(def ~(with-meta name {:doc doc})  (interceptor ~init))))
 
 (defn- infer-basic-interceptor-function
   "Given list `args`, infer a form that will evaluate to a function


### PR DESCRIPTION
I ran into a problem with the `definterceptor` macro:

```
$ cd pedestal/interceptor
$ lein repl
user=> (require '[io.pedestal.interceptor.helpers :refer [definterceptor]])
user=> (definterceptor foo {:name ::foo :enter identity})

AssertionError Assert failed: (valid-interceptor? %)  io.pedestal.interceptor/interceptor (interceptor.clj:78)
```

But this works:

```
user=> (def m {:name ::foo :enter identity})
#'user/m
user=> (definterceptor foo m)
#'user/foo
```

It looks like a small bug in the unquoting in the `definterceptor` macro.  What do you think to this proposed fix?
