### PR TITLE
Expand the async example and explanation

### DIFF
--- a/guides/documentation/service-async.md
+++ b/guides/documentation/service-async.md
@@ -55,12 +55,12 @@ thread, as shown below:
 The `go` block allows work to take place asynchronously while the
 thread is released.
 
-The lengthy-computation returns a channel that
+The `lengthy-computation` function returns a channel that
 conveys the result, `<!` will park the go block until that value is conveyed,
-after which the block continues to construct a response and `assoc` it
+after which the `go` block continues to construct a response and `assoc` it
 into the context.
 
-A `go` block returns a channel that conveys that modified context, at
+The `go` block returns a channel that conveys that modified context, at
 which point Pedestal picks back up to resume handling of the original request.
 Since a response is now ready, the original request will
 complete, and that response will be delivered to the client.

--- a/guides/documentation/service-async.md
+++ b/guides/documentation/service-async.md
@@ -44,20 +44,26 @@ thread, as shown below:
 ```clj
     (interceptors/defbefore takes-time
       [context]
-      (let [channel (chan)]
-        (go
-         (let [result (lengthy-computation (:request context))
-               new-context (assoc context :response (ring-resp/response result))]
-           (>! channel new-context)))
-        channel))
+      (go
+        (let [result (<! (lengthy-computation (:request context)))]
+          (assoc context :response (ring-resp/response result)))))
 
     (defroutes routes
       [[["/takes-time" {:get takes-time}]]])
 ```
 
 The `go` block allows work to take place asynchronously while the
-thread is released. When that work is complete, the request will
-complete, and a response will be delivered to the client.
+thread is released.
+
+The lengthy-computation returns a channel that
+conveys the result, `<!` will park the go block until that value is conveyed,
+after which the block continues to construct a response and `assoc` it
+into the context.
+
+A `go` block returns a channel that conveys that modified context, at
+which point Pedestal picks back up to resume handling of the original request.
+Since a response is now ready, the original request will
+complete, and that response will be delivered to the client.
 
 This facility allows a single value to be placed on a channel per
 interceptor; for more extensive use of channels for SSE, see


### PR DESCRIPTION
Was reading through the docs and the async example bothered me, since it appeared to show a long-running process inside a go block. I touched that up, simplified it with an explanation of what go and <! does, and otherwise expanded the description.