### PR TITLE
Fix CVE-2020-27216 by bumping Jetty versions

### DIFF
--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -18,14 +18,14 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [io.pedestal/pedestal.log "0.5.9-SNAPSHOT"]
-                 [org.eclipse.jetty/jetty-server "9.4.18.v20190429"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.18.v20190429"]
+                 [org.eclipse.jetty/jetty-server "9.4.35.v20201120"]
+                 [org.eclipse.jetty/jetty-servlet "9.4.35.v20201120"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server "9.4.18.v20190429"]
-                 [org.eclipse.jetty.http2/http2-server "9.4.18.v20190429"]
-                 [org.eclipse.jetty.websocket/websocket-api "9.4.18.v20190429"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.18.v20190429"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.4.18.v20190429"]
+                 [org.eclipse.jetty/jetty-alpn-server "9.4.35.v20201120"]
+                 [org.eclipse.jetty.http2/http2-server "9.4.35.v20201120"]
+                 [org.eclipse.jetty.websocket/websocket-api "9.4.35.v20201120"]
+                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.35.v20201120"]
+                 [org.eclipse.jetty.websocket/websocket-server "9.4.35.v20201120"]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}


### PR DESCRIPTION
This PR fixes #672