### PR TITLE
Fix `arity exception` when passing a map to `log/log-span`

### DIFF
--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -752,7 +752,7 @@
     ([t msg-map]
      (.log t ^Map (persistent!
                     (reduce-kv (fn [acc k v]
-                                 (conj! acc (format-name k) v))
+                                 (conj! acc [(format-name k) v)])
                                (transient {})
                                msg-map)))
      t)
@@ -761,7 +761,7 @@
            ^long micros
            ^Map (persistent!
                     (reduce-kv (fn [acc k v]
-                                 (conj! acc (format-name k) v))
+                                 (conj! acc [(format-name k) v)])
                                (transient {})
                                msg-map)))
      t))

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -829,7 +829,7 @@
                                          (nil? parent) (.ignoreActiveSpan builder)
                                          (instance? Span parent) (.asChildOf builder ^Span parent)
                                          :else (.asChildOf builder ^SpanContext parent))]
-       (reduce (fn [^Tracer$SpanBuilder builder k v]
+       (reduce-kv (fn [^Tracer$SpanBuilder builder k v]
                  (cond
                    (string? v) (.withTag builder ^String (format-name k) ^String v)
                    (number? v) (.withTag builder ^String (format-name k) ^Number v)

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -752,7 +752,7 @@
     ([t msg-map]
      (.log t ^Map (persistent!
                     (reduce-kv (fn [acc k v]
-                                 (conj! acc [(format-name k) v)])
+                                 (assoc! acc (format-name k) v))
                                (transient {})
                                msg-map)))
      t)
@@ -761,7 +761,7 @@
            ^long micros
            ^Map (persistent!
                     (reduce-kv (fn [acc k v]
-                                 (conj! acc [(format-name k) v)])
+                                 (assoc! acc (format-name k) v))
                                (transient {})
                                msg-map)))
      t))


### PR DESCRIPTION
When executing `(log-span span {:key "value"})` we would be receive with the following exception:

```
Caused by: clojure.lang.ArityException: Wrong number of args (3) passed to: core/conj!
        at clojure.lang.AFn.throwArity(AFn.java:429) [clojure-1.9.0.jar:na]
        at clojure.lang.AFn.invoke(AFn.java:40) [clojure-1.9.0.jar:na]
        at io.pedestal.log$eval54813$fn__54814$fn__54815.invoke(log.clj:755) ~[na:na]
        at clojure.core$fn__8072$fn__8074.invoke(core.clj:6760) ~[clojure-1.9.0.jar:na]
        at clojure.core.protocols$iter_reduce.invokeStatic(protocols.clj:49) ~[clojure-1.9.0.jar:na]
        at clojure.core.protocols$fn__7839.invokeStatic(protocols.clj:75) ~[clojure-1.9.0.jar:na]
        at clojure.core.protocols$fn__7839.invoke(protocols.clj:75) ~[clojure-1.9.0.jar:na]
        at clojure.core.protocols$fn__7781$G__7776__7794.invoke(protocols.clj:13) ~[clojure-1.9.0.jar:na]
        at clojure.core$reduce.invokeStatic(core.clj:6748) ~[clojure-1.9.0.jar:na]
        at clojure.core$fn__8072.invokeStatic(core.clj:6750) ~[clojure-1.9.0.jar:na]
        at clojure.core$fn__8072.invoke(core.clj:6750) ~[clojure-1.9.0.jar:na]
        at clojure.core.protocols$fn__7860$G__7855__7869.invoke(protocols.clj:175) ~[clojure-1.9.0.jar:na]
        at clojure.core$reduce_kv.invokeStatic(core.clj:6776) ~[clojure-1.9.0.jar:na]
        at clojure.core$reduce_kv.invoke(core.clj:6767) ~[clojure-1.9.0.jar:na]
        at io.pedestal.log$eval54813$fn__54814.invoke(log.clj:754) ~[na:na]
        at io.pedestal.log$eval54587$fn__54588$G__54578__54601.invoke(log.clj:601) ~[na:na]
        at io.pedestal.log$log_span.invokeStatic(log.clj:925) ~[na:na]
        at io.pedestal.log$log_span.invoke(log.clj:910) ~[na:na]
```

This happened as the `conj!` call does not take 3 arguments, but takes a single key value pair to build the new map.

This commit fixes the execution to allow passing maps to the function call.