### PR TITLE
Servlet Chain Provider should handle multi-valued headers

### DIFF
--- a/service/src/io/pedestal/http/request.clj
+++ b/service/src/io/pedestal/http/request.clj
@@ -23,9 +23,9 @@
   (loop [out (transient {})
          names (enumeration-seq (.getHeaderNames servlet-req))]
     (if (seq names)
-      (let [key (first names)]
-        (recur (assoc! out (.toLowerCase ^String key)
-                       (.getHeader servlet-req key))
+      (let [^String key (first names)
+            hdrstr (java.lang.String/join "," ^clojure.lang.EnumerationSeq (enumeration-seq (.getHeaders servlet-req key)))]
+        (recur (assoc! out (.toLowerCase key) hdrstr)
                (rest names)))
       (persistent! out))))
 

--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -131,7 +131,7 @@
         ;; Needed for NIO testing (see Servlet Interceptor)
         (getHeaderNames [this] (enumerator (keys (get options :headers)) ::getHeaderNames))
         (getHeader [this header] (get-in options [:headers header]))
-        ;;(getHeaders [this header] (enumerator (get-in options [:headers header]) ::getHeaders))
+        (getHeaders [this header] (enumerator [(get-in options [:headers header])] ::getHeaders))
         (getContentLength [this] (Integer/parseInt (get-in options [:headers "Content-Length"] "0")))
         (getContentLengthLong [this] (Long/parseLong (get-in options [:headers "Content-Length"] "0")))
         (getContentType [this] (get-in options [:headers "Content-Type"] ""))


### PR DESCRIPTION
Initially, the request util functions were expecting all headers to be single-valued, allowing for a single method call to be performed with no header concatenation.

This approach fails though if the headers are multi-valued or if a negotiated protocol breaks up headers.
The new code performs the concatenation with a StringBuilder (under the hood) for each header.  If the header is a single value, the String is used directly.

This code relies on Java 8's String.join method.