### PR TITLE
Interceptors: provide exception class when there is no message

### DIFF
--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -30,7 +30,8 @@
   (get interceptor :name (pr-str interceptor)))
 
 (defn- throwable->ex-info [^Throwable t execution-id interceptor stage]
-  (ex-info (str "Interceptor Exception: " (.getMessage t))
+  (ex-info (str "Interceptor Exception: " (or (.getMessage t)
+                                              (.. t getClass getName)))
            (merge {:execution-id execution-id
                    :stage stage
                    :interceptor (name interceptor)


### PR DESCRIPTION
Some exceptions don't have an exception message which leads to (unhelpful) exception messages like 

```
Interceptor Exception:
```

This change falls back to the exception class if there's no message, common cases could be arithmetic exceptions or `(rand-nth [])`. With the proposed change the above would change to this:

```
Interceptor Exception: java.lang.IndexOutOfBoundsException
```

We also see `Interceptor Exception: Interceptor Exception: ...` lots of times, not sure if that is intended or not?

