### PR TITLE
Distributed Tracing (OpenTracing and AWS-XRay), AWS Lambda support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
-lein: lein2
-script: lein2 sub install; LEIN_CMD=lein2 lein2 sub test :travis
+lein: lein
+script: lein sub install; LEIN_CMD=lein lein sub test :travis
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 **NOTE:** Whenever upgrading versions of pedestal-app, please be sure to clean your project's `out` directory by running `lein clean`.
 
+## 0.5.3 - October 3, 2017
+
+ * TODO
+
+For a full list of changes, please see this comparison of [0.5.2...0.5.3](https://github.com/pedestal/pedestal/compare/0.5.2...0.5.3).
+
 ## 0.5.2 - January 12, 2017
 
  * Immutant WebSocket support added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ## 0.5.3 - October 3, 2017
 
- * TODO
+ * CSRF default interceptor now implies `body-params` when turned on
+ * The internal linker map within `url-for` is now delayed, while upholding the existing API
+ * `not-found` and `request-logging` default interceptors are now optional and can be toggled in the Service Map
+ * All Routers are verb-neutral.  Table Routes is the only verb-neutral data definition currently
+ * Service Template improves the developer experience around CSP (mostly turned off in dev-mode)
+ * `url-for` correctly handles trailing slashes
+ * Clojure 1.9.0 and core.async spec bugs all addressed by bumping dependencies
+ * Servlet Chain Provider correctly handles multi-valued header entries
 
 For a full list of changes, please see this comparison of [0.5.2...0.5.3](https://github.com/pedestal/pedestal/compare/0.5.2...0.5.3).
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ server-side development.
 
 Leiningen dependencies:
 ```
-[io.pedestal/pedestal.service       "0.5.2"]
-[io.pedestal/pedestal.service-tools "0.5.2"] ;; Only needed for ns-watching; WAR tooling
-[io.pedestal/pedestal.jetty         "0.5.2"]
-[io.pedestal/pedestal.immutant      "0.5.2"]
-[io.pedestal/pedestal.tomcat        "0.5.2"]
+[io.pedestal/pedestal.service       "0.5.3"]
+[io.pedestal/pedestal.service-tools "0.5.3"] ;; Only needed for ns-watching; WAR tooling
+[io.pedestal/pedestal.jetty         "0.5.3"]
+[io.pedestal/pedestal.immutant      "0.5.3"]
+[io.pedestal/pedestal.tomcat        "0.5.3"]
 ```
 
 You can also use Pedestal's internal modules standalone
 ```
-[io.pedestal/pedestal.log         "0.5.2"] ;; Logging and runtime metrics
-[io.pedestal/pedestal.interceptor "0.5.2"] ;; The Interceptor chain and the Interceptor API
-[io.pedestal/pedestal.route       "0.5.2"] ;; Efficient routing algorithms and data structures
+[io.pedestal/pedestal.log         "0.5.3"] ;; Logging and runtime metrics
+[io.pedestal/pedestal.interceptor "0.5.3"] ;; The Interceptor chain and the Interceptor API
+[io.pedestal/pedestal.route       "0.5.3"] ;; Efficient routing algorithms and data structures
 ```
 
 **Please see our [Releases](https://github.com/pedestal/pedestal/releases) for

--- a/aws/project.clj
+++ b/aws/project.clj
@@ -21,9 +21,16 @@
                  [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
                  ;[com.amazonaws.serverless/aws-serverless-java-container-core "0.5.1" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
                  [javax.servlet/javax.servlet-api "3.1.0"]
-                 ;[com.fasterxml.jackson.core/jackson-databind "2.8.9"] ;; matches io.pedestal/pedestal.service
+                 [com.amazonaws/aws-java-sdk-core "1.11.331" :exclusions [commons-logging]] ;; Needed for x-ray
                  [com.amazonaws/aws-lambda-java-core "1.2.0"]
                  ;[com.amazonaws/aws-lambda-java-events "1.3.0"]
+                 [com.amazonaws/aws-xray-recorder-sdk-core "1.3.1" :exclusions [com.amazonaws/aws-java-sdk-core
+                                                                                commons-logging]]
+                 ;; Deps cleanup
+                 [commons-logging "1.2"] ;; A clash between AWS and HTTP Libs
+                 [com.fasterxml.jackson.core/jackson-core "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
+                 [commons-codec "1.11"] ;; Bring AWS libs inline with Pedestal Service
                  ]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/aws/src/io/pedestal/http/aws/lambda/utils.clj
+++ b/aws/src/io/pedestal/http/aws/lambda/utils.clj
@@ -36,6 +36,7 @@
       :uri path
       ;:query-string query-string
       :query-string-params (get apigw-event "queryStringParameters")
+      :path-params (get apigw-event "pathParameters" {})
       :scheme (get headers "X-Forwarded-Proto" "http")
       :request-method (some-> (get apigw-event "httpMethod")
                               string/lower-case

--- a/aws/src/io/pedestal/log/aws/xray.clj
+++ b/aws/src/io/pedestal/log/aws/xray.clj
@@ -1,12 +1,14 @@
 (ns io.pedestal.log.aws.xray
-  (:require [io.pedestal.log :as log])
+  (:require [io.pedestal.log :as log]
+            [clojure.string :as string])
   (:import (com.amazonaws.xray AWSXRay
                                AWSXRayRecorder
                                AWSXRayRecorderBuilder)
            (com.amazonaws.xray.entities Entity
                                         Segment
                                         Subsegment
-                                        TraceID)
+                                        TraceID
+                                        TraceHeader)
            (java.util Map)))
 
 (extend-protocol log/TraceOrigin
@@ -75,10 +77,11 @@
       :else (.putAnnotation t ^String (log/format-name tag-key) ^String (str tag-value)))
     t)
   (-finish-span
-    ([t] (.end t) t)
+    ([t] (.end t) (.close t) t)
     ([t micros]
      (.setEndTime t micros)
      (.end t)
+     (.close t)
      t))
   )
 
@@ -148,7 +151,7 @@
   (-get-baggage-map [t]
     (.getMetadata t)))
 
-(defn provide-tracer
+(defn tracer
   "This function returns an XRay Recorder.
   You can assign this tracer to be the default in Pedestal Log by either:
    * Setting the JVM property io.pedestal.log.defaultTracer to 'io.pedestal.log.aws.xray.provide-tracer'
@@ -159,4 +162,46 @@
   []
   (AWSXRay/getGlobalRecorder))
 
+(defn span-resolver
+  "This is an AWS-specific span resolver for use with the
+  `io.pedestal.interceptor.trace/tracing-interceptor` Interceptor.
+
+  This resolves any possible Span/Segment in the following order:
+   1. Pedestal tracing value in the Context
+   2. AWS X-Ray Servlet values (if the Servlet API class is detected)
+   3. AWS X-Ray Headers
+   4. Nothing found - a new span/segment is created. "
+  ([context]
+   (span-resolver context (try (Class/forName "javax.servlet.HttpServletRequest")
+                                   (catch Exception _ nil))))
+  ([context servlet-class]
+   (let [servlet-req (and servlet-class (:servlet-request context))
+         servlet-request (and servlet-req servlet-class (with-meta servlet-req {:tag servlet-class}))
+         operation-name (:io.pedestal.interceptor.trace/span-operation context "PedestalSpan")]
+     (try
+       ;; OpenTracing can throw errors when an extract fails due to no span being present (according to the docs)
+       ;; Defensively protect against span parse/extract errors,
+       ;;  and on exception, just create a new span without a parent, tagged appropriately
+       (or ;; Is there already a span in the context?
+           (::log/span context)
+           ;; Is there an AWS X-Ray specific span/segment in the servlet request?
+           (when-let [span (and servlet-request
+                                (.getAttribute servlet-request "com.amazonaws.xray.entities.Entity"))]
+             (log/span operation-name span))
+           ;; Is there an X-Ray Trace ID in the headers?
+           (when-let [header-str (or (get-in context [:request :headers "x-amzn-trace-id"])
+                                     (get-in context [:request :headers "X-Amzn-Trace-Id"]))]
+             (let [^TraceHeader trace-header (TraceHeader/fromString ^String header-str)
+                   ^TraceID trace-id (.getRootTraceId trace-header)
+                   ^String parent-id (.getParentId trace-header)]
+               (.beginSegment ^AWSXRayRecorder (AWSXRay/getGlobalRecorder)
+                              ^String operation-name
+                              trace-id
+                              ^String parent-id)))
+           ;; Otherwise, create a new span
+           (log/span operation-name))
+       (catch Exception e
+         ;; Something happened during decoding a Span,
+         ;; Create a new span and tag it accordingly
+         (log/tag-span (log/span operation-name) :revolver-exception (.getMessage e)))))))
 

--- a/aws/src/io/pedestal/log/aws/xray.clj
+++ b/aws/src/io/pedestal/log/aws/xray.clj
@@ -1,0 +1,162 @@
+(ns io.pedestal.log.aws.xray
+  (:require [io.pedestal.log :as log])
+  (:import (com.amazonaws.xray AWSXRay
+                               AWSXRayRecorder
+                               AWSXRayRecorderBuilder)
+           (com.amazonaws.xray.entities Entity
+                                        Segment
+                                        Subsegment
+                                        TraceID)
+           (java.util Map)))
+
+(extend-protocol log/TraceOrigin
+
+  AWSXRayRecorder
+  (-register [t]
+    (AWSXRay/setGlobalRecorder t))
+  (-span
+    ;;TODO: Handle `parent` as a string as from the headers
+    ([t operation-name]
+     (.beginSegment t ^String operation-name))
+    ([t operation-name parent]
+     (.beginSegment t
+                    ^String operation-name
+                    ^TraceID (.getTraceId ^Entity parent)
+                    ^String (.getId ^Entity parent)))
+    ([t operation-name parent opts]
+     (let [{:keys [initial-tags]
+            :or {initial-tags {}}} opts
+           ^Segment segment (.beginSegment t
+                                           ^String operation-name
+                                           ^TraceID (.getTraceId ^Entity parent)
+                                           ^String (.getId ^Entity parent))
+           _ (.setAnnotations segment ^Map initial-tags)]
+       segment)))
+  (-activate-span [t span]
+    (.setTraceEntity t ^Entity span)
+    span)
+  (-active-span [t]
+    ;; TODO: It may be smarter to use .getCurrentSegment here, but that might be overly specific
+    (.getTraceEntity t)))
+
+(extend-protocol log/TraceSpan
+
+  Segment
+  (-set-operation-name [t operation-name]
+    (log/info :msg "X-Ray is unable to set operation/span name once the Segment exists. Returning segment as-is"
+              :segment t
+              :attempted-operation-name operation-name)
+    t)
+  (-tag-span [t tag-key tag-value]
+    (cond
+      (string? tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^String tag-value)
+      (number? tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^Number tag-value)
+      (instance? Boolean tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^Boolean tag-value)
+      :else (.putAnnotation t ^String (log/format-name tag-key) ^String (str tag-value)))
+    t)
+  (-finish-span
+    ([t] (.end t) t)
+    ([t micros]
+     (.setEndTime t micros)
+     (.end t)
+     t))
+
+  Subsegment
+  (-set-operation-name [t operation-name]
+    (log/info :msg "X-Ray is unable to set operation/span name once the Subsegment exists. Returning segment as-is"
+              :subsegment t
+              :attempted-operation-name operation-name)
+    t)
+  (-tag-span [t tag-key tag-value]
+    (cond
+      (string? tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^String tag-value)
+      (number? tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^Number tag-value)
+      (instance? Boolean tag-value) (.putAnnotation t ^String (log/format-name tag-key) ^Boolean tag-value)
+      :else (.putAnnotation t ^String (log/format-name tag-key) ^String (str tag-value)))
+    t)
+  (-finish-span
+    ([t] (.end t) t)
+    ([t micros]
+     (.setEndTime t micros)
+     (.end t)
+     t))
+  )
+
+(extend-protocol log/TraceSpanLog
+
+  ;;TODO: Log messages should be registered as subsegments?
+  Entity
+  (-log-span
+    ([t msg]
+     (let [log-vec (log/span-baggage t :io.pedestal/log [])]
+       (if (keyword? msg)
+         (.putMetadata t "io.pedestal" "log" (conj log-vec {log/span-log-event msg}))
+         (.putMetadata t "io.pedestal" "log" (conj log-vec {log/span-log-event "info"
+                                                            log/span-log-msg msg})))
+       t))
+    ([t msg micros]
+     (let [log-vec (log/span-baggage t :io.pedestal/log [])]
+       (if (keyword? msg)
+         (.putMetadata t "io.pedestal" "log" (conj log-vec {log/span-log-event msg
+                                                            "time" micros}))
+         (.putMetadata t "io.pedestal" "log" (conj log-vec {log/span-log-event "info"
+                                                            log/span-log-msg msg
+                                                            "time" micros})))
+       t)))
+  (-error-span
+    ([t throwable]
+     (.addException t ^Throwable throwable)
+     t)
+    ([t throwable micros]
+     ;; TODO: This call ignores `micros` for now
+     (.addException t ^Throwable throwable))))
+
+(extend-protocol log/TraceSpanLogMap
+
+  Entity
+  (-log-span-map
+    ([t msg-map]
+     (let [log-vec (log/span-baggage t :io.pedestal/log [])]
+       (.putMetadata t "io.pedestal" "log" (conj log-vec msg-map))
+       t))
+    ([t msg-map micros]
+     ;; TODO: This call ignores `micros` for now
+     (let [log-vec (log/span-baggage t :io.pedestal/log [])]
+       (.putMetadata t "io.pedestal" "log" (conj log-vec msg-map))
+       t))))
+
+(extend-protocol log/TraceSpanBaggage
+
+  Entity
+  (-set-baggage [t k v]
+    (if-let [k-ns (and (keyword? k) (namespace k))]
+      (.putMetadata t k-ns (name k) v)
+      (.putMetadata t (log/format-name k) v)))
+  (-get-baggage
+    ([t k]
+     (let [k-ns (if (keyword? k) (or (namespace k) "default"))
+           k-str (if (keyword? k) (name k) (log/format-name k))
+           meta-ns-map (.get ^Map (.getMetadata t) ^String k-ns)]
+       (when meta-ns-map
+         (.get ^Map meta-ns-map ^String k-str))))
+    ([t k not-found]
+     (let [k-ns (if (keyword? k) (or (namespace k) "default"))
+           k-str (if (keyword? k) (name k) (log/format-name k))
+           meta-ns-map (.get ^Map (.getMetadata t) ^String k-ns)]
+       (when meta-ns-map
+         (.getOrDefault ^Map meta-ns-map ^String k-str not-found)))))
+  (-get-baggage-map [t]
+    (.getMetadata t)))
+
+(defn provide-tracer
+  "This function returns an XRay Recorder.
+  You can assign this tracer to be the default in Pedestal Log by either:
+   * Setting the JVM property io.pedestal.log.defaultTracer to 'io.pedestal.log.aws.xray.provide-tracer'
+   * Setting the PEDESTAL_TRACER environment variable to 'io.pedestal.log.aws.xray.provide-tracer'
+
+  If you're using an OpenTracing adaptor for XRay,
+  you can register the tracer directly with: `(io.pedestal.log/-register ...)`"
+  []
+  (AWSXRay/getGlobalRecorder))
+
+

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.immutant "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.immutant "0.5.3"
   :description "Embedded Immutant adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.immutant "0.5.3"
+(defproject io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"
   :description "Embedded Immutant adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -15,13 +15,14 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.3.442"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
 
                  ;; Error interceptor tooling
-                 [org.clojure/core.match "0.3.0-alpha4" :exclusions [[org.clojure/clojurescript]
-                                                                     [org.clojure/tools.analyzer.jvm]]]]
+                 [org.clojure/core.match "0.3.0-alpha5" :exclusions [[org.clojure/clojurescript]
+                                                                     [org.clojure/tools.analyzer.jvm]]]
+                 [org.clojure/tools.analyzer.jvm "0.7.2"]]
   :min-lein-version "2.0.0"
   :pedantic? :abort
   :global-vars {*warn-on-reflection* true}

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.interceptor "0.5.3"
+(defproject io.pedestal/pedestal.interceptor "0.5.4-SNAPSHOT"
   :description "Pedestal interceptor chain and execution utilities"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -17,7 +17,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"]
-                 [io.pedestal/pedestal.log "0.5.3"]
+                 [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
 
                  ;; Error interceptor tooling
                  [org.clojure/core.match "0.3.0-alpha4" :exclusions [[org.clojure/clojurescript]

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.interceptor "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.interceptor "0.5.3"
   :description "Pedestal interceptor chain and execution utilities"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -17,7 +17,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"]
-                 [io.pedestal/pedestal.log "0.5.3-SNAPSHOT"]
+                 [io.pedestal/pedestal.log "0.5.3"]
 
                  ;; Error interceptor tooling
                  [org.clojure/core.match "0.3.0-alpha4" :exclusions [[org.clojure/clojurescript]

--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -30,14 +30,16 @@
   (get interceptor :name (pr-str interceptor)))
 
 (defn- throwable->ex-info [^Throwable t execution-id interceptor stage]
-  (ex-info (str "Interceptor Exception: " (.getMessage t))
+  (let [iname (name interceptor)
+        throwable-str (pr-str (type t))]
+    (ex-info (str throwable-str " in Interceptor " iname " - " (.getMessage t))
            (merge {:execution-id execution-id
                    :stage stage
-                   :interceptor (name interceptor)
-                   :exception-type (keyword (pr-str (type t)))
+                   :interceptor iname
+                   :exception-type (keyword throwable-str)
                    :exception t}
                   (ex-data t))
-           t))
+           t)))
 
 (defn- try-f
   "If f is not nil, invokes it on context. If f throws an exception,

--- a/interceptor/src/io/pedestal/interceptor/trace.clj
+++ b/interceptor/src/io/pedestal/interceptor/trace.clj
@@ -1,0 +1,77 @@
+(ns io.pedestal.interceptor.trace
+  (:require [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.log :as log])
+  (:import (io.opentracing Tracer
+                           SpanContext)
+           (io.opentracing.propagation Format$Builtin
+                                       TextMapExtractAdapter)))
+
+(def should-check-servlet?
+  (try (do (import 'javax.servlet.HttpServletRequest) true)
+       (catch Throwable _ false)))
+
+(defn default-span-resolver
+  [context]
+  (let [servlet-request (and should-check-servlet? (:servlet-request context))]
+    (or (::log/span context)
+        (when-let [span-context (and servlet-request
+                                     (.getAttribute ^javax.servlet.HttpServletRequest servlet-request "TracingFilter.activeSpanContext"))]
+          (log/span (::span-operation context "PedestalSpan") ^SpanContext span-context))
+        (when-let [span-context (.extract ^Tracer log/default-tracer
+                                          Format$Builtin/HTTP_HEADERS
+                                          (TextMapExtractAdaptor. (get-in context [:request :headers] {})))]
+          (log/span (::span-operation context "PedestalSpan") ^SpanContext span-context))
+        (when-let [xray-headers (get-in context [:request :headers "X-Amzn-Trace-Id"])]
+          ;;TODO: Amazon tracing
+          ))))
+
+(defn tracing-interceptor
+  "Return an Interceptor for automatically initiating a distributed trace
+  span on every request, which is finished on `leave`.
+
+  Spans are automatically populated with relevant
+  tags: http.method, http.status_code, http.uril, span.kind
+
+  If on `leave` there is an `:error` in the context, this interceptor with
+  log the error with the span.
+
+  Possible options:
+   :span-resolver - a single-arg function that is given the context and
+                    returns a started and activated span, resolving any propagated or parent span.
+                    The default resolver is `io.pedestal.interceptor.trace.default-span-resolver`
+                    which resolves (in order; first resolution wins):
+                    1. Pedestal tracing values in the Context
+                    2. OpenTracing Servlet values (if the Servlet API class is detected)
+                    3. OpenTracing Header values
+                    4. AWS X-Ray Header values
+   :trace-filter - a single-arg function that is given the context and
+                   returns true if a span should be created for this request.
+                   If not set or set to nil, spans are created for every request
+   :uri-as-span-operation? - Boolean; True if the request URI should be used as the default span name - defaults to true
+   :default-span-operation - A string or keyword to use as the default span name if URI isn't found or :uri-as-span-operation? is false.
+                             Defaults to 'PedestalSpan'
+
+  If the trace-filter or the span-resolver return something falsey, the context is forwarded without
+  an active span"
+  [opts]
+  (let [{:keys [span-resolver
+                trace-filter
+                uri-as-span-operation?
+                default-span-operation]
+         :or {span-resolver default-span-resolver
+              trace-filter (fn [ctx] true)
+              uri-as-span-operation? true
+              default-span-operation "PedestalSpan"}} opts]
+    (interceptor/interceptor
+      {:enter (fn [context]
+                (if-let [span (and (trace-filter context)
+                                   (span-resolver (assoc context
+                                                         ::span-operation (if uri-as-span-operation?
+                                                                           (get-in context [:request :uri] default-span-operation)
+                                                                           default-span-operation))))]
+                  (assoc context
+                         ::log/span (doto span))
+                  context))
+       :leave (fn [context]
+                (if-let [span (::log/span context)]))})))
+

--- a/interceptor/src/io/pedestal/interceptor/trace.clj
+++ b/interceptor/src/io/pedestal/interceptor/trace.clj
@@ -1,29 +1,49 @@
 (ns io.pedestal.interceptor.trace
   (:require [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.log :as log])
   (:import (io.opentracing Tracer
                            SpanContext)
            (io.opentracing.propagation Format$Builtin
                                        TextMapExtractAdapter)))
 
-(def should-check-servlet?
-  (try (do (import 'javax.servlet.HttpServletRequest) true)
-       (catch Throwable _ false)))
-
 (defn default-span-resolver
-  [context]
-  (let [servlet-request (and should-check-servlet? (:servlet-request context))]
-    (or (::log/span context)
-        (when-let [span-context (and servlet-request
-                                     (.getAttribute ^javax.servlet.HttpServletRequest servlet-request "TracingFilter.activeSpanContext"))]
-          (log/span (::span-operation context "PedestalSpan") ^SpanContext span-context))
-        (when-let [span-context (.extract ^Tracer log/default-tracer
-                                          Format$Builtin/HTTP_HEADERS
-                                          (TextMapExtractAdaptor. (get-in context [:request :headers] {})))]
-          (log/span (::span-operation context "PedestalSpan") ^SpanContext span-context))
-        (when-let [xray-headers (get-in context [:request :headers "X-Amzn-Trace-Id"])]
-          ;;TODO: Amazon tracing
-          ))))
+  [context servlet-class]
+  (let [servlet-req (and servlet-class (:servlet-request context))
+        servlet-request (with-meta servlet-req {:tag servlet-class})
+        operation-name (::span-operation context "PedestalSpan")]
+    (try
+      ;; OpenTracing can throw errors when an extract fails due to no span being present (according to the docs)
+      ;; Defensively protect against span parse/extract errors,
+      ;;  and on exception, just create a new span without a parent, tagged appropriately
+      (or ;; Is there already a span in the context?
+          (::log/span context)
+          ;; Is there a span in the servlet request?
+          (when-let [span-context (and servlet-request
+                                       (.getAttribute servlet-request "TracingFilter.activeSpanContext"))]
+            (log/span operation-name ^SpanContext span-context))
+          ;; Is there a span in the headers?
+          (when-let [span-context (.extract ^Tracer log/default-tracer
+                                            Format$Builtin/HTTP_HEADERS
+                                            (TextMapExtractAdapter. (get-in context [:request :headers] {})))]
+            (log/span operation-name ^SpanContext span-context))
+          ;; Is there an AWS X-Ray specific span/segment in the servlet?
+          (when-let [span (and servlet-request
+                               (.getAttribute servlet-request "com.amazonaws.xray.entities.Entity"))]
+            (log/span operation-name span))
+          ;; Is there an AWS X-Ray specific span/segment in ther headers?
+          (when-let [xray-headers (get-in context [:request :headers "X-Amzn-Trace-Id"])]
+            ;;TODO: Amazon tracing
+            ;;
+            (log/error :msg "Found X-Ray Trace Headers, but currently not implemented")
+            nil)
+          ;; Otherwise, create a new span
+          (log/span operation-name))
+      (catch Exception e
+        ;; Something happened during decoding a Span,
+        ;; Create a new span and tag it accordingly
+        (log/tag-span (log/span operation-name) :revolver-exception (.getMessage e))))))
+
 
 (defn tracing-interceptor
   "Return an Interceptor for automatically initiating a distributed trace
@@ -43,7 +63,8 @@
                     1. Pedestal tracing values in the Context
                     2. OpenTracing Servlet values (if the Servlet API class is detected)
                     3. OpenTracing Header values
-                    4. AWS X-Ray Header values
+                    4. AWS X-Ray Servlet values (if the Servlet API class is detected)
+                    5. AWS X-Ray Header values
    :trace-filter - a single-arg function that is given the context and
                    returns true if a span should be created for this request.
                    If not set or set to nil, spans are created for every request
@@ -61,17 +82,29 @@
          :or {span-resolver default-span-resolver
               trace-filter (fn [ctx] true)
               uri-as-span-operation? true
-              default-span-operation "PedestalSpan"}} opts]
+              default-span-operation "PedestalSpan"}} opts
+        servlet-class (try (Class/forName "javax.servlet.HttpServletRequest")
+                           (catch Exception _ nil))]
     (interceptor/interceptor
       {:enter (fn [context]
                 (if-let [span (and (trace-filter context)
                                    (span-resolver (assoc context
                                                          ::span-operation (if uri-as-span-operation?
                                                                            (get-in context [:request :uri] default-span-operation)
-                                                                           default-span-operation))))]
-                  (assoc context
-                         ::log/span (doto span))
+                                                                           default-span-operation))
+                                                  servlet-class))]
+                  (assoc context ::log/span (log/tag-span
+                                              span
+                                              {"http.method" (get-in context [:request :request-method])
+                                               "http.url" (get-in context [:request :uri])
+                                               "http.user-agent" (get-in context [:request :header "User-Agent"])}))
                   context))
        :leave (fn [context]
-                (if-let [span (::log/span context)]))})))
+                (if-let [span (::log/span context)]
+                  (log/tag-span span "http.status_code" (get-in context [:response :status]))
+                  context))
+       :error (fn [context]
+                (if-let [span (::log/span context)]
+                  (log/log-span (::chain/error context))
+                  context))})))
 

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.jetty "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.jetty "0.5.3"
   :description "Embedded Jetty adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.jetty "0.5.3"
+(defproject io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"
   :description "Embedded Jetty adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/log/project.clj
+++ b/log/project.clj
@@ -17,9 +17,13 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  ;; logging
-                 [org.slf4j/slf4j-api "1.7.22"]
+                 [org.slf4j/slf4j-api "1.7.25"]
                  ;; metrics
-                 [io.dropwizard.metrics/metrics-core "3.1.2"]]
+                 [io.dropwizard.metrics/metrics-core "4.0.2"]
+                 [io.dropwizard.metrics/metrics-jmx "4.0.2"]
+                 ;; tracing
+                 [io.opentracing/opentracing-api "0.31.0"]
+                 [io.opentracing/opentracing-util "0.31.0"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
 

--- a/log/project.clj
+++ b/log/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.log "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.log "0.5.3"
   :description "Pedestal logging and metrics facilities"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/log/project.clj
+++ b/log/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.log "0.5.3"
+(defproject io.pedestal/pedestal.log "0.5.4-SNAPSHOT"
   :description "Pedestal logging and metrics facilities"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/log/project.clj
+++ b/log/project.clj
@@ -15,7 +15,7 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  ;; logging
                  [org.slf4j/slf4j-api "1.7.25"]
                  ;; metrics

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -830,10 +830,10 @@
       (let [tracer (try
                      (let [[ns-str fn-str] (clojure.string/split ns-fn-str #"/")]
                        (info :msg "Setting up a new tracer; Requiring necessary namespace"
-                                 :ns ns-str)
+                             :ns ns-str)
                        (require (symbol ns-str))
                        (info :msg "Calling Tracer resolution function..."
-                                 :fn ns-fn-str)
+                             :fn ns-fn-str)
                        ((resolve (symbol ns-fn-str)))))]
         (when-not (GlobalTracer/isRegistered)
           (-register tracer))

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -146,11 +146,11 @@
 (defn log
   "This function provides basic/core logging functionality as a function.
   You may prefer to use this if you need custom logging functionality beyond
-  what is offered by the standard Pedestal logging marcos (which in turn just call the protocols).
+  what is offered by the standard Pedestal logging macros (which in turn just call the protocols).
 
   Given a map of logging information,
     and optionally a default log-level keyword (if not found in the map) -- default is :info,
-  Determine if the appropriate logger to use,
+  Determine the appropriate logger to use,
    determine if logging-level is enabled,
    format the logging message,
   And return the result of calling the appropriate logging function, dispatched to the logging protocols.

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal "0.5.3"
   :plugins [[lein-sub "0.2.3"]]
   :sub ["log"
         "interceptor"
@@ -23,14 +23,14 @@
         "service-template"]
   :aliases {"docs" ["with-profile" "docs" "codox"]}
   :profiles {:docs {:plugins [[lein-codox "0.9.5"]]
-                    :dependencies [[io.pedestal/pedestal.log "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.interceptor "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.route "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.service "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.jetty "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.immutant "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.tomcat "0.5.3-SNAPSHOT"]
-                                   [io.pedestal/pedestal.service-tools "0.5.3-SNAPSHOT"]]
+                    :dependencies [[io.pedestal/pedestal.log "0.5.3"]
+                                   [io.pedestal/pedestal.interceptor "0.5.3"]
+                                   [io.pedestal/pedestal.route "0.5.3"]
+                                   [io.pedestal/pedestal.service "0.5.3"]
+                                   [io.pedestal/pedestal.jetty "0.5.3"]
+                                   [io.pedestal/pedestal.immutant "0.5.3"]
+                                   [io.pedestal/pedestal.tomcat "0.5.3"]
+                                   [io.pedestal/pedestal.service-tools "0.5.3"]]
                     :codox {:output-path "codox"
                             :source-uri "http://github.com/pedestal/pedestal/blob/{version}/{filepath}#L{line}"
                             :source-paths ["log/src"

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal "0.5.3"
+(defproject io.pedestal/pedestal "0.5.4-SNAPSHOT"
   :plugins [[lein-sub "0.2.3"]]
   :sub ["log"
         "interceptor"
@@ -23,14 +23,14 @@
         "service-template"]
   :aliases {"docs" ["with-profile" "docs" "codox"]}
   :profiles {:docs {:plugins [[lein-codox "0.9.5"]]
-                    :dependencies [[io.pedestal/pedestal.log "0.5.3"]
-                                   [io.pedestal/pedestal.interceptor "0.5.3"]
-                                   [io.pedestal/pedestal.route "0.5.3"]
-                                   [io.pedestal/pedestal.service "0.5.3"]
-                                   [io.pedestal/pedestal.jetty "0.5.3"]
-                                   [io.pedestal/pedestal.immutant "0.5.3"]
-                                   [io.pedestal/pedestal.tomcat "0.5.3"]
-                                   [io.pedestal/pedestal.service-tools "0.5.3"]]
+                    :dependencies [[io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.interceptor "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.route "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
+                                   [io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"]]
                     :codox {:output-path "codox"
                             :source-uri "http://github.com/pedestal/pedestal/blob/{version}/{filepath}#L{line}"
                             :source-paths ["log/src"

--- a/route/project.clj
+++ b/route/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.route "0.5.3"
+(defproject io.pedestal/pedestal.route "0.5.4-SNAPSHOT"
   :description "Pedestal route definition and router construction"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -17,8 +17,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"]
-                 [io.pedestal/pedestal.log "0.5.3"]
-                 [io.pedestal/pedestal.interceptor "0.5.3"]
+                 [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
+                 [io.pedestal/pedestal.interceptor "0.5.4-SNAPSHOT"]
                  [org.clojure/core.incubator "0.1.4"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/route/project.clj
+++ b/route/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.route "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.route "0.5.3"
   :description "Pedestal route definition and router construction"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -17,8 +17,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.async "0.3.442"]
-                 [io.pedestal/pedestal.log "0.5.3-SNAPSHOT"]
-                 [io.pedestal/pedestal.interceptor "0.5.3-SNAPSHOT"]
+                 [io.pedestal/pedestal.log "0.5.3"]
+                 [io.pedestal/pedestal.interceptor "0.5.3"]
                  [org.clojure/core.incubator "0.1.4"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -489,10 +489,10 @@
                     (assoc ctx :response {:status 400
                                           :body (str "Bad Request - " (.getMessage iae))})))))}))
 
-(def path-params
-  "Returns an interceptor which parses path parameters."
+(def path-params-decoder
+  "An Interceptor which URL-decodes path parameters."
   (interceptor/interceptor
-   {:name ::path-params
+   {:name ::path-params-decoder
     :enter (fn [ctx]
              (try
                (update-in ctx [:request] parse-path-params)

--- a/samples/project.clj
+++ b/samples/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/samples "0.5.3-SNAPSHOT"
+(defproject io.pedestal/samples "0.5.3"
   :plugins [[lein-sub "0.2.3"]]
   :sub ["hello-world"
         "server-sent-events"

--- a/samples/project.clj
+++ b/samples/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/samples "0.5.3"
+(defproject io.pedestal/samples "0.5.4-SNAPSHOT"
   :plugins [[lein-sub "0.2.3"]]
   :sub ["hello-world"
         "server-sent-events"

--- a/samples/tracing-interceptor-aws/.gitignore
+++ b/samples/tracing-interceptor-aws/.gitignore
@@ -1,0 +1,38 @@
+# Project related
+
+# Java related
+pom.xml
+pom.xml.asc
+*jar
+*.class
+
+# Leiningen
+classes/
+lib/
+native/
+checkouts/
+target/
+.lein-*
+repl-port
+.nrepl-port
+.repl
+
+# Temp Files
+*.orig
+*~
+.*.swp
+.*.swo
+*.tmp
+*.bak
+
+# OS X
+.DS_Store
+
+# Logging
+*.log
+/logs/
+
+# Builds
+out/
+build/
+

--- a/samples/tracing-interceptor-aws/Capstanfile
+++ b/samples/tracing-interceptor-aws/Capstanfile
@@ -1,0 +1,29 @@
+
+#
+# Name of the base image. Capstan will download this automatically from
+# Cloudius S3 repository.
+#
+#base: cloudius/osv
+base: cloudius/osv-openjdk8
+
+#
+# The command line passed to OSv to start up the application.
+#
+#cmdline: /java.so -cp /tracing-interceptor/app.jar clojure.main -m tracing-interceptor
+cmdline: /java.so -jar /tracing-interceptor/app.jar
+
+#
+# The command to use to build the application.
+# You can use any build tool/command (make/rake/lein/boot) - this runs locally on your machine
+#
+# For Leiningen, you can use:
+#build: lein uberjar
+# For Boot, you can use:
+#build: boot build
+
+#
+# List of files that are included in the generated image.
+#
+files:
+  /tracing-interceptor/app.jar: ./target/tracing-interceptor-0.0.1-SNAPSHOT-standalone.jar
+

--- a/samples/tracing-interceptor-aws/Dockerfile
+++ b/samples/tracing-interceptor-aws/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-alpine
+MAINTAINER Your Name <you@example.com>
+
+ADD target/tracing-interceptor-0.0.1-SNAPSHOT-standalone.jar /tracing-interceptor/app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "/tracing-interceptor/app.jar"]

--- a/samples/tracing-interceptor-aws/README.md
+++ b/samples/tracing-interceptor-aws/README.md
@@ -1,0 +1,91 @@
+
+# Working with Distributed Tracing using Pedestal's Trace Interceptor
+
+This sample walks through how to use the distributed tracing capabilities
+built into Pedestal's Trace Interceptor.
+
+Out of the box, Pedestal's `io.pedestal.log` supports the [OpenTracing API](http://opentracing.io/),
+but additional support is possible by extending Pedestal's tracing protocols.
+
+Distributed tracing works by having a centralized server collect portions of
+traces called "spans" or "segments" and proving a comprehensive view of
+requests and data moving through your service.  A single span can append tags,
+data, and log messages during execution, which all get captured during the trace.
+
+If your service forwards calls to additional services, you're able to encode
+the trace ID into those requests and continue tracking the trace across boundaries.
+
+**There are some conventions around naming schemes in tracing elements.**
+You can read about those [in the OpenTracing Docs](http://opentracing.io/documentation/pages/api/data-conventions.html).
+
+
+## Running a distributed trace server
+
+We're going to use Docker to run an instance of the [X-Ray Daemon](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-local.html),
+which provides distributed tracing for us in AWS.
+
+`$ docker run --name aws_xray --rm -d -p 2000:2000/udp \
+-e AWS_ACCESS_KEY_ID=aws_access_key \
+-e AWS_SECRET_ACCESS_KEY=aws_secret_key \
+-e AWS_REGION=aws_region \
+namshi/aws_xray --local-mode`
+
+
+## Getting Started
+
+1. Start the application: `PEDESTAL_TRACER=io.pedestal.log.aws.xray/tracer lein run`
+2. Go to [localhost:8080](http://localhost:8080/) to see: `Hello Tracing World!`
+2. Now go to [localhost:8080/trace](http://localhost:8080/trace), which will call another service endpoint, tracing each step.
+3. Read your app's source code at src/tracing/service.clj. Explore the routes, functions,
+   and tracing interceptor setup.
+4. Go to [your X-Ray UI](https://console.aws.amazon.com/xray/home) and explore the traces
+7. Stop your service and kill your X-Ray Container with `$ docker stop aws_xray`
+8. Learn more! See the [Links section below](#links).
+
+
+## Configuration
+
+To configure logging see config/logback.xml. By default, the app logs to stdout and logs/.
+To learn more about configuring Logback, read its [documentation](http://logback.qos.ch/documentation.html).
+
+
+## How we set our service up to use X-Ray
+
+With our additional dependency, `[io.pedestal/pedestal.aws "0.5.4-SNAPSHOT"]`,
+we can configure our access to our local X-Ray Daemon.
+
+The default tracer in Pedestal can be set with a JVM property setting or
+an environment variable.
+
+We used the environment variable to set the Tracer to X-Ray.
+
+It is also possible to register a tracer with the `-register` protocol function at the main
+entry point of your service (for example, in `server.clj`'s `-main` or `run-dev`),
+although this is tricky for non-OpenTracing systems.
+
+
+## Developing your service
+
+1. Start a new REPL: `lein repl`
+2. Start your service in dev-mode: `(def dev-serv (run-dev))`
+3. Connect your editor to the running REPL session.
+   Re-evaluated code will be seen immediately in the service.
+
+### [Docker](https://www.docker.com/) container support
+
+1. Build an uberjar of your service: `lein uberjar`
+2. Build a Docker image: `sudo docker build -t tracing .`
+3. Run your Docker image: `docker run -p 8080:8080 tracing`
+
+### [OSv](http://osv.io/) unikernel support with [Capstan](http://osv.io/capstan/)
+
+1. Build and run your image: `capstan run -f "8080:8080"`
+
+Once the image it built, it's cached.  To delete the image and build a new one:
+
+1. `capstan rmi tracing; capstan build`
+
+
+## Links
+* [Other examples](https://github.com/pedestal/samples)
+

--- a/samples/tracing-interceptor-aws/README.md
+++ b/samples/tracing-interceptor-aws/README.md
@@ -24,7 +24,8 @@ You can read about those [in the OpenTracing Docs](http://opentracing.io/documen
 We're going to use Docker to run an instance of the [X-Ray Daemon](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-local.html),
 which provides distributed tracing for us in AWS.
 
-`$ docker run --name aws_xray --rm -d -p 2000:2000/udp \
+`$ docker run --name aws_xray --rm -p 2000:2000/udp \
+--attach STDOUT \
 -e AWS_ACCESS_KEY_ID=aws_access_key \
 -e AWS_SECRET_ACCESS_KEY=aws_secret_key \
 -e AWS_REGION=aws_region \
@@ -39,7 +40,7 @@ namshi/aws_xray --local-mode`
 3. Read your app's source code at src/tracing/service.clj. Explore the routes, functions,
    and tracing interceptor setup.
 4. Go to [your X-Ray UI](https://console.aws.amazon.com/xray/home) and explore the traces
-7. Stop your service and kill your X-Ray Container with `$ docker stop aws_xray`
+7. Stop your service and kill your X-Ray Container with Ctrl-c
 8. Learn more! See the [Links section below](#links).
 
 

--- a/samples/tracing-interceptor-aws/config/logback.xml
+++ b/samples/tracing-interceptor-aws/config/logback.xml
@@ -1,0 +1,52 @@
+<!-- Logback configuration. See http://logback.qos.ch/manual/index.html -->
+<!-- Scanning is currently turned on; This will impact performance! -->
+<configuration scan="true" scanPeriod="10 seconds">
+  <!-- Silence Logback's own status messages about config parsing
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" /> -->
+
+  <!-- Simple file output -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>logs/tracing-interceptor-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <!-- or whenever the file size reaches 64 MB -->
+      <maxFileSize>64 MB</maxFileSize>
+    </rollingPolicy>
+
+    <!-- Safely log to the same file from multiple JVMs. Degrades performance! -->
+    <prudent>true</prudent>
+  </appender>
+
+
+  <!-- Console output -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <!-- Only log level INFO and above -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+
+  <!-- Enable FILE and STDOUT appenders for all log messages.
+       By default, only log at level INFO and above. -->
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- For loggers in the these namespaces, log at all levels. -->
+  <logger name="user" level="ALL" />
+  <!-- To log pedestal internals, enable this and change ThresholdFilter to DEBUG
+    <logger name="io.pedestal" level="ALL" />
+  -->
+
+</configuration>

--- a/samples/tracing-interceptor-aws/project.clj
+++ b/samples/tracing-interceptor-aws/project.clj
@@ -1,0 +1,33 @@
+(defproject tracing-interceptor "0.0.1-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
+
+                 ;; Remove this line and uncomment one of the next lines to
+                 ;; use Immutant or Tomcat instead of Jetty:
+                 [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
+
+                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.25"]
+                 [org.slf4j/jcl-over-slf4j "1.7.25"]
+                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+
+                 ;; X-Ray Tracing support
+                 [io.pedestal/pedestal.aws "0.5.4-SNAPSHOT"]
+
+                 ;; Tracing HTTP client to test propagation
+                 [com.amazonaws/aws-xray-recorder-sdk-apache-http "1.3.1"]]
+  :min-lein-version "2.0.0"
+  :resource-paths ["config", "resources"]
+  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
+  ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
+  :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "tracing-interceptor.server/run-dev"]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"]]}
+             :uberjar {:aot [tracing-interceptor.server]}}
+  :main ^{:skip-aot true} tracing-interceptor.server)
+

--- a/samples/tracing-interceptor-aws/src/tracing_interceptor/server.clj
+++ b/samples/tracing-interceptor-aws/src/tracing_interceptor/server.clj
@@ -19,7 +19,9 @@
   ;;  any other Tracer could be registered.  This approach will only fail if
   ;;  the Tracer is set using the JVM property or environment variable.
   (println "Registering local Trace connection")
-  (log/-register (.build (AWSXRayRecorderBuilder/standard)))
+  ;; This isn't needed because we'll set the initialization from the EnvVar
+  ;(log/-register (.build (AWSXRayRecorderBuilder/standard)))
+
   (println "\nCreating your [DEV] server...")
   (-> service/service ;; start with production configuration
       (merge {:env :dev
@@ -47,7 +49,8 @@
   ;;  any other Tracer could be registered.  This approach will only fail if
   ;;  the Tracer is set using the JVM property or environment variable.
   (println "Registering local Trace connection")
-  (log/-register (.build (AWSXRayRecorderBuilder/standard)))
+  ;; This isn't needed because we'll set the initialization from the EnvVar
+  ;(log/-register (.build (AWSXRayRecorderBuilder/standard)))
   (println "\nCreating your server...")
   (server/start runnable-service))
 

--- a/samples/tracing-interceptor-aws/src/tracing_interceptor/server.clj
+++ b/samples/tracing-interceptor-aws/src/tracing_interceptor/server.clj
@@ -1,0 +1,72 @@
+(ns tracing-interceptor.server
+  (:gen-class) ; for -main method in uberjar
+  (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.log :as log]
+            [tracing-interceptor.service :as service])
+  (:import (com.amazonaws.xray AWSXRayRecorderBuilder)))
+
+;; This is an adapted service map, that can be started and stopped
+;; From the REPL you can call server/start and server/stop on this service
+(defonce runnable-service (server/create-server service/service))
+
+(defn run-dev
+  "The entry-point for 'lein run-dev'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.build (AWSXRayRecorderBuilder/standard)))
+  (println "\nCreating your [DEV] server...")
+  (-> service/service ;; start with production configuration
+      (merge {:env :dev
+              ;; do not block thread that starts web server
+              ::server/join? false
+              ;; Routes can be a function that resolve routes,
+              ;;  we can use this to set the routes to be reloadable
+              ::server/routes #(route/expand-routes (deref #'service/routes))
+              ;; all origins are allowed in dev mode
+              ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
+              ;; Content Security Policy (CSP) is mostly turned off in dev mode
+              ::server/secure-headers {:content-security-policy-settings {:object-src "'none'"}}})
+      ;; Wire up interceptor chains
+      server/default-interceptors
+      server/dev-interceptors
+      server/create-server
+      server/start))
+
+(defn -main
+  "The entry-point for 'lein run'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.build (AWSXRayRecorderBuilder/standard)))
+  (println "\nCreating your server...")
+  (server/start runnable-service))
+
+;; If you package the service up as a WAR,
+;; some form of the following function sections is required (for io.pedestal.servlet.ClojureVarServlet).
+
+;;(defonce servlet  (atom nil))
+;;
+;;(defn servlet-init
+;;  [_ config]
+;;  ;; Initialize your app here.
+;;  (reset! servlet  (server/servlet-init service/service nil)))
+;;
+;;(defn servlet-service
+;;  [_ request response]
+;;  (server/servlet-service @servlet request response))
+;;
+;;(defn servlet-destroy
+;;  [_]
+;;  (server/servlet-destroy @servlet)
+;;  (reset! servlet nil))
+

--- a/samples/tracing-interceptor-aws/src/tracing_interceptor/service.clj
+++ b/samples/tracing-interceptor-aws/src/tracing_interceptor/service.clj
@@ -1,0 +1,93 @@
+(ns tracing-interceptor.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.interceptor.trace :as trace]
+            [io.pedestal.log.aws.xray :as xray]
+            [ring.util.response :as ring-resp]
+            [clojure.java.io :as io])
+  (:import (com.amazonaws.xray.proxies.apache.http HttpClientBuilder)
+           (org.apache.http.client.methods HttpGet)))
+
+(defn about-page
+  [request]
+  (ring-resp/response (format "Clojure %s - served from %s"
+                              (clojure-version)
+                              (route/url-for ::about-page))))
+
+(defn home-page
+  [request]
+  (ring-resp/response (str "Hello Tracing World! -> " (pr-str (:headers request)))))
+
+(defn trace-page
+  [request]
+  (let [;; Let's embed a trace back to ourselves, but a different endpoint
+        http-client (.build (HttpClientBuilder/create)) ;; This client already makes it's span parent the current active span
+        response (.execute http-client (HttpGet. "http://localhost:8080"))
+        ]
+    (ring-resp/response (str "TRACED! Response from our internal request - " (slurp (io/reader (.getContent (.getEntity response))))))))
+
+;; Defines "/" and "/about" routes with their associated :get handlers.
+;; The interceptors defined after the verb map (e.g., {:get home-page}
+;; apply to / and its children (/about).
+(def common-interceptors [(trace/tracing-interceptor {:span-resolver xray/span-resolver}) (body-params/body-params) http/html-body])
+
+;; Tabular routes
+(def routes #{["/" :get (conj common-interceptors `home-page)]
+              ["/about" :get (conj common-interceptors `about-page)]
+              ["/trace" :get (conj common-interceptors `trace-page)]})
+
+;; Map-based routes
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
+;                   :get home-page
+;                   "/about" {:get about-page}}})
+
+;; Terse/Vector-based routes
+;(def routes
+;  `[[["/" {:get home-page}
+;      ^:interceptors [(body-params/body-params) http/html-body]
+;      ["/about" {:get about-page}]]]])
+
+
+;; Consumed by tracing-interceptor.server/create-server
+;; See http/default-interceptors for additional options you can configure
+(def service {:env :prod
+              ;; You can bring your own non-default interceptors. Make
+              ;; sure you include routing and set it up right for
+              ;; dev-mode. If you do, many other keys for configuring
+              ;; default interceptors will be ignored.
+              ;; ::http/interceptors []
+              ::http/routes routes
+
+              ;; Uncomment next line to enable CORS support, add
+              ;; string(s) specifying scheme, host and port for
+              ;; allowed source(s):
+              ;;
+              ;; "http://localhost:8080"
+              ;;
+              ;;::http/allowed-origins ["scheme://host:port"]
+
+              ;; Tune the Secure Headers
+              ;; and specifically the Content Security Policy appropriate to your service/application
+              ;; For more information, see: https://content-security-policy.com/
+              ;;   See also: https://github.com/pedestal/pedestal/issues/499
+              ;;::http/secure-headers {:content-security-policy-settings {:object-src "'none'"
+              ;;                                                          :script-src "'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"
+              ;;                                                          :frame-ancestors "'none'"}}
+
+              ;; Root for resource interceptor that is available by default.
+              ::http/resource-path "/public"
+
+              ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
+              ;;  This can also be your own chain provider/server-fn -- http://pedestal.io/reference/architecture-overview#_chain_provider
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080
+              ;; Options to pass to the container (Jetty)
+              ::http/container-options {:h2c? true
+                                        :h2? false
+                                        ;:keystore "test/hp/keystore.jks"
+                                        ;:key-password "password"
+                                        ;:ssl-port 8443
+                                        :ssl? false}})
+

--- a/samples/tracing-interceptor-aws/test/tracing_interceptor/service_test.clj
+++ b/samples/tracing-interceptor-aws/test/tracing_interceptor/service_test.clj
@@ -1,0 +1,39 @@
+(ns tracing-interceptor.service-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.test :refer :all]
+            [io.pedestal.http :as bootstrap]
+            [tracing-interceptor.service :as service]))
+
+(def service
+  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+
+(deftest home-page-test
+  (is (.contains
+       (:body (response-for service :get "/"))
+       "Hello Tracing World!"))
+  (is (=
+       (:headers (response-for service :get "/"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+
+(deftest about-page-test
+  (is (.contains
+       (:body (response-for service :get "/about"))
+       "Clojure 1.9"))
+  (is (=
+       (:headers (response-for service :get "/about"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+

--- a/samples/tracing-interceptor/.gitignore
+++ b/samples/tracing-interceptor/.gitignore
@@ -1,0 +1,38 @@
+# Project related
+
+# Java related
+pom.xml
+pom.xml.asc
+*jar
+*.class
+
+# Leiningen
+classes/
+lib/
+native/
+checkouts/
+target/
+.lein-*
+repl-port
+.nrepl-port
+.repl
+
+# Temp Files
+*.orig
+*~
+.*.swp
+.*.swo
+*.tmp
+*.bak
+
+# OS X
+.DS_Store
+
+# Logging
+*.log
+/logs/
+
+# Builds
+out/
+build/
+

--- a/samples/tracing-interceptor/Capstanfile
+++ b/samples/tracing-interceptor/Capstanfile
@@ -1,0 +1,29 @@
+
+#
+# Name of the base image. Capstan will download this automatically from
+# Cloudius S3 repository.
+#
+#base: cloudius/osv
+base: cloudius/osv-openjdk8
+
+#
+# The command line passed to OSv to start up the application.
+#
+#cmdline: /java.so -cp /tracing-interceptor/app.jar clojure.main -m tracing-interceptor
+cmdline: /java.so -jar /tracing-interceptor/app.jar
+
+#
+# The command to use to build the application.
+# You can use any build tool/command (make/rake/lein/boot) - this runs locally on your machine
+#
+# For Leiningen, you can use:
+#build: lein uberjar
+# For Boot, you can use:
+#build: boot build
+
+#
+# List of files that are included in the generated image.
+#
+files:
+  /tracing-interceptor/app.jar: ./target/tracing-interceptor-0.0.1-SNAPSHOT-standalone.jar
+

--- a/samples/tracing-interceptor/Dockerfile
+++ b/samples/tracing-interceptor/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-alpine
+MAINTAINER Your Name <you@example.com>
+
+ADD target/tracing-interceptor-0.0.1-SNAPSHOT-standalone.jar /tracing-interceptor/app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "/tracing-interceptor/app.jar"]

--- a/samples/tracing-interceptor/README.md
+++ b/samples/tracing-interceptor/README.md
@@ -1,0 +1,87 @@
+
+# Working with Distributed Tracing using Pedestal's Trace Interceptor
+
+This sample walks through how to use the distributed tracing capabilities
+built into Pedestal's Trace Interceptor.
+
+Out of the box, Pedestal's `io.pedestal.log` supports the [OpenTracing API](http://opentracing.io/),
+but additional support is possible by extending Pedestal's tracing protocols.
+
+Distributed tracing works by having a centralized server collect portions of
+traces called "spans" or "segments" and proving a comprehensive view of
+requests and data moving through your service.  A single span can append tags,
+data, and log messages during execution, which all get captured during the trace.
+
+If your service forwards calls to additional services, you're able to encode
+the trace ID into those requests and continue tracking the trace across boundaries.
+
+**There are some conventions around naming schemes in tracing elements.**
+You can read about those [in the OpenTracing Docs](http://opentracing.io/documentation/pages/api/data-conventions.html).
+
+
+## Running a distributed trace server
+
+We're going to use Docker to run an instance of [Jaeger](https://github.com/jaegertracing/jaeger),
+a distributed trace server that supports OpenTracing.
+
+`$ docker run --name jaeger_example --rm -d -p 5775:5775/udp -p 16686:16686 jaegertracing/all-in-one:latest`
+
+
+## Getting Started
+
+1. Start the application: `lein run`
+2. Go to [localhost:8080](http://localhost:8080/) to see: `Hello Tracing World!`
+2. Now go to [localhost:8080/trace](http://localhost:8080/trace), which will call another service endpoint, tracing each step.
+3. Read your app's source code at src/tracing/service.clj. Explore the routes, functions,
+   and tracing interceptor setup.
+4. Go to [your local Jaeger UI](http://localhost:16686),
+   select "TracingExample" from Service dropdown and click "Find Traces"
+5. Click on one of the "TracingExample (4)" tags with a color tab.
+6. Explore the trace
+7. Stop your service and kill your Jaeger with `$ docker stop jaeger_example`
+8. Learn more! See the [Links section below](#links).
+
+
+## Configuration
+
+To configure logging see config/logback.xml. By default, the app logs to stdout and logs/.
+To learn more about configuring Logback, read its [documentation](http://logback.qos.ch/documentation.html).
+
+
+## How we set our service up to use Jaeger
+
+With our additional dependency, `[io.jaegertracing/jaeger-core "0.27.0"]`,
+we can configure our access to our Jaeger server.
+
+The default tracer in Pedestal can be set with a JVM property setting or
+an environment variable.
+If the default tracer hasn't been registered on startup, it is also possible
+to register a tracer with the `-register` protocol function at the main
+entry point of your service (for example, in `server.clj`'s `-main` or `run-dev`).
+
+
+## Developing your service
+
+1. Start a new REPL: `lein repl`
+2. Start your service in dev-mode: `(def dev-serv (run-dev))`
+3. Connect your editor to the running REPL session.
+   Re-evaluated code will be seen immediately in the service.
+
+### [Docker](https://www.docker.com/) container support
+
+1. Build an uberjar of your service: `lein uberjar`
+2. Build a Docker image: `sudo docker build -t tracing .`
+3. Run your Docker image: `docker run -p 8080:8080 tracing`
+
+### [OSv](http://osv.io/) unikernel support with [Capstan](http://osv.io/capstan/)
+
+1. Build and run your image: `capstan run -f "8080:8080"`
+
+Once the image it built, it's cached.  To delete the image and build a new one:
+
+1. `capstan rmi tracing; capstan build`
+
+
+## Links
+* [Other examples](https://github.com/pedestal/samples)
+

--- a/samples/tracing-interceptor/config/logback.xml
+++ b/samples/tracing-interceptor/config/logback.xml
@@ -1,0 +1,52 @@
+<!-- Logback configuration. See http://logback.qos.ch/manual/index.html -->
+<!-- Scanning is currently turned on; This will impact performance! -->
+<configuration scan="true" scanPeriod="10 seconds">
+  <!-- Silence Logback's own status messages about config parsing
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" /> -->
+
+  <!-- Simple file output -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>logs/tracing-interceptor-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <!-- or whenever the file size reaches 64 MB -->
+      <maxFileSize>64 MB</maxFileSize>
+    </rollingPolicy>
+
+    <!-- Safely log to the same file from multiple JVMs. Degrades performance! -->
+    <prudent>true</prudent>
+  </appender>
+
+
+  <!-- Console output -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <!-- Only log level INFO and above -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+
+  <!-- Enable FILE and STDOUT appenders for all log messages.
+       By default, only log at level INFO and above. -->
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- For loggers in the these namespaces, log at all levels. -->
+  <logger name="user" level="ALL" />
+  <!-- To log pedestal internals, enable this and change ThresholdFilter to DEBUG
+    <logger name="io.pedestal" level="ALL" />
+  -->
+
+</configuration>

--- a/samples/tracing-interceptor/project.clj
+++ b/samples/tracing-interceptor/project.clj
@@ -1,0 +1,33 @@
+(defproject tracing-interceptor "0.0.1-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
+
+                 ;; Remove this line and uncomment one of the next lines to
+                 ;; use Immutant or Tomcat instead of Jetty:
+                 [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
+
+                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.25"]
+                 [org.slf4j/jcl-over-slf4j "1.7.25"]
+                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+
+                 ;; Tracing backend
+                 [io.jaegertracing/jaeger-core "0.27.0"]
+
+                 ;; Tracing HTTP client to test propagation
+                 [io.opentracing.contrib/opentracing-apache-httpclient "0.1.0"]]
+  :min-lein-version "2.0.0"
+  :resource-paths ["config", "resources"]
+  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
+  ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
+  :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "tracing-interceptor.server/run-dev"]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"]]}
+             :uberjar {:aot [tracing-interceptor.server]}}
+  :main ^{:skip-aot true} tracing-interceptor.server)
+

--- a/samples/tracing-interceptor/src/tracing_interceptor/server.clj
+++ b/samples/tracing-interceptor/src/tracing_interceptor/server.clj
@@ -1,0 +1,88 @@
+(ns tracing-interceptor.server
+  (:gen-class) ; for -main method in uberjar
+  (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.log :as log]
+            [tracing-interceptor.service :as service])
+  (:import (io.jaegertracing Configuration
+                             Configuration$SamplerConfiguration
+                             Configuration$ReporterConfiguration)))
+
+;; This is an adapted service map, that can be started and stopped
+;; From the REPL you can call server/start and server/stop on this service
+(defonce runnable-service (server/create-server service/service))
+
+(defn run-dev
+  "The entry-point for 'lein run-dev'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.getTracer
+                   (Configuration. "TracingExample-DEV" ;; Our Service Name
+                                   (Configuration$SamplerConfiguration. "const" 1)
+                                   (Configuration$ReporterConfiguration. false       ;; log spans?
+                                                                         "localhost" ;; agent host
+                                                                         (int 5775)  ;; agent port
+                                                                         (int 1000)        ;; flush interval ms
+                                                                         (int 10000)))))   ;; max queue size
+  (println "\nCreating your [DEV] server...")
+  (-> service/service ;; start with production configuration
+      (merge {:env :dev
+              ;; do not block thread that starts web server
+              ::server/join? false
+              ;; Routes can be a function that resolve routes,
+              ;;  we can use this to set the routes to be reloadable
+              ::server/routes #(route/expand-routes (deref #'service/routes))
+              ;; all origins are allowed in dev mode
+              ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
+              ;; Content Security Policy (CSP) is mostly turned off in dev mode
+              ::server/secure-headers {:content-security-policy-settings {:object-src "'none'"}}})
+      ;; Wire up interceptor chains
+      server/default-interceptors
+      server/dev-interceptors
+      server/create-server
+      server/start))
+
+(defn -main
+  "The entry-point for 'lein run'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.getTracer
+                   (Configuration. "TracingExample" ;; Our Service Name
+                                   (Configuration$SamplerConfiguration. "const" 1)
+                                   (Configuration$ReporterConfiguration. false       ;; log spans?
+                                                                         "localhost" ;; agent host
+                                                                         (int 5775)  ;; agent port
+                                                                         (int 1000)        ;; flush interval ms
+                                                                         (int 10000)))))   ;; max queue size
+  (println "\nCreating your server...")
+  (server/start runnable-service))
+
+;; If you package the service up as a WAR,
+;; some form of the following function sections is required (for io.pedestal.servlet.ClojureVarServlet).
+
+;;(defonce servlet  (atom nil))
+;;
+;;(defn servlet-init
+;;  [_ config]
+;;  ;; Initialize your app here.
+;;  (reset! servlet  (server/servlet-init service/service nil)))
+;;
+;;(defn servlet-service
+;;  [_ request response]
+;;  (server/servlet-service @servlet request response))
+;;
+;;(defn servlet-destroy
+;;  [_]
+;;  (server/servlet-destroy @servlet)
+;;  (reset! servlet nil))
+

--- a/samples/tracing-interceptor/src/tracing_interceptor/service.clj
+++ b/samples/tracing-interceptor/src/tracing_interceptor/service.clj
@@ -1,0 +1,92 @@
+(ns tracing-interceptor.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.body-params :as body-params]
+            [io.pedestal.interceptor.trace :as trace]
+            [ring.util.response :as ring-resp]
+            [clojure.java.io :as io])
+  (:import (io.opentracing.contrib.apache.http.client TracingHttpClientBuilder)
+           (org.apache.http.client.methods HttpGet)))
+
+(defn about-page
+  [request]
+  (ring-resp/response (format "Clojure %s - served from %s"
+                              (clojure-version)
+                              (route/url-for ::about-page))))
+
+(defn home-page
+  [request]
+  (ring-resp/response (str "Hello Tracing World! -> " (pr-str (:headers request)))))
+
+(defn trace-page
+  [request]
+  (let [;; Let's embed a trace back to ourselves, but a different endpoint
+        http-client (.build (TracingHttpClientBuilder.)) ;; This client already makes it's span parent the current active span
+        response (.execute http-client (HttpGet. "http://localhost:8080"))
+        ]
+    (ring-resp/response (str "TRACED! Response from our internal request - " (slurp (io/reader (.getContent (.getEntity response))))))))
+
+;; Defines "/" and "/about" routes with their associated :get handlers.
+;; The interceptors defined after the verb map (e.g., {:get home-page}
+;; apply to / and its children (/about).
+(def common-interceptors [(trace/tracing-interceptor) (body-params/body-params) http/html-body])
+
+;; Tabular routes
+(def routes #{["/" :get (conj common-interceptors `home-page)]
+              ["/about" :get (conj common-interceptors `about-page)]
+              ["/trace" :get (conj common-interceptors `trace-page)]})
+
+;; Map-based routes
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
+;                   :get home-page
+;                   "/about" {:get about-page}}})
+
+;; Terse/Vector-based routes
+;(def routes
+;  `[[["/" {:get home-page}
+;      ^:interceptors [(body-params/body-params) http/html-body]
+;      ["/about" {:get about-page}]]]])
+
+
+;; Consumed by tracing-interceptor.server/create-server
+;; See http/default-interceptors for additional options you can configure
+(def service {:env :prod
+              ;; You can bring your own non-default interceptors. Make
+              ;; sure you include routing and set it up right for
+              ;; dev-mode. If you do, many other keys for configuring
+              ;; default interceptors will be ignored.
+              ;; ::http/interceptors []
+              ::http/routes routes
+
+              ;; Uncomment next line to enable CORS support, add
+              ;; string(s) specifying scheme, host and port for
+              ;; allowed source(s):
+              ;;
+              ;; "http://localhost:8080"
+              ;;
+              ;;::http/allowed-origins ["scheme://host:port"]
+
+              ;; Tune the Secure Headers
+              ;; and specifically the Content Security Policy appropriate to your service/application
+              ;; For more information, see: https://content-security-policy.com/
+              ;;   See also: https://github.com/pedestal/pedestal/issues/499
+              ;;::http/secure-headers {:content-security-policy-settings {:object-src "'none'"
+              ;;                                                          :script-src "'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"
+              ;;                                                          :frame-ancestors "'none'"}}
+
+              ;; Root for resource interceptor that is available by default.
+              ::http/resource-path "/public"
+
+              ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
+              ;;  This can also be your own chain provider/server-fn -- http://pedestal.io/reference/architecture-overview#_chain_provider
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080
+              ;; Options to pass to the container (Jetty)
+              ::http/container-options {:h2c? true
+                                        :h2? false
+                                        ;:keystore "test/hp/keystore.jks"
+                                        ;:key-password "password"
+                                        ;:ssl-port 8443
+                                        :ssl? false}})
+

--- a/samples/tracing-interceptor/test/tracing_interceptor/service_test.clj
+++ b/samples/tracing-interceptor/test/tracing_interceptor/service_test.clj
@@ -1,14 +1,14 @@
-(ns tracing.service-test
+(ns tracing-interceptor.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
             [io.pedestal.http :as bootstrap]
-            [tracing.service :as service]))
+            [tracing-interceptor.service :as service]))
 
 (def service
   (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
 
 (deftest home-page-test
-  (is (=
+  (is (.contains
        (:body (response-for service :get "/"))
        "Hello Tracing World!"))
   (is (=

--- a/samples/tracing/.gitignore
+++ b/samples/tracing/.gitignore
@@ -1,0 +1,38 @@
+# Project related
+
+# Java related
+pom.xml
+pom.xml.asc
+*jar
+*.class
+
+# Leiningen
+classes/
+lib/
+native/
+checkouts/
+target/
+.lein-*
+repl-port
+.nrepl-port
+.repl
+
+# Temp Files
+*.orig
+*~
+.*.swp
+.*.swo
+*.tmp
+*.bak
+
+# OS X
+.DS_Store
+
+# Logging
+*.log
+/logs/
+
+# Builds
+out/
+build/
+

--- a/samples/tracing/Capstanfile
+++ b/samples/tracing/Capstanfile
@@ -1,0 +1,29 @@
+
+#
+# Name of the base image. Capstan will download this automatically from
+# Cloudius S3 repository.
+#
+#base: cloudius/osv
+base: cloudius/osv-openjdk8
+
+#
+# The command line passed to OSv to start up the application.
+#
+#cmdline: /java.so -cp /tracing/app.jar clojure.main -m tracing
+cmdline: /java.so -jar /tracing/app.jar
+
+#
+# The command to use to build the application.
+# You can use any build tool/command (make/rake/lein/boot) - this runs locally on your machine
+#
+# For Leiningen, you can use:
+#build: lein uberjar
+# For Boot, you can use:
+#build: boot build
+
+#
+# List of files that are included in the generated image.
+#
+files:
+  /tracing/app.jar: ./target/tracing-0.0.1-SNAPSHOT-standalone.jar
+

--- a/samples/tracing/Dockerfile
+++ b/samples/tracing/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-alpine
+MAINTAINER Your Name <you@example.com>
+
+ADD target/tracing-0.0.1-SNAPSHOT-standalone.jar /tracing/app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "/tracing/app.jar"]

--- a/samples/tracing/README.md
+++ b/samples/tracing/README.md
@@ -1,0 +1,84 @@
+
+# Working with Distributed Tracing
+
+This sample walks through how to use the distributed tracing capabilities
+within `pedestal.log`.  Out of the box, the [OpenTracing API](http://opentracing.io/) is supported,
+but additional support is possible by extending Pedestal's tracing protocols.
+
+Distributed tracing works by having a centralized server collect portions of
+traces called "spans" or "segments" and proving a comprehensive view of
+requests and data moving through your service.  A single span can append tags,
+data, and log messages during execution, which all get captured during the trace.
+
+If your service forwards calls to additional services, you're able to encode
+the trace ID into those requests and continue tracking the trace across boundaries.
+
+**There are some conventions around naming schemes in tracing elements.**
+You can read about those [in the OpenTracing Docs](http://opentracing.io/documentation/pages/api/data-conventions.html).
+
+
+## Running a distributed trace server
+
+We're going to use Docker to run an instance of [Jaeger](https://github.com/jaegertracing/jaeger),
+a distributed trace server that supports OpenTracing.
+
+`$ docker run --name jaeger_example --rm -d -p 5775:5775/udp -p 16686:16686 jaegertracing/all-in-one:latest`
+
+
+## Getting Started
+
+1. Start the application: `lein run`
+2. Go to [localhost:8080](http://localhost:8080/) to see: `Hello Tracing World!`
+3. Read your app's source code at src/tracing/service.clj. Explore the routes, functions,
+   and tracing code.
+4. Go to [your local Jaeger UI](http://localhost:16686),
+   select "TracingExample" from Service dropdown and click "Find Traces"
+5. Click on one of the "TracingExample (1)" tags with a color tab.
+6. Explore the trace
+7. Stop your service and kill your Jaeger with `$ docker stop jaeger_example`
+8. Learn more! See the [Links section below](#links).
+
+
+## Configuration
+
+To configure logging see config/logback.xml. By default, the app logs to stdout and logs/.
+To learn more about configuring Logback, read its [documentation](http://logback.qos.ch/documentation.html).
+
+
+## How we set our service up to use Jaeger
+
+With our additional dependency, `[io.jaegertracing/jaeger-core "0.27.0"]`,
+we can configure our access to our Jaeger server.
+
+The default tracer in Pedestal can be set with a JVM property setting or
+an environment variable.
+If the default tracer hasn't been registered on startup, it is also possible
+to register a tracer with the `-register` protocol function at the main
+entry point of your service (for example, in `server.clj`'s `-main` or `run-dev`).
+
+
+## Developing your service
+
+1. Start a new REPL: `lein repl`
+2. Start your service in dev-mode: `(def dev-serv (run-dev))`
+3. Connect your editor to the running REPL session.
+   Re-evaluated code will be seen immediately in the service.
+
+### [Docker](https://www.docker.com/) container support
+
+1. Build an uberjar of your service: `lein uberjar`
+2. Build a Docker image: `sudo docker build -t tracing .`
+3. Run your Docker image: `docker run -p 8080:8080 tracing`
+
+### [OSv](http://osv.io/) unikernel support with [Capstan](http://osv.io/capstan/)
+
+1. Build and run your image: `capstan run -f "8080:8080"`
+
+Once the image it built, it's cached.  To delete the image and build a new one:
+
+1. `capstan rmi tracing; capstan build`
+
+
+## Links
+* [Other examples](https://github.com/pedestal/samples)
+

--- a/samples/tracing/config/logback.xml
+++ b/samples/tracing/config/logback.xml
@@ -1,0 +1,52 @@
+<!-- Logback configuration. See http://logback.qos.ch/manual/index.html -->
+<!-- Scanning is currently turned on; This will impact performance! -->
+<configuration scan="true" scanPeriod="10 seconds">
+  <!-- Silence Logback's own status messages about config parsing
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" /> -->
+
+  <!-- Simple file output -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>logs/tracing-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <!-- or whenever the file size reaches 64 MB -->
+      <maxFileSize>64 MB</maxFileSize>
+    </rollingPolicy>
+
+    <!-- Safely log to the same file from multiple JVMs. Degrades performance! -->
+    <prudent>true</prudent>
+  </appender>
+
+
+  <!-- Console output -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <!-- Only log level INFO and above -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+
+  <!-- Enable FILE and STDOUT appenders for all log messages.
+       By default, only log at level INFO and above. -->
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- For loggers in the these namespaces, log at all levels. -->
+  <logger name="user" level="ALL" />
+  <!-- To log pedestal internals, enable this and change ThresholdFilter to DEBUG
+    <logger name="io.pedestal" level="ALL" />
+  -->
+
+</configuration>

--- a/samples/tracing/project.clj
+++ b/samples/tracing/project.clj
@@ -1,0 +1,31 @@
+(defproject tracing "0.0.1-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
+
+                 ;; Remove this line and uncomment one of the next lines to
+                 ;; use Immutant or Tomcat instead of Jetty:
+                 [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
+
+                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.25"]
+                 [org.slf4j/jcl-over-slf4j "1.7.25"]
+                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+
+                 ;; Tracing backend
+                 [io.jaegertracing/jaeger-core "0.27.0"]]
+  :min-lein-version "2.0.0"
+  :resource-paths ["config", "resources"]
+  :pedantic? :abort
+  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
+  ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
+  :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "tracing.server/run-dev"]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"]]}
+             :uberjar {:aot [tracing.server]}}
+  :main ^{:skip-aot true} tracing.server)
+

--- a/samples/tracing/src/tracing/server.clj
+++ b/samples/tracing/src/tracing/server.clj
@@ -1,0 +1,88 @@
+(ns tracing.server
+  (:gen-class) ; for -main method in uberjar
+  (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.log :as log]
+            [tracing.service :as service])
+  (:import (io.jaegertracing Configuration
+                             Configuration$SamplerConfiguration
+                             Configuration$ReporterConfiguration)))
+
+;; This is an adapted service map, that can be started and stopped
+;; From the REPL you can call server/start and server/stop on this service
+(defonce runnable-service (server/create-server service/service))
+
+(defn run-dev
+  "The entry-point for 'lein run-dev'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.getTracer
+                   (Configuration. "TracingExample-DEV" ;; Our Service Name
+                                   (Configuration$SamplerConfiguration. "const" 1)
+                                   (Configuration$ReporterConfiguration. false       ;; log spans?
+                                                                         "localhost" ;; agent host
+                                                                         (int 5775)  ;; agent port
+                                                                         (int 1000)        ;; flush interval ms
+                                                                         (int 10000)))))   ;; max queue size
+  (println "\nCreating your [DEV] server...")
+  (-> service/service ;; start with production configuration
+      (merge {:env :dev
+              ;; do not block thread that starts web server
+              ::server/join? false
+              ;; Routes can be a function that resolve routes,
+              ;;  we can use this to set the routes to be reloadable
+              ::server/routes #(route/expand-routes (deref #'service/routes))
+              ;; all origins are allowed in dev mode
+              ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
+              ;; Content Security Policy (CSP) is mostly turned off in dev mode
+              ::server/secure-headers {:content-security-policy-settings {:object-src "'none'"}}})
+      ;; Wire up interceptor chains
+      server/default-interceptors
+      server/dev-interceptors
+      server/create-server
+      server/start))
+
+(defn -main
+  "The entry-point for 'lein run'"
+  [& args]
+  ;; There are multiple ways to set the default tracer referenced in `pedestal.log`.
+  ;; If the OpenTracing GlobalTracer is still unregistered (ie: it's a NoopTracer),
+  ;;  we can just use the -register protocol function to register our Tracer before
+  ;;  any other Tracer could be registered.  This approach will only fail if
+  ;;  the Tracer is set using the JVM property or environment variable.
+  (println "Registering local Trace connection")
+  (log/-register (.getTracer
+                   (Configuration. "TracingExample" ;; Our Service Name
+                                   (Configuration$SamplerConfiguration. "const" 1)
+                                   (Configuration$ReporterConfiguration. false       ;; log spans?
+                                                                         "localhost" ;; agent host
+                                                                         (int 5775)  ;; agent port
+                                                                         (int 1000)        ;; flush interval ms
+                                                                         (int 10000)))))   ;; max queue size
+  (println "\nCreating your server...")
+  (server/start runnable-service))
+
+;; If you package the service up as a WAR,
+;; some form of the following function sections is required (for io.pedestal.servlet.ClojureVarServlet).
+
+;;(defonce servlet  (atom nil))
+;;
+;;(defn servlet-init
+;;  [_ config]
+;;  ;; Initialize your app here.
+;;  (reset! servlet  (server/servlet-init service/service nil)))
+;;
+;;(defn servlet-service
+;;  [_ request response]
+;;  (server/servlet-service @servlet request response))
+;;
+;;(defn servlet-destroy
+;;  [_]
+;;  (server/servlet-destroy @servlet)
+;;  (reset! servlet nil))
+

--- a/samples/tracing/src/tracing/service.clj
+++ b/samples/tracing/src/tracing/service.clj
@@ -1,0 +1,89 @@
+(ns tracing.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.body-params :as body-params]
+            [ring.util.response :as ring-resp]
+            [io.pedestal.log :as log]))
+
+(defn about-page
+  [request]
+  (ring-resp/response (format "Clojure %s - served from %s"
+                              (clojure-version)
+                              (route/url-for ::about-page))))
+
+(defn home-page
+  [request]
+  (let [;; Create a new trace span for this operation
+        ;; The `operation name` can either be a keyword or a string.
+        ;;  It's common to use path segments like "/" for operation names that are endpoints
+        span (log/span "/")
+        _ (log/log-span span "Making a response")
+        resp (ring-resp/response "Hello Tracing World!")]
+    (log/tag-span span :http.status_code 200)
+    (log/log-span span "Returning a response")
+    (log/finish-span span)
+    resp))
+
+;; Defines "/" and "/about" routes with their associated :get handlers.
+;; The interceptors defined after the verb map (e.g., {:get home-page}
+;; apply to / and its children (/about).
+(def common-interceptors [(body-params/body-params) http/html-body])
+
+;; Tabular routes
+(def routes #{["/" :get (conj common-interceptors `home-page)]
+              ["/about" :get (conj common-interceptors `about-page)]})
+
+;; Map-based routes
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
+;                   :get home-page
+;                   "/about" {:get about-page}}})
+
+;; Terse/Vector-based routes
+;(def routes
+;  `[[["/" {:get home-page}
+;      ^:interceptors [(body-params/body-params) http/html-body]
+;      ["/about" {:get about-page}]]]])
+
+
+;; Consumed by tracing.server/create-server
+;; See http/default-interceptors for additional options you can configure
+(def service {:env :prod
+              ;; You can bring your own non-default interceptors. Make
+              ;; sure you include routing and set it up right for
+              ;; dev-mode. If you do, many other keys for configuring
+              ;; default interceptors will be ignored.
+              ;; ::http/interceptors []
+              ::http/routes routes
+
+              ;; Uncomment next line to enable CORS support, add
+              ;; string(s) specifying scheme, host and port for
+              ;; allowed source(s):
+              ;;
+              ;; "http://localhost:8080"
+              ;;
+              ;;::http/allowed-origins ["scheme://host:port"]
+
+              ;; Tune the Secure Headers
+              ;; and specifically the Content Security Policy appropriate to your service/application
+              ;; For more information, see: https://content-security-policy.com/
+              ;;   See also: https://github.com/pedestal/pedestal/issues/499
+              ;;::http/secure-headers {:content-security-policy-settings {:object-src "'none'"
+              ;;                                                          :script-src "'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"
+              ;;                                                          :frame-ancestors "'none'"}}
+
+              ;; Root for resource interceptor that is available by default.
+              ::http/resource-path "/public"
+
+              ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
+              ;;  This can also be your own chain provider/server-fn -- http://pedestal.io/reference/architecture-overview#_chain_provider
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080
+              ;; Options to pass to the container (Jetty)
+              ::http/container-options {:h2c? true
+                                        :h2? false
+                                        ;:keystore "test/hp/keystore.jks"
+                                        ;:key-password "password"
+                                        ;:ssl-port 8443
+                                        :ssl? false}})
+

--- a/samples/tracing/test/tracing/service_test.clj
+++ b/samples/tracing/test/tracing/service_test.clj
@@ -1,0 +1,39 @@
+(ns tracing.service-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.test :refer :all]
+            [io.pedestal.http :as bootstrap]
+            [tracing.service :as service]))
+
+(def service
+  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+
+(deftest home-page-test
+  (is (=
+       (:body (response-for service :get "/"))
+       "Hello World!"))
+  (is (=
+       (:headers (response-for service :get "/"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+
+(deftest about-page-test
+  (is (.contains
+       (:body (response-for service :get "/about"))
+       "Clojure 1.9"))
+  (is (=
+       (:headers (response-for service :get "/about"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+

--- a/service-template/project.clj
+++ b/service-template/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject pedestal-service/lein-template "0.5.3"
+(defproject pedestal-service/lein-template "0.5.4-SNAPSHOT"
   :description "A Pedestal Service template."
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/service-template/project.clj
+++ b/service-template/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject pedestal-service/lein-template "0.5.3-SNAPSHOT"
+(defproject pedestal-service/lein-template "0.5.3"
   :description "A Pedestal Service template."
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/service-template/src/leiningen/new/pedestal_service/project.clj
+++ b/service-template/src/leiningen/new/pedestal_service/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
 
                  ;; Remove this line and uncomment one of the next lines to
@@ -12,10 +12,10 @@
                  ;; [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
                  ;; [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
 
-                 [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.22"]
-                 [org.slf4j/jcl-over-slf4j "1.7.22"]
-                 [org.slf4j/log4j-over-slf4j "1.7.22"]]
+                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.25"]
+                 [org.slf4j/jcl-over-slf4j "1.7.25"]
+                 [org.slf4j/log4j-over-slf4j "1.7.25"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency

--- a/service-template/src/leiningen/new/pedestal_service/project.clj
+++ b/service-template/src/leiningen/new/pedestal_service/project.clj
@@ -4,13 +4,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.3"]
+                 [io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.3"]
-                 ;; [io.pedestal/pedestal.immutant "0.5.3"]
-                 ;; [io.pedestal/pedestal.tomcat "0.5.3"]
+                 [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
 
                  [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.22"]
@@ -21,7 +21,7 @@
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
   ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "{{namespace}}.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.3"]]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"]]}
              :uberjar {:aot [{{namespace}}.server]}}
   :main ^{:skip-aot true} {{namespace}}.server)
 

--- a/service-template/src/leiningen/new/pedestal_service/project.clj
+++ b/service-template/src/leiningen/new/pedestal_service/project.clj
@@ -4,13 +4,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [io.pedestal/pedestal.service "0.5.3-SNAPSHOT"]
+                 [io.pedestal/pedestal.service "0.5.3"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.3-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.immutant "0.5.3-SNAPSHOT"]
-                 ;; [io.pedestal/pedestal.tomcat "0.5.3-SNAPSHOT"]
+                 [io.pedestal/pedestal.jetty "0.5.3"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.3"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.3"]
 
                  [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.22"]
@@ -21,7 +21,7 @@
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
   ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "{{namespace}}.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.3-SNAPSHOT"]]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.3"]]}
              :uberjar {:aot [{{namespace}}.server]}}
   :main ^{:skip-aot true} {{namespace}}.server)
 

--- a/service-template/src/leiningen/new/pedestal_service/server.clj
+++ b/service-template/src/leiningen/new/pedestal_service/server.clj
@@ -22,7 +22,7 @@
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
               ;; Content Security Policy (CSP) is mostly turned off in dev mode
-              ::server/secure-headers {:content-security-policy-settings {:object-src "none"}}})
+              ::server/secure-headers {:content-security-policy-settings {:object-src "'none'"}}})
       ;; Wire up interceptor chains
       server/default-interceptors
       server/dev-interceptors

--- a/service-template/src/leiningen/new/pedestal_service/service_test.clj
+++ b/service-template/src/leiningen/new/pedestal_service/service_test.clj
@@ -25,7 +25,7 @@
 (deftest about-page-test
   (is (.contains
        (:body (response-for service :get "/about"))
-       "Clojure 1.8"))
+       "Clojure 1.9"))
   (is (=
        (:headers (response-for service :get "/about"))
        {"Content-Type" "text/html;charset=UTF-8"

--- a/service-tools/project.clj
+++ b/service-tools/project.clj
@@ -10,14 +10,14 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.service-tools "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.service-tools "0.5.3"
   :description "Pedestal tools for service development"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[io.pedestal/pedestal.service "0.5.3-SNAPSHOT"]
+  :dependencies [[io.pedestal/pedestal.service "0.5.3"]
                  [org.clojure/data.xml "0.1.0-beta1"]
 
                  ;; Auto-reload changes

--- a/service-tools/project.clj
+++ b/service-tools/project.clj
@@ -10,14 +10,14 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.service-tools "0.5.3"
+(defproject io.pedestal/pedestal.service-tools "0.5.4-SNAPSHOT"
   :description "Pedestal tools for service development"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[io.pedestal/pedestal.service "0.5.3"]
+  :dependencies [[io.pedestal/pedestal.service "0.5.4-SNAPSHOT"]
                  [org.clojure/data.xml "0.1.0-beta1"]
 
                  ;; Auto-reload changes

--- a/service/project.clj
+++ b/service/project.clj
@@ -23,7 +23,7 @@
                  [io.pedestal/pedestal.route "0.5.4-SNAPSHOT"]
 
                  ;; channels
-                 [org.clojure/core.async "0.4.474"]
+                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
 
                  ;; interceptors
                  [ring/ring-core "1.6.3" :exclusions [[org.clojure/clojure]
@@ -33,6 +33,7 @@
 
                  [cheshire "5.8.0"]
                  [org.clojure/tools.reader "1.2.2"]
+                 [org.clojure/tools.analyzer.jvm "0.7.2"]
                  [com.cognitect/transit-clj "0.8.309"]
                  [commons-codec "1.11"]
                  [crypto-random "1.2.0" :exclusions [[commons-codec]]]

--- a/service/project.clj
+++ b/service/project.clj
@@ -1,5 +1,5 @@
 ; Copyright 2013 Relevance, Inc.
-; Copyright 2014-2016 Cognitect, Inc.
+; Copyright 2014-2018 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
@@ -16,25 +16,25 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
 
                  [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.4-SNAPSHOT"]
                  [io.pedestal/pedestal.route "0.5.4-SNAPSHOT"]
 
                  ;; channels
-                 [org.clojure/core.async "0.3.442"]
+                 [org.clojure/core.async "0.4.474"]
 
                  ;; interceptors
-                 [ring/ring-core "1.5.1" :exclusions [[org.clojure/clojure]
+                 [ring/ring-core "1.6.3" :exclusions [[org.clojure/clojure]
                                                       [org.clojure/tools.reader]
                                                       [crypto-random]
                                                       [crypto-equality]]]
 
-                 ;[com.fasterxml.jackson.core/jackson-core "2.3.2"]
-                 [cheshire "5.7.0" :exclusions [[com.fasterxml.jackson.core/jackson-core]]]
-                 [com.cognitect/transit-clj "0.8.300"]
-                 [commons-codec "1.10"]
+                 [cheshire "5.8.0"]
+                 [org.clojure/tools.reader "1.2.2"]
+                 [com.cognitect/transit-clj "0.8.309"]
+                 [commons-codec "1.11"]
                  [crypto-random "1.2.0" :exclusions [[commons-codec]]]
                  [crypto-equality "1.0.0"]]
   :min-lein-version "2.0.0"
@@ -65,11 +65,11 @@
                                   [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
                                   [javax.servlet/javax.servlet-api "3.1.0"]
                                   ;; Logging:
-                                  [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
+                                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
                                   [org.clojure/tools.logging "0.3.1"]
-                                  [org.slf4j/jul-to-slf4j "1.7.22"]
-                                  [org.slf4j/jcl-over-slf4j "1.7.22"]
-                                  [org.slf4j/log4j-over-slf4j "1.7.22"]
+                                  [org.slf4j/jul-to-slf4j "1.7.25"]
+                                  [org.slf4j/jcl-over-slf4j "1.7.25"]
+                                  [org.slf4j/log4j-over-slf4j "1.7.25"]
 
                                   ;; only used for route-bench - remove when no longer needed
                                   [incanter/incanter-core "1.5.6"]

--- a/service/project.clj
+++ b/service/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.service "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.service "0.5.3"
   :description "Pedestal Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -18,9 +18,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
 
-                 [io.pedestal/pedestal.log "0.5.3-SNAPSHOT"]
-                 [io.pedestal/pedestal.interceptor "0.5.3-SNAPSHOT"]
-                 [io.pedestal/pedestal.route "0.5.3-SNAPSHOT"]
+                 [io.pedestal/pedestal.log "0.5.3"]
+                 [io.pedestal/pedestal.interceptor "0.5.3"]
+                 [io.pedestal/pedestal.route "0.5.3"]
 
                  ;; channels
                  [org.clojure/core.async "0.3.442"]
@@ -60,9 +60,9 @@
                                                                  [clj-tuple]]]
                                   [com.ning/async-http-client "1.8.13"]
                                   [org.eclipse.jetty/jetty-servlets "9.4.0.v20161208"]
-                                  [io.pedestal/pedestal.jetty "0.5.3-SNAPSHOT"]
-                                  [io.pedestal/pedestal.immutant "0.5.3-SNAPSHOT"]
-                                  [io.pedestal/pedestal.tomcat "0.5.3-SNAPSHOT"]
+                                  [io.pedestal/pedestal.jetty "0.5.3"]
+                                  [io.pedestal/pedestal.immutant "0.5.3"]
+                                  [io.pedestal/pedestal.tomcat "0.5.3"]
                                   [javax.servlet/javax.servlet-api "3.1.0"]
                                   ;; Logging:
                                   [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]

--- a/service/project.clj
+++ b/service/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.service "0.5.3"
+(defproject io.pedestal/pedestal.service "0.5.4-SNAPSHOT"
   :description "Pedestal Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"
@@ -18,9 +18,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
 
-                 [io.pedestal/pedestal.log "0.5.3"]
-                 [io.pedestal/pedestal.interceptor "0.5.3"]
-                 [io.pedestal/pedestal.route "0.5.3"]
+                 [io.pedestal/pedestal.log "0.5.4-SNAPSHOT"]
+                 [io.pedestal/pedestal.interceptor "0.5.4-SNAPSHOT"]
+                 [io.pedestal/pedestal.route "0.5.4-SNAPSHOT"]
 
                  ;; channels
                  [org.clojure/core.async "0.3.442"]
@@ -60,9 +60,9 @@
                                                                  [clj-tuple]]]
                                   [com.ning/async-http-client "1.8.13"]
                                   [org.eclipse.jetty/jetty-servlets "9.4.0.v20161208"]
-                                  [io.pedestal/pedestal.jetty "0.5.3"]
-                                  [io.pedestal/pedestal.immutant "0.5.3"]
-                                  [io.pedestal/pedestal.tomcat "0.5.3"]
+                                  [io.pedestal/pedestal.jetty "0.5.4-SNAPSHOT"]
+                                  [io.pedestal/pedestal.immutant "0.5.4-SNAPSHOT"]
+                                  [io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"]
                                   [javax.servlet/javax.servlet-api "3.1.0"]
                                   ;; Logging:
                                   [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]

--- a/service/project.clj
+++ b/service/project.clj
@@ -39,7 +39,7 @@
                  [crypto-equality "1.0.0"]]
   :min-lein-version "2.0.0"
   :java-source-paths ["java"]
-  :javac-options ["-target" "1.7" "-source" "1.7"]
+  :javac-options ["-target" "1.8" "-source" "1.8"]
   :jvm-opts ["-D\"clojure.compiler.direct-linking=true\""]
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort

--- a/service/project.clj
+++ b/service/project.clj
@@ -52,8 +52,7 @@
   :profiles {:default [:dev :provided :user :base]
              :provided {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
              :dev {:source-paths ["dev" "src" "bench"]
-                   :dependencies [[codox "0.9.5" :exclusions [[org.clojure/tools.reader]]]
-                                  [criterium "0.4.4"]
+                   :dependencies [[criterium "0.4.4"]
                                   [org.clojure/java.classpath "0.2.3"]
                                   [org.clojure/tools.namespace "0.2.11"]
                                   ;[clj-http "0.9.1"]

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -212,7 +212,8 @@
   * :secure-headers: A settings map for various secure headers.
      Keys are: [:hsts-settings :frame-options-settings :content-type-settings :xss-protection-settings :download-options-settings :cross-domain-policies-settings :content-security-policy-settings]
      If nil, this interceptor is not added.  Default is the default secure-headers settings
-  * :enable-path-param-decoding: Interceptor to decode path params. Default is true."
+  * :path-params-decoder: An Interceptor to decode path params. Default is URL Decoding via `io.pedestal.http.route/path-params-decoder.
+     If nil, this interceptor is not added."
   [service-map]
   (let [{interceptors ::interceptors
          request-logger ::request-logger
@@ -227,7 +228,7 @@
          enable-session ::enable-session
          enable-csrf ::enable-csrf
          secure-headers ::secure-headers
-         enable-path-param-decoding ::enable-path-param-decoding
+         path-params-decoder ::path-params-decoder
          :or {file-path nil
               request-logger log-request
               router :map-tree
@@ -238,7 +239,7 @@
               enable-session nil
               enable-csrf nil
               secure-headers {}
-              enable-path-param-decoding true}} service-map
+              path-params-decoder route/path-params-decoder}} service-map
         processed-routes (cond
                            (satisfies? route/ExpandableRoutes routes) (route/expand-routes routes)
                            (fn? routes) routes
@@ -258,7 +259,7 @@
                                           (csrf/anti-forgery enable-csrf)])
                true (conj (middlewares/content-type {:mime-types ext-mime-types}))
                true (conj route/query-params)
-               enable-path-param-decoding (conj route/path-params)
+               (some? path-params-decoder) (conj path-params-decoder)
                true (conj (route/method-param method-param-name))
                (some? secure-headers) (conj (sec-headers/secure-headers secure-headers))
                ;; TODO: If all platforms support async/NIO responses, we can bring this back

--- a/service/test/io/pedestal/http/default_interceptors_test.clj
+++ b/service/test/io/pedestal/http/default_interceptors_test.clj
@@ -88,7 +88,7 @@
   (table/table-routes
    {}
    [["/echo"                    :any  echo :route-name :echo]
-    ["/pecho/:user-id"          :get  [route/path-params echo]:route-name :pecho]
+    ["/pecho/:user-id"          :get  [route/path-params-decoder echo]:route-name :pecho]
     ["/fecho"                   :post [(body-params/body-params) params/keyword-params echo] :route-name :echo-form]]))
 
 (defn- test-query

--- a/tomcat/project.clj
+++ b/tomcat/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.tomcat "0.5.3"
+(defproject io.pedestal/pedestal.tomcat "0.5.4-SNAPSHOT"
   :description "Embedded Tomcat adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/tomcat/project.clj
+++ b/tomcat/project.clj
@@ -10,7 +10,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.tomcat "0.5.3-SNAPSHOT"
+(defproject io.pedestal/pedestal.tomcat "0.5.3"
   :description "Embedded Tomcat adapter for Pedestal HTTP Service"
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"


### PR DESCRIPTION
This PR collapses a few smaller feature branches together.

### Distributed Tracing

This PR introduces a new set of protocols in `io.pedestal.log` to support distributed tracing.  Out of the box, Pedestal extends these protocols to the OpenTracing API, which many tracing backends support.

A standalone tracing example was added to the Samples: `samples/tracing`.

There is also a new tracing interceptor, `io.pedestal.interceptor.trace`, which starts a new trace span/segment per request -- complete with all the relevant information added according to the OpenTracing semantics spec.  It intelligently inspects the Servlet and/or HTTP Headers to see if the inbound request is part of an on-going trace across systems.

A tracing-interceptor example was added to the Samples: `samples/tracing-interceptor`


### A new Pedestal module for AWS-specific functionality - `aws`

A new Pedestal module was added to hold the AWS-specific extensions of Pedestal's core functionality.  The Lambda utilities have been migrated to this new location (they were sitting on a stale branch) along with API Gateway support for request/response handling.
Additionally, the distributed tracing protocols have been extended to support X-Ray.

There are samples for Lambda and X-Ray.  The Lambda one is a bit stale, but the X-Ray one, `samples/tracing-interceptor-xray` aligns with the other tracing samples.