### PR TITLE
fast-resource pass on context unmodified when request is not GET or HEAD

### DIFF
--- a/service/src/io/pedestal/http/ring_middlewares.clj
+++ b/service/src/io/pedestal/http/ring_middlewares.clj
@@ -190,7 +190,8 @@
                                                                           (into-array OpenOption [StandardOpenOption/READ])))))]
                        (if response
                          (assoc ctx :response response)
-                         ctx)))))}))))
+                         ctx))
+                     ctx)))}))))
 
 (defn session
   "Interceptor for session ring middleware. Be sure to persist :session and

--- a/service/test/io/pedestal/http/ring_middlewares_test.clj
+++ b/service/test/io/pedestal/http/ring_middlewares_test.clj
@@ -178,6 +178,10 @@
           (get-in [:response :body])
           slurp))))
 
+(deftest fast-resource-passes-on-post
+  (let [ctx (context {:uri "/index.html" :request-method :post})]
+    (is (= ctx ((:enter (fast-resource "/io/pedestal/public")) ctx)))))
+
 (defn- make-store [reader writer deleter]
   (reify SessionStore
     (read-session [_ k] (reader k))


### PR DESCRIPTION
Trying to diagnose why I was not getting a 404 when POSTing to routes that didn't exist, I finally figured out that the `fast-resource` interceptor returns `nil` when the request method is not GET or HEAD. This changes it to instead return `ctx` unmodified.