### PR TITLE
Adds test support for HttpServletResponse SendError.

### DIFF
--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -181,6 +181,11 @@
                  (setContentLengthLong [this content-length] (swap! headers-map assoc :content-length content-length))
                  (flushBuffer [this] (reset! committed true))
                  (isCommitted [this] @committed)
+                 (sendError [this sc]
+                   (.sendError this sc "Server Error"))
+                 (sendError [this sc msg]
+                   (reset! status-val sc)
+                   (io/copy msg output-stream))
 
                  ;; Force all async NIO behaviors to be sync
                  container/WriteNIOByteBody

--- a/service/test/io/pedestal/test_test.clj
+++ b/service/test/io/pedestal/test_test.clj
@@ -43,3 +43,14 @@
     (is (= {:scheme "http", :host "localhost", :port 8080, :path "foo", :query-string "param=value"}
            (parse-url "http://localhost:8080/foo?param=value")))))
 
+(deftest response-senderror-test
+  (testing "sendError with status only"
+    (let [resp (test-servlet-response)]
+      (.sendError resp 500)
+      (is (= 500 (test-servlet-response-status resp)))
+      (is (= "Server Error" (.toString (test-servlet-response-body resp))))))
+  (testing "sendError with status and message"
+    (let [resp (test-servlet-response)]
+      (.sendError resp 500 "Boom!")
+      (is (= 500 (test-servlet-response-status resp)))
+      (is (= "Boom!" (.toString (test-servlet-response-body resp)))))))


### PR DESCRIPTION
Support HttpServletResponse's `sendError` method with and without a message.

Addresses #634 .