### PR TITLE
Fix #678 - print-method should be readable

### DIFF
--- a/interceptor/src/io/pedestal/interceptor.clj
+++ b/interceptor/src/io/pedestal/interceptor.clj
@@ -18,7 +18,9 @@
 
 (defmethod print-method Interceptor
   [^Interceptor i ^java.io.Writer w]
-  (.write w (str "#Interceptor{:name " (.name i) "}")))
+  (.write w (if-let [n (.name i)]
+              (str "#Interceptor{:name " (pr-str n) "}")
+              "#Interceptor{}")))
 
 (defprotocol IntoInterceptor
   (-interceptor [t] "Given a value, produce an Interceptor Record."))


### PR DESCRIPTION
- Avoid `#Interceptor{:name nil}` when `:name` is `nil` (will print `#Interceptor{}`)
- Avoid `#Interceptor{:name a b}` when `:name` is `"a b"` (will print `#Interceptor{:name "a b"}`)