### PR TITLE
Use HTTPS in helloworld-metrics sample

### DIFF
--- a/samples/helloworld-metrics/project.clj
+++ b/samples/helloworld-metrics/project.clj
@@ -29,7 +29,7 @@
                  [org.slf4j/jcl-over-slf4j "1.7.25"]
                  [org.slf4j/log4j-over-slf4j "1.7.25"]
                  [com.readytalk/metrics3-statsd "4.1.2"]]
-  :repositories [["jcenter" "http://jcenter.bintray.com"]]
+  :repositories [["jcenter" "https://jcenter.bintray.com"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "helloworld-metrics.server/run-dev"]}}


### PR DESCRIPTION
When trying to run `lein run-dev` on the helloworld-metrics sample I'm getting an error

```
Tried to use insecure HTTP repository without TLS:                                                                          
 jcenter: http://jcenter.bintray.com                                                                                        
 com/readytalk/metrics3-statsd/4.1.2/metrics3-statsd-4.1.2.pom                                                              
                                                                                                                            
This is almost certainly a mistake; for details see                                                                         
https://github.com/technomancy/leiningen/blob/master/doc/FAQ.md
```

Using https fixes it.

> Leiningen 2.9.3 on Java 1.8.0_252 OpenJDK 64-Bit Server VM