### PR TITLE
Improve service template test upgrade resiliency

### DIFF
--- a/service-template/src/leiningen/new/pedestal_service/service_test.clj
+++ b/service-template/src/leiningen/new/pedestal_service/service_test.clj
@@ -23,9 +23,10 @@
         "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
 
 (deftest about-page-test
-  (is (.contains
-       (:body (response-for service :get "/about"))
-       "Clojure 1.9"))
+  (is
+   (re-find #"Clojure \d+\.\d+(\.\d+)?"
+            (:body (response-for service :get "/about"))))
+  
   (is (=
        (:headers (response-for service :get "/about"))
        {"Content-Type" "text/html;charset=UTF-8"


### PR DESCRIPTION
The current `/about` test case checks for a specific Clojure version.
When users create a new pedestal-service, they often upgrade
stale dependencies right away. This test adds unnecessary friction.