### PR TITLE
Support `deps.edn` in pedestal.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ pom.xml.asc
 *jar
 *.class
 
+# Clojure related
+.cpcache
 # Leiningen
 classes/
 lib/

--- a/aws/deps.edn
+++ b/aws/deps.edn
@@ -1,0 +1,23 @@
+{:paths ["src"]
+ :deps  {;com.amazonaws.serverless/aws-serverless-java-container-core {:mvn/version"0.5.1" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]}
+         javax.servlet/javax.servlet-api                                 {:mvn/version "3.1.0"}
+         com.amazonaws/aws-java-sdk-core                                 {:mvn/version "1.11.331"
+                                                                          :exclusions  [commons-logging]} ;; Needed for x-ray
+         com.amazonaws/aws-lambda-java-core                              {:mvn/version "1.2.0"}
+
+         ; com.amazonaws/aws-lambda-java-events {:mvn/version "1.3.0"}
+         com.amazonaws/aws-xray-recorder-sdk-core                 {:mvn/version "1.3.1"
+                                                                   :exclusions  [com.amazonaws/aws-java-sdk-core
+                                                                                 commons-logging
+                                                                                 joda-time]}
+         ;; Deps cleanup
+         commons-logging                                          {:mvn/version "1.2"}   ;; A clash between AWS and HTTP Libs
+         com.fasterxml.jackson.core/jackson-core                  {:mvn/version "2.9.0"} ;; Bring AWS libs inline with Pedestal Service
+         com.fasterxml.jackson.dataformat/jackson-dataformat-cbor {:mvn/version "2.9.0"} ;; Bring AWS libs inline with Pedestal Service
+         commons-codec                                            {:mvn/version "1.11"}  ;; Bring AWS libs inline with Pedestal Service
+         joda-time                                                {:mvn/version "2.8.2"} ;; Bring AWS libs inline with Pedestal Service
+         }
+ :aliases {:release {:extra-deps {io.pedestal/pedestal.interceptor {:mvn/version "0.5.5-SNAPSHOT"}
+                                  io.pedestal/pedestal.log         {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :dev     {:extra-deps {io.pedestal/pedestal.interceptor {:local/root "../interceptor"}
+                                  io.pedestal/pedestal.log         {:local/root "../log"}}}}}

--- a/immutant/deps.edn
+++ b/immutant/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps {potemkin {:mvn/version "0.4.5"}
+        org.jboss.logging/jboss-logging {:mvn/version "3.3.2.Final"}
+        org.immutant/web {:mvn/version "2.1.10" :exclusions [org.jboss.logging/jboss-logging]}
+        javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}}

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -8,23 +8,32 @@
 ; the terms of this license.
 ;
 ; You must not remove this notice, or any other, from this software.
+(let [dir           (clojure.string/join "/"
+                                         (butlast (clojure.string/split *file* #"/")))
+      all-deps      (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter (fn [deps]
+                      (reduce (fn [acc [k v]]
+                                (if-let [exclude (:exclusions v)]
+                                  (conj acc [k (:mvn/version v) :exclusions exclude])
+                                  (conj acc [k (:mvn/version v)])))
+                              []
+                              deps))
+      deps-vec-vec  (->> all-deps
+                         :deps
+                         dep-formatter
+                         (into ['[org.clojure/clojure "1.9.0"]]))]
+  (defproject io.pedestal/pedestal.immutant "0.5.5-SNAPSHOT"
+    :description "Embedded Immutant adapter for Pedestal HTTP Service"
+    :url "https://github.com/pedestal/pedestal"
+    :scm "https://github.com/pedestal/pedestal"
+    :license {:name "Eclipse Public License"
+              :url  "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies ~deps-vec-vec
+    :min-lein-version "2.0.0"
+    :global-vars {*warn-on-reflection* true}
+    :pedantic? :abort
 
-(defproject io.pedestal/pedestal.immutant "0.5.5-SNAPSHOT"
-  :description "Embedded Immutant adapter for Pedestal HTTP Service"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [potemkin "0.4.5"]
-                 [org.jboss.logging/jboss-logging "3.3.2.Final"]
-                 [org.immutant/web "2.1.10" :exclusions  [org.jboss.logging/jboss-logging]]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
-  :min-lein-version "2.0.0"
-  :global-vars {*warn-on-reflection* true}
-  :pedantic? :abort
+    :aliases {"docs" ["with-profile" "docs" "codox"]}
 
-  :aliases {"docs" ["with-profile" "docs" "codox"]}
-
-  :profiles {:docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]}})
+    :profiles {:docs {:pedantic? :ranges
+                      :plugins   [[lein-codox "0.9.5"]]}}))

--- a/interceptor/deps.edn
+++ b/interceptor/deps.edn
@@ -1,0 +1,11 @@
+{:paths ["src"]
+ :deps {org.clojure/core.async {:mvn/version "0.4.474"
+                                :exclusions [org.clojure/tools.analyzer.jvm]}
+
+        ;; Error interceptor tooling
+        org.clojure/core.match {:mvn/version "0.3.0-alpha5"
+                                :exclusions [[org.clojure/clojurescript]
+                                             [org.clojure/tools.analyzer.jvm]]}
+        org.clojure/tools.analyzer.jvm {:mvn/version "0.7.2"}}
+ :aliases {:release {:extra-deps {io.pedestal/pedestal.log {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :dev     {:extra-deps {io.pedestal/pedestal.log {:local/root "../log"}}}}}

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -9,25 +9,34 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.interceptor "0.5.5-SNAPSHOT"
-  :description "Pedestal interceptor chain and execution utilities"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
-                 [io.pedestal/pedestal.log "0.5.5-SNAPSHOT"]
+(let [dir           (clojure.string/join "/"
+                                         (butlast (clojure.string/split *file* #"/")))
+      all-deps      (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter (fn [deps]
+                      (reduce (fn [acc [k v]]
+                                (if-let [exclude (:exclusions v)]
+                                  (conj acc [k (:mvn/version v) :exclusions exclude])
+                                  (conj acc [k (:mvn/version v)])))
+                              []
+                              deps))
+      release-deps    (get-in all-deps [:aliases :release :extra-deps])
+      deps-vec-vec (->> all-deps
+                        :deps
+                        (merge release-deps)
+                        dep-formatter
+                        (into ['[org.clojure/clojure "1.9.0"]]))]
+  (defproject io.pedestal/pedestal.interceptor "0.5.5-SNAPSHOT"
+    :description "Pedestal interceptor chain and execution utilities"
+    :url "https://github.com/pedestal/pedestal"
+    :scm "https://github.com/pedestal/pedestal"
+    :license {:name "Eclipse Public License"
+              :url  "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies ~deps-vec-vec
+    :min-lein-version "2.0.0"
+    :pedantic? :abort
+    :global-vars {*warn-on-reflection* true}
 
-                 ;; Error interceptor tooling
-                 [org.clojure/core.match "0.3.0-alpha5" :exclusions [[org.clojure/clojurescript]
-                                                                     [org.clojure/tools.analyzer.jvm]]]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]]
-  :min-lein-version "2.0.0"
-  :pedantic? :abort
-  :global-vars {*warn-on-reflection* true}
+    :aliases {"docs" ["with-profile" "docs" "codox"]}
 
-  :aliases {"docs" ["with-profile" "docs" "codox"]}
-
-  :profiles {:docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]}})
+    :profiles {:docs {:pedantic? :ranges
+                      :plugins   [[lein-codox "0.9.5"]]}}))

--- a/jetty/deps.edn
+++ b/jetty/deps.edn
@@ -1,0 +1,10 @@
+{:paths ["src"]
+ :deps {org.eclipse.jetty/jetty-server {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty.alpn/alpn-api {:mvn/version "1.1.3.v20160715"}
+        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.10.v20180503"}
+        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.10.v20180503"}
+        javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}}

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -9,28 +9,32 @@
 ; the terms of this license.
 ;
 ; You must not remove this notice, or any other, from this software.
+(let [dir           (clojure.string/join "/"
+                                         (butlast (clojure.string/split *file* #"/")))
+      all-deps      (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter (fn [deps]
+                      (reduce (fn [acc [k v]]
+                                (if-let [exclude (:exclusions v)]
+                                  (conj acc [k (:mvn/version v) :exclusions exclude])
+                                  (conj acc [k (:mvn/version v)])))
+                              []
+                              deps))
+      deps-vec-vec  (->> all-deps
+                         :deps
+                         dep-formatter
+                         (into ['[org.clojure/clojure "1.9.0"]]))]
+  (defproject io.pedestal/pedestal.jetty "0.5.5-SNAPSHOT"
+    :description "Embedded Jetty adapter for Pedestal HTTP Service"
+    :url "https://github.com/pedestal/pedestal"
+    :scm "https://github.com/pedestal/pedestal"
+    :license {:name "Eclipse Public License"
+              :url  "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies ~deps-vec-vec
+    :min-lein-version "2.0.0"
+    :global-vars {*warn-on-reflection* true}
+    :pedantic? :abort
 
-(defproject io.pedestal/pedestal.jetty "0.5.5-SNAPSHOT"
-  :description "Embedded Jetty adapter for Pedestal HTTP Service"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.eclipse.jetty/jetty-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.10.v20180503"]
-                 [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty.http2/http2-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-api "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.4.10.v20180503"]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
-  :min-lein-version "2.0.0"
-  :global-vars {*warn-on-reflection* true}
-  :pedantic? :abort
+    :aliases {"docs" ["with-profile" "docs" "codox"]}
 
-  :aliases {"docs" ["with-profile" "docs" "codox"]}
-
-  :profiles {:docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]}})
+    :profiles {:docs {:pedantic? :ranges
+                      :plugins   [[lein-codox "0.9.5"]]}}))

--- a/log/deps.edn
+++ b/log/deps.edn
@@ -1,0 +1,11 @@
+{:paths ["src"]
+ :deps  {;; logging
+         org.slf4j/slf4j-api {:mvn/version "1.7.25"}
+
+         ;; metrics
+         io.dropwizard.metrics/metrics-core {:mvn/version "4.0.2"}
+         io.dropwizard.metrics/metrics-jmx  {:mvn/version "4.0.2"}
+
+         ;; tracing
+         io.opentracing/opentracing-api  {:mvn/version "0.31.0"}
+         io.opentracing/opentracing-util {:mvn/version "0.31.0"}}}

--- a/log/project.clj
+++ b/log/project.clj
@@ -22,7 +22,6 @@
                                    :deps
                                    dep-formatter
                                    (into ['[org.clojure/clojure "1.9.0"]]))]
-
      (defproject io.pedestal/pedestal.log "0.5.5-SNAPSHOT"
        :description "Pedestal logging and metrics facilities"
        :url "https://github.com/pedestal/pedestal"

--- a/log/project.clj
+++ b/log/project.clj
@@ -8,27 +8,33 @@
 ; the terms of this license.
 ;
 ; You must not remove this notice, or any other, from this software.
+(let [dir (clojure.string/join "/"
+                               (butlast (clojure.string/split *file* #"/")))
+      all-deps         (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter    (fn [deps]
+                         (reduce (fn [acc [k v]]
+                                   (if-let [exclude (:exclusions v)]
+                                     (conj acc [k (:mvn/version v) :exclusions exclude])
+                                     (conj acc [k (:mvn/version v)])))
+                                 []
+                                 deps))
+      deps-vec-vec             (->> all-deps
+                                   :deps
+                                   dep-formatter
+                                   (into ['[org.clojure/clojure "1.9.0"]]))]
 
-(defproject io.pedestal/pedestal.log "0.5.5-SNAPSHOT"
-  :description "Pedestal logging and metrics facilities"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 ;; logging
-                 [org.slf4j/slf4j-api "1.7.25"]
-                 ;; metrics
-                 [io.dropwizard.metrics/metrics-core "4.0.2"]
-                 [io.dropwizard.metrics/metrics-jmx "4.0.2"]
-                 ;; tracing
-                 [io.opentracing/opentracing-api "0.31.0"]
-                 [io.opentracing/opentracing-util "0.31.0"]]
-  :min-lein-version "2.0.0"
-  :global-vars {*warn-on-reflection* true}
-  :pedantic? :abort
+     (defproject io.pedestal/pedestal.log "0.5.5-SNAPSHOT"
+       :description "Pedestal logging and metrics facilities"
+       :url "https://github.com/pedestal/pedestal"
+       :scm "https://github.com/pedestal/pedestal"
+       :license {:name "Eclipse Public License"
+                 :url  "http://www.eclipse.org/legal/epl-v10.html"}
+       :dependencies ~deps-vec-vec
+       :min-lein-version "2.0.0"
+       :global-vars {*warn-on-reflection* true}
+       :pedantic? :abort
 
-  :aliases {"docs" ["with-profile" "docs" "codox"]}
+       :aliases {"docs" ["with-profile" "docs" "codox"]}
 
-  :profiles {:docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]}})
+       :profiles {:docs {:pedantic? :ranges
+                         :plugins   [[lein-codox "0.9.5"]]}}))

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.clojure/core.async {:mvn/version "0.4.474"
+                                :exclusions [org.clojure/tools.analyzer.jvm]}
+        org.clojure/core.incubator {:mvn/version "0.1.4"}}
+ :aliases {:release {:extra-deps {io.pedestal/pedestal.log {:mvn/version "0.5.5-SNAPSHOT"}
+                                  io.pedestal/pedestal.interceptor {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :dev     {:extra-deps {io.pedestal/pedestal.log {:local/root "../log"}
+                                  io.pedestal/pedestal.interceptor {:local/root "../interceptor"}}}}}

--- a/script/release.rb
+++ b/script/release.rb
@@ -36,7 +36,7 @@ check_credentials!
 # Pre-requisites met. Precalculate the pending release and the new development stream.
 
 project_cljs = Dir['**/project.clj']
-
+deps_edns = Dir['**/deps.edn']
 
 release_version = version_number!(project_cljs, Common::WITHOUT_SNAPSHOT_DEFPROJECT_RE)
 release_version =~ /(\d+\.\d+\.)(\d+)/
@@ -64,7 +64,7 @@ clean!
 
 # Bump SNAPSHOT versions up to released versions, commit and tag.
 
-bump_version(project_cljs, Common::WITHOUT_SNAPSHOT_DEFPROJECT_RE, "#{release_version}-SNAPSHOT", release_version)
+bump_version(project_cljs, Common::WITHOUT_SNAPSHOT_DEFPROJECT_RE, deps_edns, "#{release_version}-SNAPSHOT", release_version)
 
 unless system('git add -u') && system("git commit -m \"Prepare #{release_version} release\"") && system("git tag #{release_version}")
   puts "Failed to create release commit. Aborting."
@@ -75,7 +75,7 @@ end
 deploy!
 
 # Update to pre-release SNAPSHOT version, commit, and push.
-bump_version(project_cljs, release_defproject_re, release_version, pre_release_version)
+bump_version(project_cljs, release_defproject_re, deps_edns, release_version, pre_release_version)
 
 puts "Release #{release_version} pushed to Clojars, tagged and committed.\nRelease #{pre_release_version} set as the latest development stream.\n\nDO NOT FORGET TO 'git push' WHEN YOU ARE READY!"
 
@@ -83,5 +83,3 @@ unless system('git add -u') && system("git commit -m \"Begin #{pre_release_versi
   puts "Failed to create post-release version-bump commit. Aborting."
   exit -1
 end
-
-

--- a/script/util/common.rb
+++ b/script/util/common.rb
@@ -82,16 +82,30 @@ module Common
     end
   end
 
-  def bump_version(project_cljs, defproject_re, prev_version, new_version)
+  def bump_project_cljs(project_cljs, defproject_re, prev_version, new_version)
     project_cljs.each do |project_clj|
       contents = File.read project_clj
       File.open(project_clj,"w") do |file|
         redefined = contents.gsub(defproject_re, '(defproject \1 "'+ new_version + '"')
-        redepended = redefined.gsub(/\[io.pedestal\/(.+) "#{prev_version}"/,
-                                    '[io.pedestal/\1 "'+new_version+'"')
+        file.puts redefined
+      end
+    end
+  end
+
+  def bump_deps_edns(deps_edns, prev_version, new_version)
+    deps_edns.each do |deps_edn|
+      contents = File.read deps_edn
+      File.open(deps_edn,"w") do |file|
+        redepended = contents.gsub(/io.pedestal\/(.+) "#{prev_version}"/,
+                                   'io.pedestal/\1 "'+new_version+'"')
         file.puts redepended
       end
     end
+  end
+
+  def bump_version(project_cljs, defproject_re, deps_edns, prev_version, new_version)
+    bump_project_cljs(project_cljs, defproject_re, prev_version, new_version)
+    bump_deps_edns(deps_edns, prev_version, new_version)
   end
 
 end

--- a/service-tools/deps.edn
+++ b/service-tools/deps.edn
@@ -1,0 +1,17 @@
+{:paths ["src"]
+ :deps  {org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}
+
+         ;; Auto-reload changes
+         ns-tracker {:mvn/version "0.3.1"}
+
+         ;; Logging
+         ch.qos.logback/logback-classic {:mvn/version "1.2.3" :exclusions [org.slf4j/slf4j-api]}
+         org.slf4j/jul-to-slf4j         {:mvn/version "1.7.25"}
+         org.slf4j/jcl-over-slf4j       {:mvn/version "1.7.25"}
+         org.slf4j/log4j-over-slf4j     {:mvn/version "1.7.25"}}
+ :aliases {:release  {:extra-deps {io.pedestal/pedestal.service {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :lein-dev {:extra-deps {javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}}
+           :dev      {:extra-deps {io.pedestal/pedestal.service     {:local/root "../service"}
+                                   io.pedestal/pedestal.log         {:local/root "../log"}
+                                   io.pedestal/pedestal.interceptor {:local/root "../interceptor"}
+                                   io.pedestal/pedestal.route       {:local/root "../route"}}}}}

--- a/service-tools/src/io/pedestal/service_tools/war.clj
+++ b/service-tools/src/io/pedestal/service_tools/war.clj
@@ -39,10 +39,10 @@
                   servlet-name
                   servlet-class
                   url-pattern]
-           :or [servlet-description "Pedestal HTTP Servlet"
-                servlet-name "PedestalServlet"
-                servlet-class "io.pedestal.servlet.ClojureVarServlet"
-                url-pattern "/*"]} opts]
+           :or {servlet-description "Pedestal HTTP Servlet"
+                servlet-name        "PedestalServlet"
+                servlet-class       "io.pedestal.servlet.ClojureVarServlet"
+                url-pattern         "/*"}} opts]
       (xml/indent-str
         (xml/sexp-as-element
           [:web-app {:xmlns              "http://java.sun.com/xml/ns/javaee"
@@ -168,4 +168,3 @@
      (write-war opts war-path)
      (println "Created" war-path)
      war-path)))
-

--- a/service/deps.edn
+++ b/service/deps.edn
@@ -1,0 +1,48 @@
+{:paths ["src"]
+ :deps { ;; channels
+        org.clojure/core.async {:mvn/version "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]}
+
+        ;; interceptors
+        ring/ring-core {:mvn/version "1.6.3" :exclusions [[org.clojure/clojure]
+                                                          [org.clojure/tools.reader]
+                                                          [crypto-random]
+                                                          [crypto-equality]]}
+
+        cheshire {:mvn/version "5.8.0"}
+        org.clojure/tools.reader {:mvn/version "1.2.2"}
+        org.clojure/tools.analyzer.jvm {:mvn/version "0.7.2"}
+        com.cognitect/transit-clj {:mvn/version "0.8.309"}
+        commons-codec {:mvn/version "1.11"}
+        crypto-random {:mvn/version "1.2.0" :exclusions [[commons-codec]]}
+        crypto-equality {:mvn/version "1.0.0"}}
+ :aliases {:release  {:extra-deps {io.pedestal/pedestal.log         {:mvn/version "0.5.5-SNAPSHOT"}
+                                   io.pedestal/pedestal.interceptor {:mvn/version "0.5.5-SNAPSHOT"}
+                                   io.pedestal/pedestal.route       {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :dev-lein {:extra-deps {io.pedestal/pedestal.jetty    {:mvn/version "0.5.5-SNAPSHOT"}
+                                   io.pedestal/pedestal.immutant {:mvn/version "0.5.5-SNAPSHOT"}
+                                   io.pedestal/pedestal.tomcat   {:mvn/version "0.5.5-SNAPSHOT"}}}
+           :provided {:extra-deps {javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}}
+           :dev      {:extra-paths ["dev" "bench"]
+                      :extra-deps  {criterium                        {:mvn/version "0.4.4"}
+                                    org.clojure/java.classpath       {:mvn/version "0.2.3"}
+                                    org.clojure/tools.namespace      {:mvn/version "0.2.11"}
+                                    clj-http                         {:mvn/version "2.0.0" :exclusions [[potemkin]
+                                                                                                        [clj-tuple]]}
+                                    com.ning/async-http-client       {:mvn/version "1.8.13"}
+                                    org.eclipse.jetty/jetty-servlets {:mvn/version "9.4.10.v20180503"}
+                                    io.pedestal/pedestal.jetty       {:local/root "../jetty"}
+                                    io.pedestal/pedestal.immutant    {:local/root "../immutant"}
+                                    io.pedestal/pedestal.tomcat      {:local/root "../tomcat"}
+
+                                    ;; Logging:
+                                    ch.qos.logback/logback-classic {:mvn/version "1.2.3" :exclusions [org.slf4j/slf4j-api]}
+                                    org.clojure/tools.logging      {:mvn/version "0.3.1"}
+                                    org.slf4j/jul-to-slf4j         {:mvn/version "1.7.25"}
+                                    org.slf4j/jcl-over-slf4j       {:mvn/version "1.7.25"}
+                                    org.slf4j/log4j-over-slf4j     {:mvn/version "1.7.25"}
+
+                                    ;; only used for route-bench - remove when no longer needed
+                                    incanter/incanter-core   {:mvn/version "1.5.6"}
+                                    incanter/incanter-charts {:mvn/version "1.5.6"}}}
+           :test {:extra-paths ["test"]}}
+ :mvn/repos {"sonatype-oss" {:url "https://oss.sonatype.org/content/groups/public/"}}}

--- a/service/project.clj
+++ b/service/project.clj
@@ -10,84 +10,70 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject io.pedestal/pedestal.service "0.5.5-SNAPSHOT"
-  :description "Pedestal Service"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-
-                 [io.pedestal/pedestal.log "0.5.5-SNAPSHOT"]
-                 [io.pedestal/pedestal.interceptor "0.5.5-SNAPSHOT"]
-                 [io.pedestal/pedestal.route "0.5.5-SNAPSHOT"]
-
-                 ;; channels
-                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
-
-                 ;; interceptors
-                 [ring/ring-core "1.6.3" :exclusions [[org.clojure/clojure]
-                                                      [org.clojure/tools.reader]
-                                                      [crypto-random]
-                                                      [crypto-equality]]]
-
-                 [cheshire "5.8.0"]
-                 [org.clojure/tools.reader "1.2.2"]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]
-                 [com.cognitect/transit-clj "0.8.309"]
-                 [commons-codec "1.11"]
-                 [crypto-random "1.2.0" :exclusions [[commons-codec]]]
-                 [crypto-equality "1.0.0"]]
-  :min-lein-version "2.0.0"
-  :java-source-paths ["java"]
-  :javac-options ["-target" "1.8" "-source" "1.8"]
-  :jvm-opts ["-D\"clojure.compiler.direct-linking=true\""]
-  :global-vars {*warn-on-reflection* true}
-  :pedantic? :abort
-  :aliases {"bench-log" ["trampoline" "run" "-m" "io.pedestal.log-bench"]
-            "bench-service" ["trampoline" "run" "-m" "io.pedestal.niotooling.server"]
-            "bench-route" ["trampoline" "run" "-m" "io.pedestal.route.route-bench"]
-            "dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]
-            "docs" ["with-profile" "docs" "codox"]}
-  :profiles {:default [:dev :provided :user :base]
-             :provided {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
-             :dev {:source-paths ["dev" "src" "bench"]
-                   :dependencies [[criterium "0.4.4"]
-                                  [org.clojure/java.classpath "0.2.3"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  ;[clj-http "0.9.1"]
-                                  [clj-http "2.0.0" :exclusions [[potemkin]
-                                                                 [clj-tuple]]]
-                                  [com.ning/async-http-client "1.8.13"]
-                                  [org.eclipse.jetty/jetty-servlets "9.4.10.v20180503"]
-                                  [io.pedestal/pedestal.jetty "0.5.5-SNAPSHOT"]
-                                  [io.pedestal/pedestal.immutant "0.5.5-SNAPSHOT"]
-                                  [io.pedestal/pedestal.tomcat "0.5.5-SNAPSHOT"]
-                                  [javax.servlet/javax.servlet-api "3.1.0"]
-                                  ;; Logging:
-                                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                                  [org.clojure/tools.logging "0.3.1"]
-                                  [org.slf4j/jul-to-slf4j "1.7.25"]
-                                  [org.slf4j/jcl-over-slf4j "1.7.25"]
-                                  [org.slf4j/log4j-over-slf4j "1.7.25"]
-
-                                  ;; only used for route-bench - remove when no longer needed
-                                  [incanter/incanter-core "1.5.6"]
-                                  [incanter/incanter-charts "1.5.6"]]
-                   :repositories [["sonatype-oss"
-                                   "https://oss.sonatype.org/content/groups/public/"]]}
-             :docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]
-                    :dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}}
-  ;:jvm-opts ^:replace ["-D\"clojure.compiler.direct-linking=true\""
-  ;                     "-d64" "-server"
-  ;                     "-Xms1g"                             ;"-Xmx1g"
-  ;                     "-XX:+UnlockCommercialFeatures"      ;"-XX:+FlightRecorder"
-  ;                     ;"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8030"
-  ;                     "-XX:+UseG1GC"
-  ;                     ;"-XX:+UseConcMarkSweepGC" "-XX:+UseParNewGC" "-XX:+CMSParallelRemarkEnabled"
-  ;                     ;"-XX:+ExplicitGCInvokesConcurrent"
-  ;                     "-XX:+AggressiveOpts"
-  ;                     ;-XX:+UseLargePages
-  ;                     "-XX:+UseCompressedOops"]
-  )
+(let [dir                   (clojure.string/join "/"
+                                                 (butlast (clojure.string/split *file* #"/")))
+      all-deps              (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter         (fn [deps]
+                              (reduce (fn [acc [k v]]
+                                        (if-let [exclude (:exclusions v)]
+                                          (conj acc [k (:mvn/version v) :exclusions exclude])
+                                          (conj acc [k (:mvn/version v)])))
+                                      []
+                                      deps))
+      repo-formatter        (fn [repos]
+                              (reduce (fn [acc [k v]]
+                                        (conj acc[k v]))
+                                      []
+                                      repos))
+      release-deps          (get-in all-deps [:aliases :release :extra-deps])
+      dev-lein-deps         (get-in all-deps [:aliases :dev-lein :extra-deps])
+      dev-deps              (get-in all-deps [:aliases :dev :extra-deps])
+      dev-paths             (get-in all-deps [:aliases :dev :extra-paths])
+      repos             (:mvn/repos all-deps)
+      repos-vec-vec     (repo-formatter repos)
+      dev-deps-vec-vec      (dep-formatter (merge dev-deps dev-lein-deps))
+      deps-vec-vec          (->> all-deps
+                                 :deps
+                                 (merge release-deps)
+                                 dep-formatter
+                                 (into ['[org.clojure/clojure "1.9.0"]]))
+      provided-deps         (get-in all-deps [:aliases :provided :extra-deps])
+      provided-deps-vec-vec (dep-formatter provided-deps)]
+  (defproject io.pedestal/pedestal.service "0.5.5-SNAPSHOT"
+    :description "Pedestal Service"
+    :url "https://github.com/pedestal/pedestal"
+    :scm "https://github.com/pedestal/pedestal"
+    :license {:name "Eclipse Public License"
+              :url  "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies ~deps-vec-vec
+    :min-lein-version "2.0.0"
+    :java-source-paths ["java"]
+    :javac-options ["-target" "1.8" "-source" "1.8"]
+    :jvm-opts ["-D\"clojure.compiler.direct-linking=true\""]
+    :global-vars {*warn-on-reflection* true}
+    :pedantic? :abort
+    :aliases {"bench-log"     ["trampoline" "run" "-m" "io.pedestal.log-bench"]
+              "bench-service" ["trampoline" "run" "-m" "io.pedestal.niotooling.server"]
+              "bench-route"   ["trampoline" "run" "-m" "io.pedestal.route.route-bench"]
+              "dumbrepl"      ["trampoline" "run" "-m" "clojure.main/main"]
+              "docs"          ["with-profile" "docs" "codox"]}
+    :profiles {:default  [:dev :provided :user :base]
+               :provided {:dependencies ~provided-deps-vec-vec}
+               :dev      {:source-paths ~dev-paths
+                          :dependencies ~dev-deps-vec-vec
+                          :repositories ~repos-vec-vec}
+               :docs {:pedantic?    :ranges
+                      :plugins      [[lein-codox "0.9.5"]]
+                      :dependencies ~provided-deps-vec-vec}}
+                                        ;:jvm-opts ^:replace ["-D\"clojure.compiler.direct-linking=true\""
+                                        ;                     "-d64" "-server"
+                                        ;                     "-Xms1g"                             ;"-Xmx1g"
+                                        ;                     "-XX:+UnlockCommercialFeatures"      ;"-XX:+FlightRecorder"
+                                        ;                     ;"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8030"
+                                        ;                     "-XX:+UseG1GC"
+                                        ;                     ;"-XX:+UseConcMarkSweepGC" "-XX:+UseParNewGC" "-XX:+CMSParallelRemarkEnabled"
+                                        ;                     ;"-XX:+ExplicitGCInvokesConcurrent"
+                                        ;                     "-XX:+AggressiveOpts"
+                                        ;                     ;-XX:+UseLargePages
+                                        ;                     "-XX:+UseCompressedOops"]
+    ))

--- a/tomcat/deps.edn
+++ b/tomcat/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src"]
+ :deps {org.apache.tomcat.embed/tomcat-embed-logging-juli {:mvn/version "8.0.52"}
+        org.apache.tomcat.embed/tomcat-embed-jasper {:mvn/version "9.0.8"}
+        org.apache.tomcat.embed/tomcat-embed-core {:mvn/version "9.0.8"}
+        javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}}

--- a/tomcat/project.clj
+++ b/tomcat/project.clj
@@ -9,23 +9,32 @@
 ; the terms of this license.
 ;
 ; You must not remove this notice, or any other, from this software.
+(let [dir           (clojure.string/join "/"
+                                         (butlast (clojure.string/split *file* #"/")))
+      all-deps      (clojure.edn/read-string (slurp (clojure.java.io/file dir "deps.edn")))
+      dep-formatter (fn [deps]
+                      (reduce (fn [acc [k v]]
+                                (if-let [exclude (:exclusions v)]
+                                  (conj acc [k (:mvn/version v) :exclusions exclude])
+                                  (conj acc [k (:mvn/version v)])))
+                              []
+                              deps))
+      deps-vec-vec  (->> all-deps
+                         :deps
+                         dep-formatter
+                         (into ['[org.clojure/clojure "1.9.0"]]))]
+  (defproject io.pedestal/pedestal.tomcat "0.5.5-SNAPSHOT"
+    :description "Embedded Tomcat adapter for Pedestal HTTP Service"
+    :url "https://github.com/pedestal/pedestal"
+    :scm "https://github.com/pedestal/pedestal"
+    :license {:name "Eclipse Public License"
+              :url  "http://www.eclipse.org/legal/epl-v10.html"}
+    :dependencies ~deps-vec-vec
+    :min-lein-version "2.0.0"
+    :global-vars {*warn-on-reflection* true}
+    :pedantic? :abort
 
-(defproject io.pedestal/pedestal.tomcat "0.5.5-SNAPSHOT"
-  :description "Embedded Tomcat adapter for Pedestal HTTP Service"
-  :url "https://github.com/pedestal/pedestal"
-  :scm "https://github.com/pedestal/pedestal"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.tomcat.embed/tomcat-embed-logging-juli "8.0.52"]
-                 [org.apache.tomcat.embed/tomcat-embed-jasper "9.0.8"]
-                 [org.apache.tomcat.embed/tomcat-embed-core "9.0.8"]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
-  :min-lein-version "2.0.0"
-  :global-vars {*warn-on-reflection* true}
-  :pedantic? :abort
+    :aliases {"docs" ["with-profile" "docs" "codox"]}
 
-  :aliases {"docs" ["with-profile" "docs" "codox"]}
-
-  :profiles {:docs {:pedantic? :ranges
-                    :plugins [[lein-codox "0.9.5"]]}})
+    :profiles {:docs {:pedantic? :ranges
+                      :plugins   [[lein-codox "0.9.5"]]}}))


### PR DESCRIPTION
This change allows folks to experiment with clojure 1.10 beta without having to locally build a snapshot.

The git coordinate in the `deps.edn`  referencing `pedestal.log` must include the `:deps/root` key. Example:

`{:git/url "https://github.com/pedestal/pedestal" :sha "xxxx" :deps/root "log"}`

This PR addresses #595.