### PR TITLE
Quick bug fixes and tweaks

### DIFF
--- a/aws/project.clj
+++ b/aws/project.clj
@@ -25,12 +25,14 @@
                  [com.amazonaws/aws-lambda-java-core "1.2.0"]
                  ;[com.amazonaws/aws-lambda-java-events "1.3.0"]
                  [com.amazonaws/aws-xray-recorder-sdk-core "1.3.1" :exclusions [com.amazonaws/aws-java-sdk-core
-                                                                                commons-logging]]
+                                                                                commons-logging
+                                                                                joda-time]]
                  ;; Deps cleanup
                  [commons-logging "1.2"] ;; A clash between AWS and HTTP Libs
                  [com.fasterxml.jackson.core/jackson-core "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
                  [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
                  [commons-codec "1.11"] ;; Bring AWS libs inline with Pedestal Service
+                 [joda-time "2.8.2"] ;; Bring AWS libs inline with Pedestal Service
                  ]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -511,7 +511,13 @@
                          (System/getenv "PEDESTAL_METRICS_RECORDER"))]
     (if (= "nil" ns-fn-str)
       nil
-      ((resolve (symbol ns-fn-str))))
+      (let [[ns-str fn-str] (clojure.string/split ns-fn-str #"/")]
+        (info :msg "Setting up a new metrics recorder; Requiring necessary namespace"
+              :ns ns-str)
+        (require (symbol ns-str))
+        (info :msg "Calling metrics recorder resolution function..."
+              :fn ns-fn-str)
+        ((resolve (symbol ns-fn-str)))))
     (metric-registry jmx-reporter)))
 
 ;; Public Metrics API

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -337,7 +337,7 @@
   (let [{type ::type
          :or {type :jetty}} service-map
         ;; Ensure that if a host arg was supplied, we default to a safe option, "localhost"
-        service-map-with-host (if (:host service-map)
+        service-map-with-host (if (::host service-map)
                                 service-map
                                 (assoc service-map ::host "localhost"))
         server-fn (if (fn? type)


### PR DESCRIPTION
As I've been testing Pedestal with various prod and prod-like setups, I've hit a few edge cases that I'm cleaning up:

 * It should be possible to set the bind host from the service map and from the server creation (fixed a typo I introduced)
 * Clean up the deps a bit more when using AWS-related utilities
 * When patching the metrics recorder from the environment (instead of programmatically), attempt to require the namespace before resolving symbol to avoid ns loading dependencies.
