### PR TITLE
Support Jetty context-path in container-options and url-for

### DIFF
--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -246,9 +246,11 @@
         path-parts (do (log/debug :in :link-str
                                   :path-parts path-parts
                                   :context-path-parts context-path-parts)
-                       (if (and context-path-parts (empty? (first path-parts)))
-                         (concat context-path-parts (rest path-parts))
-                         path-parts))
+                       ;;(concat context-path-parts path-parts)
+                       (cond
+                         (and context-path-parts (empty? (first path-parts))) (concat context-path-parts (rest path-parts))
+                         context-path-parts (concat context-path-parts path-parts)
+                         :else path-parts))
         path-chunk (str/join \/ (map #(get path-params % %) path-parts))
         path (if (and (= \/ (last path))
                       (not= \/ (last path-chunk)))

--- a/service/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/service/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -202,6 +202,7 @@
              ;                                                 :servlet-request servlet-request
              ;                                                 :servlet-response servlet-response})
              :async? servlet-async?)
+      (assoc-in [:request :context-path] (some-> servlet-request (.getContextPath)))
       (update-in [:enter-async] (fnil conj []) start-servlet-async)))
 
 (defn- leave-stylobate

--- a/service/test/io/pedestal/http/jetty_context_path_test.clj
+++ b/service/test/io/pedestal/http/jetty_context_path_test.clj
@@ -1,0 +1,79 @@
+;; This test file is a port of the official Ring jetty-adapter test
+;; that works with Pedestal interceptors. The original version is
+;; here:
+;;
+;; https://github.com/ring-clojure/ring/blob/master/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+
+(ns io.pedestal.http.jetty-context-path-test
+  (:use clojure.test)
+  (:require [clj-http.client :as http]
+            [io.pedestal.http :as service]
+            [io.pedestal.http.route :as route]))
+
+(defn hello-page [request]
+  {:status  200
+   :headers {"Content-Type" "text/plain"}
+   :body    "Hello World"})
+
+(def routes
+  (route/expand-routes
+   #{["/hello" :get `hello-page :route-name :hello]}))
+
+(def service-map
+  {:io.pedestal.http/type :jetty
+   :io.pedestal.http/routes routes})
+
+(defmacro with-server [app options & body]
+  `(let [server# (service/create-server (merge ~app {:io.pedestal.http/join? false} ~options))]
+     (try
+       (service/start server#)
+       ~@body
+       (finally (service/stop server#)))))
+
+(deftest test-run-jetty-default-context
+  (testing "default context-path"
+    (with-server service-map {:io.pedestal.http/port 4347}
+      (let [response (http/get "http://localhost:4347/hello")
+            url-for (route/url-for-routes routes)]
+        (is (= (:status response) 200))
+        (is (.startsWith ^String (get-in response [:headers "content-type"])
+                         "text/plain"))
+        (is (= (:body response) "Hello World"))
+        (is (= (url-for :hello) "/hello"))))))
+
+(deftest test-run-jetty-custom-context
+  (testing "custom context-path"
+    (with-server service-map {:io.pedestal.http/port 4347 :io.pedestal.http/container-options {:context-path "/context"}}
+      (let [response (http/get "http://localhost:4347/context/hello")
+            url-for (route/url-for-routes routes :context "/context")]
+        (is (= (:status response) 200))
+        (is (.startsWith ^String (get-in response [:headers "content-type"])
+                         "text/plain"))
+        (is (= (:body response) "Hello World"))
+        (is (= (url-for :hello) "/context/hello"))))))
+
+#_(def add-context-path-to-request
+  {:name ::add-context-path-to-request
+   :enter (fn [context] (assoc-in context [:request :context-path] (some-> (:servlet-request context) (.getContextPath))))})
+
+(defn hello-page2 [request]
+  {:status  200
+   :headers {"Content-Type" "text/plain"}
+   :body    (route/url-for :hello)})
+
+(def routes2
+  (route/expand-routes
+   #{["/hello" :get `hello-page2 :route-name :hello]}))
+
+(def service-map2
+  {:io.pedestal.http/type :jetty
+   :io.pedestal.http/routes routes2})
+
+(deftest test-run-jetty-custom-context-with-servletcontext
+  (testing "custom context-path via servlet context"
+    (with-server service-map2 {:io.pedestal.http/port 4347 :io.pedestal.http/container-options {:context-path "/context"}}
+      (let [response (http/get "http://localhost:4347/context/hello")]
+        (is (= (:status response) 200))
+        (is (.startsWith ^String (get-in response [:headers "content-type"])
+                         "text/plain"))
+        (is (= (:body response) "/context/hello"))))))


### PR DESCRIPTION
Proposed patch for issue #578.

In route.clj, I think maybe the (concat context-path-parts path-parts) could replace that cond.

# Description

I've been looking into migrating some Pedestal services from WildFly/Immutant to standalone Jetty. When run under WildFly, the deployment gets its context path from the container. When deploying the same route table to Jetty, it's now in the root context. This makes it inconvenient to target both containers during a transition. There may also be other use-cases for deploying the same app to Jetty under multiple/different context paths. Or even running multiple Jetty apps behind a single load balancer, and having them under different contexts/prefixes instead of all in the root context on different ports.

One option is to (programmatically) update the routes, i.e. have separate route tables for the different containers.
Another option would be to use the same route table, but enable Jetty to use a context similar to WildFly.

I've looked into the latter and have a patch for this with passing tests:
* add support for a :context-path in Jetty's :container-options
* change url-for-routes to support existing :context parameter (it had an if branch for this already, but I didn't get it to work and it doesn't appear to be tested)
* change servlet-interceptor to add :context-path to the request again, to support dynamic url-for via :request :context-path and the same if branch as above. (Ref also our previous discussion in issue #439.) Tried to do this with an 'external' interceptor, but then the default-interceptors and routing plumbing seem to adds the url-for function to the context _before_ the :context-path is available. Not sure how to prepend an interceptor to the chain. (default-interceptors both constructs the vector and updates service-map, perhaps these two operations could be separated later.)

I think the changes are only breaking for anyone using url-for and its :context parameter, but I believe this did not work as documented.

(Note that url-for probably doesn't work for WildFly/Immutant right now either, ref the previous discussion. This patch doesn't fix this, but possibly makes it easier to do. OTOH, if url-for isn't wanted/required for Jetty either, adding only :context-path seems trivial.)

Preparing a PR.

## Expected Behavior

Pedestal could support Jetty's context-path and make it more convenient to transition between WildFly and Jetty deployment, or support the same app under different contexts.

## Actual Behavior

Pedestal does not support Jetty's context-path.

## Steps to reproduce

# Environment

## Operating System (including version).

## Your current Leiningen or Boot version (`lein --version` or `boot --version`)

## Pedestal version

0.5.3
