### PR TITLE
Add 4-arity `TraceOrigin/-span` for nils

### DIFF
--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -807,7 +807,8 @@
   (-register [t] nil)
   (-span
     ([t operation-name] nil)
-    ([t operation-name parent] nil))
+    ([t operation-name parent] nil)
+    ([t operation-name parent opts] nil))
   (-activate-span [t span] nil)
   (-active-span [t] nil)
 

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -807,7 +807,7 @@
   (-register [t] nil)
   (-span
     ([t operation-name] nil)
-    ([t opertaion-name parent] nil))
+    ([t operation-name parent] nil))
   (-activate-span [t span] nil)
   (-active-span [t] nil)
 

--- a/service/test/io/pedestal/log_test.clj
+++ b/service/test/io/pedestal/log_test.clj
@@ -16,3 +16,7 @@
     (is (= {:a 1}
            @unwrapped-value))))
 
+(deftest nil-trace-origin
+  (is (nil? (log/-span nil "operation-name")))
+  (is (nil? (log/-span nil "operation-name" nil)))
+  (is (nil? (log/-span nil "operation-name" nil nil))))


### PR DESCRIPTION
Hello there!

This is a small change I hope won't be too controversial (apologies for going straight to code without an issue/discussion beforehand).

While implementing some tracing, I mistakingly passed a nil `io.opentracing.Tracer` to `io.pedestal.log/-span`, and the result was a rather confusing error that looks something like this:

```
Wrong number of args (4) passed to: io.pedestal.log/eval13888/fn--13891
  clojure.lang.AFn throwArity "AFn.java" 429
  clojure.lang.AFn invoke "AFn.java" 44
  io.pedestal.log$eval13733$fn__13745$G__13720__13766 invoke "log.clj" 632
```

I didn't mean to pass a non-existent Tracer, so have fixed that, but I think this missing arity might trip others up.

Hope everyone's doing well out there! :wave: 