### PR TITLE
Fix error suppression bug.

### DIFF
--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -74,7 +74,7 @@
                    :execution-id execution-id)
         (try (error-fn (dissoc context ::error) ex)
              (catch Throwable t
-               (if (identical? (type t) (type (:exception ex)))
+               (if (identical? (type t) (-> ex ex-data :exception type))
                  (do (log/debug :rethrow t :execution-id execution-id)
                      context)
                  (do (log/debug :throw t :suppressed (:exception-type ex) :execution-id execution-id)


### PR DESCRIPTION
This bug surfaced when discussing #640. The comparison used for the `io.pedestal.interceptor.chain/suppressed` decision was intended to compare the original exception with the caught one. Since Errors assoc'd to the context during chain execution are wrapped by an `ExceptionInfo` instance, `ex-data` needs to be called first.