### PR TITLE
added missing expand-route to run-dev function to fix NPE

### DIFF
--- a/samples/cors/src/cors/server.clj
+++ b/samples/cors/src/cors/server.clj
@@ -13,6 +13,7 @@
 (ns cors.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [cors.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
               ;; Content Security Policy (CSP) is mostly turned off in dev mode

--- a/samples/hello-world/src/hello_world/server.clj
+++ b/samples/hello-world/src/hello_world/server.clj
@@ -13,6 +13,7 @@
 (ns hello-world.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
             [hello-world.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::http/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::http/routes #(deref #'service/routes)
+              ::http/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::http/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/helloworld-metrics/src/helloworld_metrics/server.clj
+++ b/samples/helloworld-metrics/src/helloworld_metrics/server.clj
@@ -1,6 +1,7 @@
 (ns helloworld-metrics.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [helloworld-metrics.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -17,7 +18,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/http2-conscrypt/src/hp/server.clj
+++ b/samples/http2-conscrypt/src/hp/server.clj
@@ -1,6 +1,7 @@
 (ns hp.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [hp.service :as service])
   (:import (java.security Security)
            (org.conscrypt OpenSSLProvider)))
@@ -22,7 +23,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/http2/src/hp/server.clj
+++ b/samples/http2/src/hp/server.clj
@@ -1,6 +1,7 @@
 (ns hp.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [hp.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -17,7 +18,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/immutant/src/hello_world/server.clj
+++ b/samples/immutant/src/hello_world/server.clj
@@ -13,6 +13,7 @@
 (ns hello-world.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [hello-world.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/jetty-web-sockets/src/jetty_web_sockets/server.clj
+++ b/samples/jetty-web-sockets/src/jetty_web_sockets/server.clj
@@ -1,6 +1,7 @@
 (ns jetty-web-sockets.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [jetty-web-sockets.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -17,7 +18,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/nio/src/nio/server.clj
+++ b/samples/nio/src/nio/server.clj
@@ -13,6 +13,7 @@
 (ns nio.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [nio.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/ring-middleware/src/ring_middleware/server.clj
+++ b/samples/ring-middleware/src/ring_middleware/server.clj
@@ -13,6 +13,7 @@
 (ns ring-middleware.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [ring-middleware.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/server-sent-events/src/server_sent_events/server.clj
+++ b/samples/server-sent-events/src/server_sent_events/server.clj
@@ -13,6 +13,7 @@
 (ns server-sent-events.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [server-sent-events.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/server-with-links/src/server_with_links/server.clj
+++ b/samples/server-with-links/src/server_with_links/server.clj
@@ -13,6 +13,7 @@
 (ns server-with-links.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [server-with-links.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/servlet-filters-gzip/src/gzip/server.clj
+++ b/samples/servlet-filters-gzip/src/gzip/server.clj
@@ -12,6 +12,7 @@
 (ns gzip.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [gzip.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -28,7 +29,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains

--- a/samples/template-server/src/template_server/server.clj
+++ b/samples/template-server/src/template_server/server.clj
@@ -13,6 +13,7 @@
 (ns template-server.server
   (:gen-class) ; for -main method in uberjar
   (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
             [template-server.service :as service]))
 
 ;; This is an adapted service map, that can be started and stopped
@@ -29,7 +30,7 @@
               ::server/join? false
               ;; Routes can be a function that resolve routes,
               ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(deref #'service/routes)
+              ::server/routes #(route/expand-routes (deref #'service/routes))
               ;; all origins are allowed in dev mode
               ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
       ;; Wire up interceptor chains


### PR DESCRIPTION
For some pedestal samples the `run-dev` method in `server.clj` did not call `io.pedestal.http.route/expand-routes` which result in a `NullPointerException` on each request. This problem occurs only in _dev mode_ when starting the example via `(run-dev)`.