### PR TITLE
Use ByteArrayOutputStream as buffer instead of outputting directly to…

### DIFF
--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -30,7 +30,8 @@
             [cognitect.transit :as transit]
             [io.pedestal.log :as log])
   (:import (java.io OutputStreamWriter
-                    OutputStream)))
+                    OutputStream
+                    ByteArrayOutputStream)))
 
 ;; edn and json response formats
 
@@ -152,8 +153,10 @@
           (-> response
               (ring-response/content-type default-content-type)
               (assoc :body (fn [^OutputStream output-stream]
-                             (transit/write
-                              (transit/writer output-stream transit-format transit-opts) body)
+                             (let [out (ByteArrayOutputStream. 4096)
+                                   writer (transit/writer out transit-format transit-opts)]
+                               (transit/write writer body)
+                               (.writeTo out output-stream))
                              (.flush output-stream))))
           response))))))
 


### PR DESCRIPTION
… HttpOutput

The current behavior of `transit-body-interceptor` directly writes transit encoded data to HttpOutput. This makes it work very slow. By using the transit writer as proposed in the docs of transit-clj (https://github.com/cognitect/transit-clj#usage), thus by using a in-memory buffer, the encoding time goes down to very acceptable levels.

In our own project, the time it took to finish a request with about 100 entities went from about 7 seconds to about 0,25 seconds.