### PR TITLE
Bump versions, fixes, doc updates.

### DIFF
--- a/aws/project.clj
+++ b/aws/project.clj
@@ -16,23 +16,23 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [io.pedestal/pedestal.interceptor "0.5.6-SNAPSHOT"]
                  [io.pedestal/pedestal.log "0.5.6-SNAPSHOT"]
                  ;[com.amazonaws.serverless/aws-serverless-java-container-core "0.5.1" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
                  [javax.servlet/javax.servlet-api "3.1.0"]
-                 [com.amazonaws/aws-java-sdk-core "1.11.331" :exclusions [commons-logging]] ;; Needed for x-ray
+                 [com.amazonaws/aws-java-sdk-core "1.11.567" :exclusions [commons-logging]] ;; Needed for x-ray
                  [com.amazonaws/aws-lambda-java-core "1.2.0"]
                  ;[com.amazonaws/aws-lambda-java-events "1.3.0"]
-                 [com.amazonaws/aws-xray-recorder-sdk-core "1.3.1" :exclusions [com.amazonaws/aws-java-sdk-core
+                 [com.amazonaws/aws-xray-recorder-sdk-core "2.2.1" :exclusions [com.amazonaws/aws-java-sdk-core
                                                                                 commons-logging
                                                                                 joda-time]]
                  ;; Deps cleanup
                  [commons-logging "1.2"] ;; A clash between AWS and HTTP Libs
-                 [com.fasterxml.jackson.core/jackson-core "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.0"] ;; Bring AWS libs inline with Pedestal Service
-                 [commons-codec "1.11"] ;; Bring AWS libs inline with Pedestal Service
-                 [joda-time "2.8.2"] ;; Bring AWS libs inline with Pedestal Service
+                 [com.fasterxml.jackson.core/jackson-core "2.9.9"] ;; Bring AWS libs inline with Pedestal Service
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.9"] ;; Bring AWS libs inline with Pedestal Service
+                 [commons-codec "1.12"] ;; Bring AWS libs inline with Pedestal Service
+                 [joda-time "2.10.2"] ;; Bring AWS libs inline with Pedestal Service
                  ]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
@@ -42,4 +42,3 @@
 
   :profiles {:docs {:pedantic? :ranges
                     :plugins [[lein-codox "0.9.5"]]}})
-

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -15,9 +15,9 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [potemkin "0.4.5"]
-                 [org.jboss.logging/jboss-logging "3.3.2.Final"]
+                 [org.jboss.logging/jboss-logging "3.4.0.Final"]
                  [org.immutant/web "2.1.10" :exclusions  [org.jboss.logging/jboss-logging]]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
   :min-lein-version "2.0.0"

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -15,13 +15,12 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.6-SNAPSHOT"]
 
                  ;; Error interceptor tooling
-                 [org.clojure/core.match "0.3.0-alpha5" :exclusions [[org.clojure/clojurescript]
-                                                                     [org.clojure/tools.analyzer.jvm]]]
+                 [org.clojure/core.match "0.3.0" :exclusions [[org.clojure/clojurescript]]]
                  [org.clojure/tools.analyzer.jvm "0.7.2"]]
   :min-lein-version "2.0.0"
   :pedantic? :abort

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -16,7 +16,7 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.eclipse.jetty/jetty-server "9.4.18.v20190429"]
                  [org.eclipse.jetty/jetty-servlet "9.4.18.v20190429"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -17,14 +17,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.eclipse.jetty/jetty-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.10.v20180503"]
+                 [org.eclipse.jetty/jetty-server "9.4.18.v20190429"]
+                 [org.eclipse.jetty/jetty-servlet "9.4.18.v20190429"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty.http2/http2-server "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-api "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.10.v20180503"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.4.10.v20180503"]
+                 [org.eclipse.jetty/jetty-alpn-server "9.4.18.v20190429"]
+                 [org.eclipse.jetty.http2/http2-server "9.4.18.v20190429"]
+                 [org.eclipse.jetty.websocket/websocket-api "9.4.18.v20190429"]
+                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.18.v20190429"]
+                 [org.eclipse.jetty.websocket/websocket-server "9.4.18.v20190429"]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -111,18 +111,22 @@
        (.setHost host)))))
 
 (defn- http-configuration
-  "Provides an HttpConfiguration that can be consumed by connection factories"
+  "Provides an HttpConfiguration that can be consumed by connection factories.
+  The `:io.pedestal.http.jetty/http-configuration` option can be used to specify
+  your own HttpConfiguration instance."
   [options]
-  (let [{:keys [ssl? ssl-port h2?]} options
-        http-conf ^HttpConfiguration (HttpConfiguration.)]
-    (when (or ssl? ssl-port h2?)
-      (.setSecurePort http-conf ssl-port)
-      (.setSecureScheme http-conf "https"))
-    (doto http-conf
-      (.setSendDateHeader true)
-      (.setSendXPoweredBy false)
-      (.setSendServerVersion false)
-      (.addCustomizer (SecureRequestCustomizer.)))))
+  (if-let [http-conf-override ^HttpConfiguration (::http-configuration options)]
+    http-conf-override
+    (let [{:keys [ssl? ssl-port h2?]} options
+          http-conf                   ^HttpConfiguration (HttpConfiguration.)]
+      (when (or ssl? ssl-port h2?)
+        (.setSecurePort http-conf ssl-port)
+        (.setSecureScheme http-conf "https"))
+      (doto http-conf
+        (.setSendDateHeader true)
+        (.setSendXPoweredBy false)
+        (.setSendServerVersion false)
+        (.addCustomizer (SecureRequestCustomizer.))))))
 
 (defn- needed-pool-size
   "Jetty 9 calculates a needed number of threads per acceptors and selectors,

--- a/log/project.clj
+++ b/log/project.clj
@@ -15,15 +15,15 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  ;; logging
-                 [org.slf4j/slf4j-api "1.7.25"]
+                 [org.slf4j/slf4j-api "1.7.26"]
                  ;; metrics
-                 [io.dropwizard.metrics/metrics-core "4.0.2"]
-                 [io.dropwizard.metrics/metrics-jmx "4.0.2"]
+                 [io.dropwizard.metrics/metrics-core "4.1.0"]
+                 [io.dropwizard.metrics/metrics-jmx "4.1.0"]
                  ;; tracing
-                 [io.opentracing/opentracing-api "0.31.0"]
-                 [io.opentracing/opentracing-util "0.31.0"]]
+                 [io.opentracing/opentracing-api "0.33.0"]
+                 [io.opentracing/opentracing-util "0.33.0"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort

--- a/route/project.clj
+++ b/route/project.clj
@@ -15,8 +15,8 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.6-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.6-SNAPSHOT"]
                  [org.clojure/core.incubator "0.1.4"]]

--- a/service-template/src/leiningen/new/pedestal_service/project.clj
+++ b/service-template/src/leiningen/new/pedestal_service/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [io.pedestal/pedestal.service "0.5.6-SNAPSHOT"]
 
                  ;; Remove this line and uncomment one of the next lines to
@@ -13,9 +13,9 @@
                  ;; [io.pedestal/pedestal.tomcat "0.5.6-SNAPSHOT"]
 
                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.25"]
-                 [org.slf4j/jcl-over-slf4j "1.7.25"]
-                 [org.slf4j/log4j-over-slf4j "1.7.25"]]
+                 [org.slf4j/jul-to-slf4j "1.7.26"]
+                 [org.slf4j/jcl-over-slf4j "1.7.26"]
+                 [org.slf4j/log4j-over-slf4j "1.7.26"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
@@ -24,4 +24,3 @@
                    :dependencies [[io.pedestal/pedestal.service-tools "0.5.6-SNAPSHOT"]]}
              :uberjar {:aot [{{namespace}}.server]}}
   :main ^{:skip-aot true} {{namespace}}.server)
-

--- a/service-template/src/leiningen/new/pedestal_service/service.clj
+++ b/service-template/src/leiningen/new/pedestal_service/service.clj
@@ -75,5 +75,8 @@
                                         ;:keystore "test/hp/keystore.jks"
                                         ;:key-password "password"
                                         ;:ssl-port 8443
-                                        :ssl? false}})
-
+                                        :ssl? false
+                                        ;; Alternatively, You can specify you're own Jetty HTTPConfiguration
+                                        ;; via the `:io.pedestal.http.jetty/http-configuration` container option.
+                                        ;:io.pedestal.http.jetty/http-configuration (org.eclipse.jetty.server.HttpConfiguration.)
+                                        }})

--- a/service-tools/project.clj
+++ b/service-tools/project.clj
@@ -21,13 +21,13 @@
                  [org.clojure/data.xml "0.2.0-alpha5"]
 
                  ;; Auto-reload changes
-                 [ns-tracker "0.3.1"]
+                 [ns-tracker "0.4.0"]
 
                  ;; Logging
                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.25"]
-                 [org.slf4j/jcl-over-slf4j "1.7.25"]
-                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+                 [org.slf4j/jul-to-slf4j "1.7.26"]
+                 [org.slf4j/jcl-over-slf4j "1.7.26"]
+                 [org.slf4j/log4j-over-slf4j "1.7.26"]
 
                  [javax.servlet/javax.servlet-api "3.1.0" :scope "test"]]
 

--- a/service/project.clj
+++ b/service/project.clj
@@ -59,7 +59,7 @@
                                   [clj-http "2.0.0" :exclusions [[potemkin]
                                                                  [clj-tuple]]]
                                   [com.ning/async-http-client "1.8.13"]
-                                  [org.eclipse.jetty/jetty-servlets "9.4.10.v20180503"]
+                                  [org.eclipse.jetty/jetty-servlets "9.4.18.v20190429"]
                                   [io.pedestal/pedestal.jetty "0.5.6-SNAPSHOT"]
                                   [io.pedestal/pedestal.immutant "0.5.6-SNAPSHOT"]
                                   [io.pedestal/pedestal.tomcat "0.5.6-SNAPSHOT"]

--- a/service/project.clj
+++ b/service/project.clj
@@ -16,26 +16,26 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
 
                  [io.pedestal/pedestal.log "0.5.6-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.6-SNAPSHOT"]
                  [io.pedestal/pedestal.route "0.5.6-SNAPSHOT"]
 
                  ;; channels
-                 [org.clojure/core.async "0.4.474" :exclusions [org.clojure/tools.analyzer.jvm]]
+                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
 
                  ;; interceptors
-                 [ring/ring-core "1.6.3" :exclusions [[org.clojure/clojure]
+                 [ring/ring-core "1.7.1" :exclusions [[org.clojure/clojure]
                                                       [org.clojure/tools.reader]
                                                       [crypto-random]
                                                       [crypto-equality]]]
 
-                 [cheshire "5.8.0"]
-                 [org.clojure/tools.reader "1.2.2"]
+                 [cheshire "5.8.1"]
+                 [org.clojure/tools.reader "1.3.2"]
                  [org.clojure/tools.analyzer.jvm "0.7.2"]
-                 [com.cognitect/transit-clj "0.8.309"]
-                 [commons-codec "1.11"]
+                 [com.cognitect/transit-clj "0.8.313"]
+                 [commons-codec "1.12"]
                  [crypto-random "1.2.0" :exclusions [[commons-codec]]]
                  [crypto-equality "1.0.0"]]
   :min-lein-version "2.0.0"
@@ -52,12 +52,22 @@
   :profiles {:default [:dev :provided :user :base]
              :provided {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
              :dev {:source-paths ["dev" "src" "bench"]
-                   :dependencies [[criterium "0.4.4"]
-                                  [org.clojure/java.classpath "0.2.3"]
+                   :dependencies [[criterium "0.4.5"]
+                                  [org.clojure/java.classpath "0.3.0"]
                                   [org.clojure/tools.namespace "0.2.11"]
-                                  ;[clj-http "0.9.1"]
+                                  ;; TODO: clj-http 3.10.0 is available but
+                                  ;; gzip compression test fails. Even though
+                                  ;; `accept-encoding: gzip, deflate` is set by clj-http
+                                  ;; (in HttpRequest), there is an issue with either
+                                  ;; test setup or response processing (in clj-http).
+                                  ;; This requires further investigation.
                                   [clj-http "2.0.0" :exclusions [[potemkin]
                                                                  [clj-tuple]]]
+                                  ;; TODO: While com.ning/async-http-client 1.9.40 is available,
+                                  ;; an arity error is encountered when running `lein bench-service`.
+                                  ;; Furthermore, the project has been moved to
+                                  ;; https://github.com/AsyncHttpClient/async-http-client
+                                  ;; So benchmarking should be updated to use that.
                                   [com.ning/async-http-client "1.8.13"]
                                   [org.eclipse.jetty/jetty-servlets "9.4.18.v20190429"]
                                   [io.pedestal/pedestal.jetty "0.5.6-SNAPSHOT"]
@@ -66,14 +76,14 @@
                                   [javax.servlet/javax.servlet-api "3.1.0"]
                                   ;; Logging:
                                   [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                                  [org.clojure/tools.logging "0.3.1"]
-                                  [org.slf4j/jul-to-slf4j "1.7.25"]
-                                  [org.slf4j/jcl-over-slf4j "1.7.25"]
-                                  [org.slf4j/log4j-over-slf4j "1.7.25"]
+                                  [org.clojure/tools.logging "0.4.0"]
+                                  [org.slf4j/jul-to-slf4j "1.7.26"]
+                                  [org.slf4j/jcl-over-slf4j "1.7.26"]
+                                  [org.slf4j/log4j-over-slf4j "1.7.26"]
 
                                   ;; only used for route-bench - remove when no longer needed
-                                  [incanter/incanter-core "1.5.6"]
-                                  [incanter/incanter-charts "1.5.6"]]
+                                  [incanter/incanter-core "1.9.3"]
+                                  [incanter/incanter-charts "1.9.3"]]
                    :repositories [["sonatype-oss"
                                    "https://oss.sonatype.org/content/groups/public/"]]}
              :docs {:pedantic? :ranges

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -380,14 +380,18 @@
 
 (defn start
   "Given service-map, an initialized service map returned by `create-server`,
-  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/start-fn.`"
+  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/start-fn.`
+
+  Returns `service-map` on success."
   [service-map]
   ((::start-fn service-map))
   service-map)
 
 (defn stop
   "Given service-map, an initialized service map returned by `create-server`,
-  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/stop-fn.`"
+  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/stop-fn.`
+
+  Returns `service-map` on success."
   [service-map]
   ((::stop-fn service-map))
   service-map)

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -355,6 +355,21 @@
     (merge service-map-with-host (server-map->service-map server-map))))
 
 (defn create-server
+  "Given a service map, creates an returns an initialized service map which is
+  ready to be started via `io.pedestal.http/start`. If init-fn, a zero
+  arg function, is provided, it is invoked first.
+
+  Notes:
+  - The returned, initialized service map contains the `io.pedestal.http/start-fn`
+    and `io.pedestal.http/stop-fn` keys whose values are zero arg functions which
+    are used to start/stop the http service, respectively.
+  - If the service map option `:io.pedestal.http/chain-provider` is present,
+    it is used to create the server, otherwise a servlet provider will be used.
+    In this case, the type of servlet container created is determined by the
+    `:io.pedestal.http/type` option.
+  - For servlet containers, the resulting service-map will contain the
+    `io.pedestal.http/service-fn` key which is useful for testing the service
+    without starting it."
   ([service-map]
    (create-server service-map log/maybe-init-java-util-log))
   ([service-map init-fn]
@@ -363,11 +378,17 @@
       create-provider ;; Creates/connects a backend to the interceptor chain
       server)))
 
-(defn start [service-map]
+(defn start
+  "Given service-map, an initialized service map returned by `create-server`,
+  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/start-fn.`"
+  [service-map]
   ((::start-fn service-map))
   service-map)
 
-(defn stop [service-map]
+(defn stop
+  "Given service-map, an initialized service map returned by `create-server`,
+  invokes the zero-arg function assoc'd to the service map via `:io.pedestal.http/stop-fn.`"
+  [service-map]
   ((::stop-fn service-map))
   service-map)
 
@@ -384,4 +405,3 @@
 
 (defn servlet-service [service servlet-req servlet-resp]
   (.service ^javax.servlet.Servlet (::servlet service) servlet-req servlet-resp))
-


### PR DESCRIPTION
- Bumps project dependencies.
  - There were a number of vulnerabilities reported for the previous Jetty
    version as per the OWASP Dependency Check tool 
    (https://www.owasp.org/index.php/OWASP_Dependency_Check). Changes were benchmarked 
    locally using `lein benchmark-service` + `service/bin/perfit.sh` and showed no significant 
    difference.
- Jetty HttpConfiguration can now be set via `:container-options`.



Resolves #619, #615.