### PR TITLE
Unquoted CSP option give browser warning

### DIFF
--- a/service-template/src/leiningen/new/pedestal_service/server.clj
+++ b/service-template/src/leiningen/new/pedestal_service/server.clj
@@ -22,7 +22,7 @@
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
               ;; Content Security Policy (CSP) is mostly turned off in dev mode
-              ::server/secure-headers {:content-security-policy-settings {:object-src "none"}}})
+              ::server/secure-headers {:content-security-policy-settings {:object-src "'none'"}}})
       ;; Wire up interceptor chains
       server/default-interceptors
       server/dev-interceptors


### PR DESCRIPTION
The template for server.clj is missing quotes for CSP object-src none. This results in a warning from the browser:
"Content Security Policy: Interpreting none as a hostname, not a keyword. If you intended this to be a keyword, use ‘none’ (wrapped in single quotes)."