### PR TITLE
Content negotiation: fix the default no-match-fn

### DIFF
--- a/service/src/io/pedestal/http/content_negotiation.clj
+++ b/service/src/io/pedestal/http/content_negotiation.clj
@@ -169,7 +169,8 @@
         {:keys [no-match-fn content-param-paths]
          :or {no-match-fn (fn [ctx]
                             (assoc ctx :response {:status 406
-                                                  :body "Not Acceptable"}))
+                                                  :body "Not Acceptable"
+                                                  :headers {}}))
               content-param-paths [[:request :headers "accept"]
                                    [:request :headers :accept]]}} opts-map]
     (interceptor/interceptor


### PR DESCRIPTION
The default function does not return a valid ring response (checked here https://github.com/pedestal/pedestal/blob/41337e41ae773f3c17baeb1c244be13ddf6c28db/service/src/io/pedestal/http/impl/servlet_interceptor.clj#L233), so the rest of the interceptors are called even when the content negotiation fails.

Adding `:headers {}` to the response map solves it.