### PR TITLE
Return StringBuffer on getRequestURL

### DIFF
--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -106,7 +106,7 @@
         (getMethod [this] (-> verb
                             name
                             cstr/upper-case))
-        (getRequestURL [this] url)
+        (getRequestURL [this] (StringBuffer. url))
         (getServerPort [this] port)
         (getServerName [this] host)
         (getRemoteAddr [this] "127.0.0.1")


### PR DESCRIPTION
When calling `(.getRequestURL req)` on a request created by `response-for` the following error popped up:
```
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.StringBuffer
```

Which is logical because `javax.servlet.http.HttpServletRequest#getRequestUrl` expects to return a `StringBuffer` instead of a `String`.

---

Happy to add a tests, but I'd need a suggestion on the approach, the fn is private and creating an interceptor for testing the request seems non-ideal.