### PR TITLE
Change index? into :index-files?

### DIFF
--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -149,11 +149,11 @@
   This interceptor will return async responses for large files (files larger than the HTTP Buffer)
   If your container doesn't recognize FileChannel response bodies, this interceptor will cause errors
   Supports a map of options:
-  :index? - If path is a directory, will attempt to find an 'index.*' file to serve. Defaults to true
+  :index-files? - If path is a directory, will attempt to find an 'index.*' file to serve. Defaults to true
   :follow-symlinks? - Serve files through symbolic links. Defaults to false
   :loader - A class loader specific for these resource fetches. Default to nil (use the main class loader)"
   ([root-path]
-   (fast-resource root-path {:index? true
+   (fast-resource root-path {:index-files? true
                              :allow-symlinks? false
                              :loader nil}))
   ([root-path opts]


### PR DESCRIPTION
As https://ring-clojure.github.io/ring/ring.util.response.html#var-file-response shows that the option for rendering index files is called `:index-files?` and not `:index?` this should be reflected in the documentation and default options for `io.pedestal.http.ring-middlewares/fast-resource`.

I think my changes can be seen as
> sufficiently trivial

and as a result I have written no tests. 