### PR TITLE
The `url-for` function and linker map should be delayed (possible breaking change)

### DIFF
--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -339,7 +339,8 @@
     - The incoming request being routed."
   [route-name & options]
   (if *url-for*
-    (apply *url-for* route-name options)
+    (apply (if (delay? *url-for*) (deref *url-for*) *url-for*)
+           route-name options)
     (throw (ex-info "*url-for* not bound" {}))))
 
 (defprotocol ExpandableRoutes
@@ -393,7 +394,7 @@
   (if-let [route (router/find-route router (:request context))]
     ;;  This is where path-params are added to the request. vvvv
     (let [request-with-path-params (assoc (:request context) :path-params (:path-params route))
-          linker (url-for-routes routes :request request-with-path-params)]
+          linker (delay (url-for-routes routes :request request-with-path-params))]
       (-> context
           (assoc :route route
                  :request (assoc request-with-path-params :url-for linker)


### PR DESCRIPTION
As mentioned in #498 the url-for linker map and function was being created for every request regardless if it was being used.  This change wraps the calculation in a `delay` and is only calculated when `url-for` is actually called.

This is a potentially breaking change if existing code relies upon the `:url-for` key within the context.  If you only ever used the linker-map through the `url-for` function, everything should work as expected.