### PR TITLE
Extract OpenTracing context from headers

### DIFF
--- a/samples/tracing-interceptor/project.clj
+++ b/samples/tracing-interceptor/project.clj
@@ -1,24 +1,24 @@
-(defproject tracing-interceptor "0.5.5"
+(defproject tracing-interceptor "0.5.7"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [io.pedestal/pedestal.service "0.5.5"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [io.pedestal/pedestal.service "0.5.7"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.5"]
+                 [io.pedestal/pedestal.jetty "0.5.7"]
                  ;; [io.pedestal/pedestal.immutant "0.5.4"]
                  ;; [io.pedestal/pedestal.tomcat "0.5.4"]
 
                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.25"]
-                 [org.slf4j/jcl-over-slf4j "1.7.25"]
-                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+                 [org.slf4j/jul-to-slf4j "1.7.26"]
+                 [org.slf4j/jcl-over-slf4j "1.7.26"]
+                 [org.slf4j/log4j-over-slf4j "1.7.26"]
 
                  ;; Tracing backend
-                 [io.jaegertracing/jaeger-core "0.27.0"]
+                 [io.jaegertracing/jaeger-core "1.0.0"]
 
                  ;; Tracing HTTP client to test propagation
                  [io.opentracing.contrib/opentracing-apache-httpclient "0.1.0"]]

--- a/samples/tracing-interceptor/src/tracing_interceptor/server.clj
+++ b/samples/tracing-interceptor/src/tracing_interceptor/server.clj
@@ -6,11 +6,26 @@
             [tracing-interceptor.service :as service])
   (:import (io.jaegertracing Configuration
                              Configuration$SamplerConfiguration
-                             Configuration$ReporterConfiguration)))
+                             Configuration$ReporterConfiguration
+                             Configuration$SenderConfiguration)))
 
 ;; This is an adapted service map, that can be started and stopped
 ;; From the REPL you can call server/start and server/stop on this service
 (defonce runnable-service (server/create-server service/service))
+
+(defn- jaeger-tracer [service-name]
+  (.getTracer
+    (-> (Configuration/fromEnv service-name)
+        (.withSampler (-> (Configuration$SamplerConfiguration/fromEnv)
+                          (.withType "const")
+                          (.withParam 1)))
+        (.withReporter (-> (Configuration$ReporterConfiguration/fromEnv)
+                           (.withLogSpans false)
+                           (.withFlushInterval (int 1000))
+                           (.withMaxQueueSize (int 10000))
+                           (.withSender (-> (Configuration$SenderConfiguration.)
+                                            (.withAgentHost "localhost")
+                                            (.withAgentPort (int 5775)))))))))
 
 (defn run-dev
   "The entry-point for 'lein run-dev'"
@@ -21,14 +36,7 @@
   ;;  any other Tracer could be registered.  This approach will only fail if
   ;;  the Tracer is set using the JVM property or environment variable.
   (println "Registering local Trace connection")
-  (log/-register (.getTracer
-                   (Configuration. "TracingExample-DEV" ;; Our Service Name
-                                   (Configuration$SamplerConfiguration. "const" 1)
-                                   (Configuration$ReporterConfiguration. false       ;; log spans?
-                                                                         "localhost" ;; agent host
-                                                                         (int 5775)  ;; agent port
-                                                                         (int 1000)        ;; flush interval ms
-                                                                         (int 10000)))))   ;; max queue size
+  (log/-register (jaeger-tracer "TracingExample-DEV")) ;; Our Service Name
   (println "\nCreating your [DEV] server...")
   (-> service/service ;; start with production configuration
       (merge {:env :dev
@@ -56,14 +64,7 @@
   ;;  any other Tracer could be registered.  This approach will only fail if
   ;;  the Tracer is set using the JVM property or environment variable.
   (println "Registering local Trace connection")
-  (log/-register (.getTracer
-                   (Configuration. "TracingExample" ;; Our Service Name
-                                   (Configuration$SamplerConfiguration. "const" 1)
-                                   (Configuration$ReporterConfiguration. false       ;; log spans?
-                                                                         "localhost" ;; agent host
-                                                                         (int 5775)  ;; agent port
-                                                                         (int 1000)        ;; flush interval ms
-                                                                         (int 10000)))))   ;; max queue size
+  (log/-register (jaeger-tracer "TracingExample"))   ;; Our Service Name
   (println "\nCreating your server...")
   (server/start runnable-service))
 

--- a/samples/tracing/project.clj
+++ b/samples/tracing/project.clj
@@ -1,24 +1,24 @@
-(defproject tracing "0.5.5"
+(defproject tracing "0.5.7"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [io.pedestal/pedestal.service "0.5.5"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [io.pedestal/pedestal.service "0.5.7"]
 
                  ;; Remove this line and uncomment one of the next lines to
                  ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.5"]
+                 [io.pedestal/pedestal.jetty "0.5.7"]
                  ;; [io.pedestal/pedestal.immutant "0.5.5"]
                  ;; [io.pedestal/pedestal.tomcat "0.5.5"]
 
                  [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.25"]
-                 [org.slf4j/jcl-over-slf4j "1.7.25"]
-                 [org.slf4j/log4j-over-slf4j "1.7.25"]
+                 [org.slf4j/jul-to-slf4j "1.7.26"]
+                 [org.slf4j/jcl-over-slf4j "1.7.26"]
+                 [org.slf4j/log4j-over-slf4j "1.7.26"]
 
                  ;; Tracing backend
-                 [io.jaegertracing/jaeger-core "0.27.0"]]
+                 [io.jaegertracing/jaeger-core "1.0.0"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :pedantic? :abort

--- a/service/project.clj
+++ b/service/project.clj
@@ -83,7 +83,10 @@
 
                                   ;; only used for route-bench - remove when no longer needed
                                   [incanter/incanter-core "1.9.3"]
-                                  [incanter/incanter-charts "1.9.3"]]
+                                  [incanter/incanter-charts "1.9.3"]
+
+                                  ;; only used for tracing test
+                                  [io.jaegertracing/jaeger-client "1.0.0"]]
                    :repositories [["sonatype-oss"
                                    "https://oss.sonatype.org/content/groups/public/"]]}
              :docs {:pedantic? :ranges

--- a/service/test/io/pedestal/interceptor/trace_test.clj
+++ b/service/test/io/pedestal/interceptor/trace_test.clj
@@ -1,0 +1,26 @@
+(ns io.pedestal.interceptor.trace-test
+  (:require [io.pedestal.interceptor.trace :as trace]
+            [clojure.test :refer :all])
+  (:import (io.jaegertracing Configuration
+                             Configuration$SamplerConfiguration
+                             Configuration$ReporterConfiguration
+                             Configuration$SenderConfiguration)))
+
+(def jaeger-tracer
+   (.getTracer
+    (-> (Configuration/fromEnv "test-service")
+        (.withSampler (-> (Configuration$SamplerConfiguration/fromEnv)
+                          (.withType "const")
+                          (.withParam 1)))
+        (.withReporter (-> (Configuration$ReporterConfiguration/fromEnv)
+                           (.withLogSpans false)
+                           (.withFlushInterval (int 1000))
+                           (.withMaxQueueSize (int 10000))
+                           (.withSender (-> (Configuration$SenderConfiguration.)
+                                            (.withAgentHost "localhost")
+                                            (.withAgentPort (int 5775)))))))))
+
+(deftest extract-span-context
+  (is (not (nil? (trace/headers->span-context
+                  jaeger-tracer
+                  {"uber-trace-id" "c7f80b90c5049e2b:28cbcfdd0ed5e4a9:c7f80b90c5049e1b:1"})))))


### PR DESCRIPTION
I had some trouble working with `jaeger` and `pedestal 0.5.7`
The `tracing-interceptor` wasn't able to extract the span context from the request headers.

> WARN  i.j.i.PropagationRegistry$ExceptionCatchingExtractorDecorator - Error when extracting SpanContext from carrier. Handling gracefully.
> java.lang.ClassCastException: class io.opentracing.propagation.TextMapExtractAdapter cannot be cast to class io.opentracing.propagation.TextMap (io.opentracing.propagation.TextMapExtractAdapter and io.opentracing.propagation.TextMap are in unnamed module of loader 'app')

Using a `TextMapAdapter` instead of a `TextMapExtractAdapter` seems to fix the issue.
I added a simple test to make sure something was extracted from the `uber-trace-id` header.

I also updated the `tracing` and `tracing-interceptor` samples to use the last deps.
The issue can be reproduced running the updated `tracing-interceptor` sample.