### PR TITLE
'nil' :path-params are not allowed.

### DIFF
--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -258,7 +258,7 @@
                             (set (seq (:path-params route))) ;; match the params from the route?  `seq` is used to handle cases where no `path-params` are required
                             )
                       ;; nils are not allowed.
-                      (reduce-kv #(if (nil? %3) (reduced true)  %1) false path-params)))
+                      (reduce-kv #(if (nil? %3) (reduced true)  false) nil path-params)))
             (throw (ex-info "Attempted to create a URL with `url-for`, but missing required :path-params - :strict-path-params was set to true.
                             Either include all path-params, or if your URL actually contains ':' in the path, set :strict-path-params to false in the options"
                             {:path-parts path-parts

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -260,7 +260,7 @@
                       ;; nils are not allowed.
                       (reduce-kv #(if (nil? %3) (reduced true)  false) nil path-params)))
             (throw (ex-info "Attempted to create a URL with `url-for`, but missing required :path-params - :strict-path-params was set to true.
-                            Either include all path-params, or if your URL actually contains ':' in the path, set :strict-path-params to false in the options"
+                            Either include all path-params (`nil` is not allowed), or if your URL actually contains ':' in the path, set :strict-path-params to false in the options"
                             {:path-parts path-parts
                              :path-params path-params
                              :options opts

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -253,9 +253,12 @@
                          context-path-parts (concat context-path-parts path-parts)
                          :else path-parts))
         _ (when (and (true? strict-path-params?)
-                     (not= (keys path-params) ;; Do the params passed in...
-                           (seq (:path-params route)) ;; match the params from the route?  `seq` is used to handle cases where no `path-params` are required
-                           ))
+                     (or
+                      (not= (set (keys path-params)) ;; Do the params passed in...
+                            (set (seq (:path-params route))) ;; match the params from the route?  `seq` is used to handle cases where no `path-params` are required
+                            )
+                      ;; nils are not allowed.
+                      (some nil? (vals path-params))))
             (throw (ex-info "Attempted to create a URL with `url-for`, but missing required :path-params - :strict-path-params was set to true.
                             Either include all path-params, or if your URL actually contains ':' in the path, set :strict-path-params to false in the options"
                             {:path-parts path-parts

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -258,7 +258,7 @@
                             (set (seq (:path-params route))) ;; match the params from the route?  `seq` is used to handle cases where no `path-params` are required
                             )
                       ;; nils are not allowed.
-                      (some nil? (vals path-params))))
+                      (reduce-kv #(if (nil? %3) (reduced true)  %1) false path-params)))
             (throw (ex-info "Attempted to create a URL with `url-for`, but missing required :path-params - :strict-path-params was set to true.
                             Either include all path-params, or if your URL actually contains ':' in the path, set :strict-path-params to false in the options"
                             {:path-parts path-parts

--- a/service/test/io/pedestal/http/route_test.clj
+++ b/service/test/io/pedestal/http/route_test.clj
@@ -1131,10 +1131,19 @@
     (testing "missing path params throws an exception when :strict-path-params is true"
       (is (= [:user-id]
              (get-in (ex-data (try (url-for-admin ::delete-user
-                                          :strict-path-params? true)
-                           (catch clojure.lang.ExceptionInfo e
-                             e)))
-                     [:route :path-params]))))))
+                                                  :strict-path-params? true
+                                                  :path-params {:user-id nil})
+                                   (catch clojure.lang.ExceptionInfo e
+                                     e)))
+                     [:route :path-params]))
+          "Should throw when nil.")
+      (is (= [:user-id]
+             (get-in (ex-data (try (url-for-admin ::delete-user
+                                                  :strict-path-params? true)
+                                   (catch clojure.lang.ExceptionInfo e
+                                     e)))
+                     [:route :path-params]))
+          "Should throw when missing."))))
 
 ;; Map-route support
 
@@ -1317,4 +1326,3 @@
           false
           (catch java.lang.AssertionError ae
             true)))))
-


### PR DESCRIPTION
This PR resolves #602. We should not allow `nil` values for path-params when using `url-for`. It also compares sets of path param keys since `keys` does not guarantee order.