### PR TITLE
Bugfix: AWS X-Ray op name when keyword

### DIFF
--- a/aws/src/io/pedestal/log/aws/xray.clj
+++ b/aws/src/io/pedestal/log/aws/xray.clj
@@ -37,10 +37,10 @@
            ^Entity entity (if-let [current-entity (try
                                                     (.getTraceEntity t)
                                                     (catch Exception e nil))]
-                            (.beginSubsegment t ^String operation-name)
+                            (.beginSubsegment t ^String op-name)
                             (if parent
                               (.beginSegment t
-                                             ^String operation-name
+                                             ^String op-name
                                              ^TraceID (.getTraceId ^Entity parent)
                                              ^String (.getId ^Entity parent))
                               (.beginSegment t op-name)))]


### PR DESCRIPTION
This initial fix was put in place in a previous commit, but the newly extracted op-names weren't being used in subsegments.