### PR TITLE
Adds support for jetty websocket flow control.

### DIFF
--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -17,6 +17,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
+                 [io.pedestal/pedestal.log "0.5.8-SNAPSHOT"]
                  [org.eclipse.jetty/jetty-server "9.4.18.v20190429"]
                  [org.eclipse.jetty/jetty-servlet "9.4.18.v20190429"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -17,7 +17,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [io.pedestal/pedestal.log "0.5.8-SNAPSHOT"]
+                 [io.pedestal/pedestal.log "0.5.9-SNAPSHOT"]
                  [org.eclipse.jetty/jetty-server "9.4.18.v20190429"]
                  [org.eclipse.jetty/jetty-servlet "9.4.18.v20190429"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]

--- a/jetty/src/io/pedestal/http/jetty/websockets.clj
+++ b/jetty/src/io/pedestal/http/jetty/websockets.clj
@@ -1,20 +1,22 @@
 (ns io.pedestal.http.jetty.websockets
-  (:require [clojure.core.async :as async :refer [go-loop]])
+  (:require [clojure.core.async :as async :refer [go-loop]]
+            [io.pedestal.log :as log])
   (:import (java.nio ByteBuffer)
            (org.eclipse.jetty.servlet ServletContextHandler ServletHolder)
            (org.eclipse.jetty.websocket.servlet WebSocketCreator
-                                                WebSocketServlet
-                                                WebSocketServletFactory)
+                                                WebSocketServlet)
            (org.eclipse.jetty.websocket.api Session
                                             WebSocketListener
                                             WebSocketConnectionListener
-                                            RemoteEndpoint)))
+                                            RemoteEndpoint
+                                            WriteCallback)))
 
 
 ;; This is a protocol used to extend the capabilities on messages are
 ;; marshalled on send
 (defprotocol WebSocketSend
-  (ws-send [msg remote-endpoint]))
+  (ws-send [msg remote-endpoint]
+    "Sends `msg` to `remote-endpoint`. May block."))
 
 (extend-protocol WebSocketSend
 
@@ -25,7 +27,6 @@
   ByteBuffer
   (ws-send [msg ^RemoteEndpoint remote-endpoint]
     (.sendBytes remote-endpoint msg)))
-
 
 (defn start-ws-connection
   "Given a function of two arguments
@@ -42,14 +43,84 @@
   ([on-connect-fn send-buffer-or-n]
    (fn [^Session ws-session]
      (let [send-ch (async/chan send-buffer-or-n)
-           remote ^RemoteEndpoint (.getRemote ws-session)]
+           remote  ^RemoteEndpoint (.getRemote ws-session)]
        ;; Let's process sends...
        (go-loop []
-                (if-let [out-msg (and (.isOpen ws-session)
-                                      (async/<! send-ch))]
-                  (do (ws-send out-msg remote)
-                      (recur))
-                  (.close ws-session)))
+         (if-let [out-msg (and (.isOpen ws-session)
+                               (async/<! send-ch))]
+           (do (try (ws-send out-msg remote)
+                    (catch Exception ex
+                      (log/error :msg "Failed on ws-send"
+                                 :exception ex)))
+               (recur))
+           (.close ws-session)))
+       (on-connect-fn ws-session send-ch)))))
+
+;; Support non-blocking transmission with optional flow control
+(defprotocol WebSocketSendAsync
+  (ws-send-async [msg remote-endpoint]
+    "Sends `msg` to `remote-endpoint`. Returns a
+     promise channel from which the result can be taken."))
+
+(extend-protocol WebSocketSendAsync
+  String
+  (ws-send-async [msg ^RemoteEndpoint remote-endpoint]
+    (let [p-chan (async/promise-chan)]
+      (.sendString remote-endpoint msg (reify WriteCallback
+                                         (writeFailed [_ ex]
+                                           (async/put! p-chan ex))
+                                         (writeSuccess [_]
+                                           (async/put! p-chan :success))))
+      p-chan))
+
+  ByteBuffer
+  (ws-send-async [msg ^RemoteEndpoint remote-endpoint]
+    (let [p-chan (async/promise-chan)]
+      (.sendBytes remote-endpoint msg (reify WriteCallback
+                                        (writeFailed [_ ex]
+                                          (async/put! p-chan ex))
+                                        (writeSuccess [_]
+                                          (async/put! p-chan :success))))
+      p-chan)))
+
+(defn start-ws-connection-with-fc-support
+  "Like `start-ws-connection` but transmission is non-blocking and supports
+  conveying transmission results. This allows services to implement flow
+  control.
+
+  Notes:
+  
+  Putting a sequential value on the `send` channel signals that a
+  transmission response is desired. In this case the value is expected to
+  be a 2-tuple of [`msg` `resp-ch`] where `msg` is the message to be sent
+  and `resp-ch` is the channel in which the transmission result will be
+  put.
+  "
+  ([on-connect-fn]
+   (start-ws-connection-with-fc-support on-connect-fn 10))
+  ([on-connect-fn send-buffer-or-n]
+   (fn [^Session ws-session]
+     (let [send-ch (async/chan send-buffer-or-n)
+           remote  ^RemoteEndpoint (.getRemote ws-session)]
+       (go-loop []
+         (if-let [payload (and (.isOpen ws-session)
+                               (async/<! send-ch))]
+           (let [[out-msg resp-ch] (if (sequential? payload)
+                                     payload
+                                     [payload nil])
+                 result (try (async/<! (ws-send-async out-msg remote))
+                             (catch Exception ex
+                               (log/error :msg "Failed on ws-send-async"
+                                          :exception ex)
+                               ex))]
+             (when resp-ch
+               (try
+                 (async/put! resp-ch result)
+                 (catch Exception ex
+                   (log/error :msg "Invalid response channel"
+                              :exception ex))))
+             (recur))
+           (.close ws-session)))
        (on-connect-fn ws-session send-ch)))))
 
 (defn make-ws-listener


### PR DESCRIPTION
This PR adds a new websocket connect function, `start-ws-connection-with-fc-support`, along with a protocol `WebSocketSendAsync` which is internally non-blocking and optionally supports flow control. 

Additionally, while the intended behavior of `start-ws-connection` was left intact, additional error handling was added to ensure the go loop does not terminate when invalid input is provided.

The use of either _start_ fn is optional and service implementers are free to provide their own and integrate directly with the websocket Session if neither impl fits their needs.

Resolves #497.