### PR TITLE
#696: Remove sync io from go blocks

### DIFF
--- a/samples/jetty-web-sockets/project.clj
+++ b/samples/jetty-web-sockets/project.clj
@@ -15,20 +15,18 @@
   :url "http://pedestal.io/samples/index"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [io.pedestal/pedestal.service "0.5.5"]
-                 [org.clojure/core.async "0.4.474"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [io.pedestal/pedestal.service "0.5.10" :exclusions [org.clojure/core.async
+                                                                     org.clojure/tools.reader
+                                                                     org.clojure/tools.analyzer.jvm]]
+                 [org.clojure/core.async "1.5.648"]
 
-                 ;; Remove this line and uncomment one of the next lines to
-                 ;; use Immutant or Tomcat instead of Jetty:
-                 [io.pedestal/pedestal.jetty "0.5.5"]
-                 ;; [io.pedestal/pedestal.immutant "0.5.5"]
-                 ;; [io.pedestal/pedestal.tomcat "0.5.5"]
+                 [io.pedestal/pedestal.jetty "0.5.10"]
 
-                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.25"]
-                 [org.slf4j/jcl-over-slf4j "1.7.25"]
-                 [org.slf4j/log4j-over-slf4j "1.7.25"]]
+                 [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.35"]
+                 [org.slf4j/jcl-over-slf4j "1.7.35"]
+                 [org.slf4j/log4j-over-slf4j "1.7.35"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :pedantic? :abort


### PR DESCRIPTION
- Deprecate the WebSocketSend protocol
- Remove default implementations of WebSocketSend protocol
- Rewrite `start-ws-connection` in terms of `ws-send-async`
- Conveys exceptions on write in band over the promise channel as per `start-ws-connection-with-fc-support`