### PR TITLE
Fix typo ('interceptors' for possessive singular)

### DIFF
--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -97,7 +97,7 @@
 
 (defn head
   "Interceptor to handle head requests. If used with defroutes, it will not work
-  if specified in an interceptors meta-key."
+  if specified in an interceptor's meta-key."
   []
   (interceptor {:name ::head
                 :enter (fn [ctx]


### PR DESCRIPTION
This is a dangling bit of business left over from pedestal/pedestal-docs/issues/125