### PR TITLE
support async handler function

### DIFF
--- a/interceptor/src/io/pedestal/interceptor.clj
+++ b/interceptor/src/io/pedestal/interceptor.clj
@@ -44,7 +44,7 @@
                                  (if (channel? resp)
                                    (async/go
                                      (assoc context :response (async/<! resp)))
-                                   (assoc context :response ))))}))))
+                                   (assoc context :response resp))))}))))
 
   clojure.lang.IPersistentList
   (-interceptor [t] (interceptor (eval t)))

--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -17,13 +17,11 @@
   (:refer-clojure :exclude (name))
   (:require [clojure.core.async :as async :refer [<! go]]
             [io.pedestal.log :as log]
-            [io.pedestal.interceptor :as interceptor])
+            [io.pedestal.interceptor :as interceptor :refer [channel?]])
   (:import java.util.concurrent.atomic.AtomicLong))
 
 (declare execute)
 (declare execute-only)
-
-(defn- channel? [c] (instance? clojure.core.async.impl.protocols.Channel c))
 
 ;; This is used for printing out interceptors within debug messages
 (defn- name [interceptor]


### PR DESCRIPTION
To use the async handler feature of pedestal, the handler function must be wrapped in a full interceptor, for instance with the  `interceptor.helpers/defbefore` macro:

```clojure
(defbefore handle-login
  [context]
  (async/go
    (async/<! (async/timeout 1000))
    (assoc context :response {:status 200 :body "hello"}))
```

This patch make it able to be simplified to:

```clojure
(defn hello
  [request]
  (async/go
    (async/<! (async/timeout 1000))
    {:status 200 :body "hello"}))
```