### PR TITLE
io.pedestal.http.jetty: use SslContextFactory$Server

### DIFF
--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -24,7 +24,7 @@
            (org.eclipse.jetty.server.handler AbstractHandler)
            (org.eclipse.jetty.servlet ServletContextHandler ServletHolder)
            (org.eclipse.jetty.util.thread QueuedThreadPool)
-           (org.eclipse.jetty.util.ssl SslContextFactory)
+           (org.eclipse.jetty.util.ssl SslContextFactory SslContextFactory$Server)
            (org.eclipse.jetty.alpn ALPN)
            (org.eclipse.jetty.alpn.server ALPNServerConnectionFactory)
            (org.eclipse.jetty.http2 HTTP2Cipher)
@@ -51,7 +51,7 @@
                     ^String trust-password
                     ^String security-provider
                     client-auth]} options
-            ^SslContextFactory context (SslContextFactory.)]
+            ^SslContextFactory context (SslContextFactory$Server.)]
         (when (every? nil? [keystore key-password truststore trust-password client-auth])
           (throw (IllegalArgumentException. "You are attempting to use SSL, but you did not supply any certificate management (KeyStore/TrustStore/etc.)")))
         (if (string? keystore)


### PR DESCRIPTION
The plain org.eclipse.jetty.util.ssl.SslContextFactory has been
deprecated since Jetty 9.4.16.v20190411 and does not support some more
complicated SSL setups such as when SNI is required or when a
certificate contains multiple SAN with wildcard certificates:

  java.lang.IllegalStateException: KeyStores with multiple certificates
  are not supported on the base class
  org.eclipse.jetty.util.ssl.SslContextFactory. (Use
  org.eclipse.jetty.util.ssl.SslContextFactory$Server or
  org.eclipse.jetty.util.ssl.SslContextFactory$Client instead)

Since Jetty is being used as a HTTPS server, use the appropriate factory
for server SSL contexts instead.