### PR TITLE
Bump jetty version to 9.44.v20210927. Fixes #718

### DIFF
--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -18,14 +18,14 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
-                 [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.44.v20210927"]
+                 [org.eclipse.jetty/jetty-server "9.4.48.v20220622"]
+                 [org.eclipse.jetty/jetty-servlet "9.4.48.v20220622"]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server "9.4.44.v20210927"]
-                 [org.eclipse.jetty.http2/http2-server "9.4.44.v20210927"]
-                 [org.eclipse.jetty.websocket/websocket-api "9.4.44.v20210927"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.44.v20210927"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.4.44.v20210927"]
+                 [org.eclipse.jetty/jetty-alpn-server "9.4.48.v20220622"]
+                 [org.eclipse.jetty.http2/http2-server "9.4.48.v20220622"]
+                 [org.eclipse.jetty.websocket/websocket-api "9.4.48.v20220622"]
+                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.48.v20220622"]
+                 [org.eclipse.jetty.websocket/websocket-server "9.4.48.v20220622"]
                  [javax.servlet/javax.servlet-api "3.1.0"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/samples/http2-conscrypt/project.clj
+++ b/samples/http2-conscrypt/project.clj
@@ -28,7 +28,7 @@
                  ;;   Normally, you'd only take the version based on your OS,
                  ;;   but the Uberjar has all shared libs bundled up, which is nice for this example
                  [org.conscrypt/conscrypt-openjdk-uber "1.1.2"]
-                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.10.v20180503"]]
+                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.48.v20220622"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hp.server/run-dev"]}}

--- a/samples/servlet-filters-gzip/project.clj
+++ b/samples/servlet-filters-gzip/project.clj
@@ -21,7 +21,7 @@
                  ;; This samples is specific to jetty, so
                  ;; other options don't appear here.
                  [io.pedestal/pedestal.jetty "0.5.5"]
-                 [org.eclipse.jetty/jetty-servlets "9.4.10.v20180503"]
+                 [org.eclipse.jetty/jetty-servlets "9.4.48.v20220622"]
                  [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.35"]
                  [org.slf4j/jcl-over-slf4j "1.7.35"]

--- a/service/project.clj
+++ b/service/project.clj
@@ -69,11 +69,11 @@
                                   ;; https://github.com/AsyncHttpClient/async-http-client
                                   ;; So benchmarking should be updated to use that.
                                   [com.ning/async-http-client "1.8.13"]
-                                  [org.eclipse.jetty/jetty-servlets "9.4.44.v20210927"]
+                                  [org.eclipse.jetty/jetty-servlets "9.4.48.v20220622"]
                                   [io.pedestal/pedestal.jetty "0.5.11-SNAPSHOT"]
                                   [io.pedestal/pedestal.immutant "0.5.11-SNAPSHOT"]
                                   [io.pedestal/pedestal.tomcat "0.5.11-SNAPSHOT"]
-                                  [javax.servlet/javax.servlet-api "3.1.0"]
+                                  ;;[javax.servlet/javax.servlet-api "3.1.0"]
                                   ;; Logging:
                                   [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
                                   [org.clojure/tools.logging "0.4.0"]


### PR DESCRIPTION
This adresses vulnerabilities described in

- CVE-2022-2047 [1]
- CVE-2022-2191 [2]
- CVE-2022-2048 [3]

[1] https://ossindex.sonatype.org/vulnerability/CVE-2022-2047?component-type=maven&component-name=org.eclipse.jetty%2Fjetty-http&utm_source=dependency-check&utm_medium=integration&utm_content=6.5.1
[2] https://ossindex.sonatype.org/vulnerability/CVE-2022-2191?component-type=maven&component-name=org.eclipse.jetty%2Fjetty-io&utm_source=dependency-check&utm_medium=integration&utm_content=6.5.1
[3] https://ossindex.sonatype.org/vulnerability/CVE-2022-2048?component-type=maven&component-name=org.eclipse.jetty.http2%2Fhttp2-server&utm_source=dependency-check&utm_medium=integration&utm_content=6.5.1