### PR TITLE
Remove two-arg call to activate

### DIFF
--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -839,7 +839,7 @@
                initial-tags)
        (.start ^Tracer$SpanBuilder builder))))
   (-activate-span [t span]
-    (.activate (.scopeManager t) ^Span span false)
+    (.activate (.scopeManager t) ^Span span)
     span)
   (-active-span [t]
     (.activeSpan t)))


### PR DESCRIPTION
The two-arity version is [removed in version 0.33](https://github.com/opentracing/opentracing-java/commit/5ed6a47975ed9a19c8de3bcbe27a9385a14de479#diff-1fba031275dd47ef915364ad0aa5c267) and the one-arity call is present in 0.31