### PR TITLE
Fix async termination

### DIFF
--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -152,7 +152,7 @@
    (process-all-with-binding context :enter))
   ([context interceptor-key]
   (log/debug :in 'process-all :handling interceptor-key :execution-id (::execution-id context))
-  (loop [context context]
+   (loop [context (check-terminators context)]
     (let [queue (::queue context)
           stack (::stack context)
           execution-id (::execution-id context)]

--- a/service/test/io/pedestal/interceptor_test.clj
+++ b/service/test/io/pedestal/interceptor_test.clj
@@ -281,7 +281,8 @@
                                (failed-channeler :c)
                                (tracer :d)]))
         result (<!! result-chan)]
-    (is (= [[:enter :a]
+    (is (= (::trace result)
+           [[:enter :a]
             [:enter :b]
             [:error :b :from nil]
             [:leave :a]]))))


### PR DESCRIPTION
Addresses the issue described in #581. The terminators are checked in the initial loop binding of `process-all-with-binding`.