### PR TITLE
Remove deref call in routes function in service-template

### DIFF
--- a/service-template/src/leiningen/new/pedestal_service/server.clj
+++ b/service-template/src/leiningen/new/pedestal_service/server.clj
@@ -18,7 +18,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(route/expand-routes (deref #'service/routes))
+              ::server/routes #(route/expand-routes service/routes)
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
               ;; Content Security Policy (CSP) is mostly turned off in dev mode


### PR DESCRIPTION
I may be misunderstanding something but from what I can tell using the `service/routes` symbol directly inside the function will always get the current value of `service/routes` when the `server/routes` function is called, so dereferencing the var is unnecessary. This change works for me - changes to the routes are picked up without a server restart.