### PR TITLE
FileChannel/open expects a vararg of options

### DIFF
--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -33,7 +33,8 @@
             [ring.util.codec :as codec]
             [ring.util.response :as ring-resp])
   (:import (java.nio.channels FileChannel)
-           (java.nio.file StandardOpenOption)
+           (java.nio.file OpenOption
+                          StandardOpenOption)
            (java.io File)))
 
 (defn response-fn-adapter
@@ -186,7 +187,7 @@
                                            file-resp
                                            (assoc file-resp
                                                   :body (FileChannel/open (.toPath ^File (:body file-resp))
-                                                                          StandardOpenOption/READ))))]
+                                                                          (into-array OpenOption [StandardOpenOption/READ])))))]
                        (if response
                          (assoc ctx :response response)
                          ctx)))))}))))


### PR DESCRIPTION
Java `FileChannel/open` expects a variable argument of `OpenOption`s as the second paramenter. Passing a non-vararg `OpenOption` value, as was before this patch, throws an exception.

Reference: https://docs.oracle.com/javase/7/docs/api/java/nio/channels/FileChannel.html#open(java.nio.file.Path,%20java.nio.file.OpenOption...)