### PR TITLE
Bump tajvm, treader and core.async to fix clj11 warnings

### DIFF
--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -16,12 +16,12 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
+                 [org.clojure/core.async "1.5.648" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
 
                  ;; Error interceptor tooling
                  [org.clojure/core.match "0.3.0" :exclusions [[org.clojure/clojurescript]]]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]]
+                 [org.clojure/tools.analyzer.jvm "1.2.2"]]
   :min-lein-version "2.0.0"
   :pedantic? :abort
   :global-vars {*warn-on-reflection* true}

--- a/route/project.clj
+++ b/route/project.clj
@@ -16,7 +16,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
+                 [org.clojure/core.async "1.5.648" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.11-SNAPSHOT"]
                  [org.clojure/core.incubator "0.1.4"]]

--- a/service/project.clj
+++ b/service/project.clj
@@ -32,8 +32,8 @@
                                                       [crypto-equality]]]
 
                  [cheshire "5.9.0"]
-                 [org.clojure/tools.reader "1.3.2"]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]
+                 [org.clojure/tools.reader "1.3.6"]
+                 [org.clojure/tools.analyzer.jvm "1.2.2"]
                  [com.cognitect/transit-clj "0.8.313"]
                  [commons-codec "1.15"]
                  [crypto-random "1.2.0" :exclusions [[commons-codec]]]


### PR DESCRIPTION
Bump tajvm to 1.2.2, treader to 1.3.6 and core.async to 1.5.648 to fix clj11 warnings