### PR TITLE
SSE: Properly decrement io.pedestal.http.sse/active-streams metric

### DIFF
--- a/service/src/io/pedestal/http/sse.clj
+++ b/service/src/io/pedestal/http/sse.clj
@@ -157,8 +157,8 @@
          (log/info :msg "Event channel has closed. Shutting down SSE stream."))))
     (async/close! event-channel)
     (async/close! response-channel)
-    (when on-client-disconnect (on-client-disconnect))
-    (log/counter ::active-streams -1)))
+    (log/counter ::active-streams -1)
+    (when on-client-disconnect (on-client-disconnect))))
 
 (defn start-stream
   "Starts an SSE event stream and initiates a heartbeat to keep the

--- a/service/src/io/pedestal/http/sse.clj
+++ b/service/src/io/pedestal/http/sse.clj
@@ -154,12 +154,11 @@
              (log/info :msg "Response channel was closed when sending event. Shutting down SSE stream.")))
 
          :else
-         (do
-           (log/counter ::active-streams -1)
-           (log/info :msg "Event channel has closed. Shutting down SSE stream.")))))
+         (log/info :msg "Event channel has closed. Shutting down SSE stream."))))
     (async/close! event-channel)
     (async/close! response-channel)
-    (when on-client-disconnect (on-client-disconnect))))
+    (when on-client-disconnect (on-client-disconnect))
+    (log/counter ::active-streams -1)))
 
 (defn start-stream
   "Starts an SSE event stream and initiates a heartbeat to keep the


### PR DESCRIPTION
Moved the call to decrement the active streams counter metric outside of the dispatch loop, after the `on-client-disconnect` callback. Previously, the counter would not decrement if the stream was closed on a heartbeat or send failure.