### PR TITLE
log-request interceptor made optional.

### DIFF
--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -222,6 +222,7 @@
          enable-session ::enable-session
          enable-csrf ::enable-csrf
          secure-headers ::secure-headers
+         no-logging ::no-logging
          :or {file-path nil
               router :map-tree
               resource-path nil
@@ -230,6 +231,7 @@
               ext-mime-types {}
               enable-session nil
               enable-csrf nil
+              no-logging false
               secure-headers {}}} service-map
         processed-routes (cond
                            (satisfies? route/ExpandableRoutes routes) (route/expand-routes routes)
@@ -242,7 +244,7 @@
     (if-not interceptors
       (assoc service-map ::interceptors
              (cond-> []
-                     true (conj log-request)
+                     (not no-logging) (conj log-request)
                      (not (nil? allowed-origins)) (conj (cors/allow-origin allowed-origins))
                      true (conj not-found-interceptor)
                      (or enable-session enable-csrf) (conj (middlewares/session (or enable-session {})))
@@ -370,4 +372,3 @@
 
 (defn servlet-service [service servlet-req servlet-resp]
   (.service ^javax.servlet.Servlet (::servlet service) servlet-req servlet-resp))
-


### PR DESCRIPTION
Problem:
Not every one need the `log-request` interceptor. Since pedestal
is a library it should give the control to user to customize every
aspect of the system ( at least as much as possible ).

Solution:
`log-request` made optional. By default it would be the first interceptor
in the vector returned `default-interceptors`. But if the `::http/no-logging`
key had a truthy value in the service map then log request interceptor
won't be conjed into the default interceptors vector.

Personally I have my own logging interceptor which fits my needs but `log-request` interceptor is something that don't help me in my case but i didn't have the chance to disable it. I either had to create the default interceptor stack manually or do some hack to remove it from system map 