### PR TITLE
Fix bad import

### DIFF
--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -31,7 +31,7 @@
                            SpanContext
                            Tracer
                            Tracer$SpanBuilder)
-           (io.opentracing.log.Fields)
+           (io.opentracing.log Fields)
            (io.opentracing.util GlobalTracer)
            (java.util Map)
            (java.util.concurrent TimeUnit)


### PR DESCRIPTION
As of core.specs.alpha 0.2.44, the spec for import has been tightened and will now fail if you use `(:import (package.class))`, which has always been wrong (and actually silently did nothing). Should actually be `(:import (package class))`.