### PR TITLE
Port to jetty 10.x and update deps to latest

### DIFF
--- a/aws/project.clj
+++ b/aws/project.clj
@@ -16,23 +16,25 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [io.pedestal/pedestal.interceptor "0.5.11-SNAPSHOT"]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
                  ;[com.amazonaws.serverless/aws-serverless-java-container-core "0.5.1" :exclusions [[com.fasterxml.jackson.core/jackson-databind]]]
-                 [javax.servlet/javax.servlet-api "3.1.0"]
-                 [com.amazonaws/aws-java-sdk-core "1.11.567" :exclusions [commons-logging]] ;; Needed for x-ray
-                 [com.amazonaws/aws-lambda-java-core "1.2.0"]
+                 [javax.servlet/javax.servlet-api "4.0.1"]
+                 [com.amazonaws/aws-java-sdk-core "1.12.276" :exclusions [commons-logging]] ;; Needed for x-ray
+                 [com.amazonaws/aws-lambda-java-core "1.2.1"]
                  ;[com.amazonaws/aws-lambda-java-events "1.3.0"]
-                 [com.amazonaws/aws-xray-recorder-sdk-core "2.2.1" :exclusions [com.amazonaws/aws-java-sdk-core
+                 [com.amazonaws/aws-xray-recorder-sdk-core "2.11.2" :exclusions [com.amazonaws/aws-java-sdk-core
                                                                                 commons-logging
                                                                                 joda-time]]
                  ;; Deps cleanup
                  [commons-logging "1.2"] ;; A clash between AWS and HTTP Libs
-                 [com.fasterxml.jackson.core/jackson-core "2.9.9"] ;; Bring AWS libs inline with Pedestal Service
-                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.9.9"] ;; Bring AWS libs inline with Pedestal Service
-                 [commons-codec "1.12"] ;; Bring AWS libs inline with Pedestal Service
-                 [joda-time "2.10.2"] ;; Bring AWS libs inline with Pedestal Service
+                 [com.fasterxml.jackson.core/jackson-core "2.13.3"] ;; Bring AWS libs inline with Pedestal Service
+                 [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor "2.13.3" ;; Bring AWS libs inline with Pedestal Service
+                  :exclusions [[com.fasterxml.jackson.core/jackson-annotations]
+                               [com.fasterxml.jackson.core/jackson-databind]]] 
+                 [commons-codec "1.15"] ;; Bring AWS libs inline with Pedestal Service
+                 [joda-time "2.10.14"] ;; Bring AWS libs inline with Pedestal Service
                  ]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}

--- a/immutant/project.clj
+++ b/immutant/project.clj
@@ -15,9 +15,9 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [potemkin "0.4.5"]
-                 [org.jboss.logging/jboss-logging "3.4.1.Final"]
+                 [org.jboss.logging/jboss-logging "3.5.0.Final"]
                  [org.immutant/web "2.1.10" :exclusions  [org.jboss.logging/jboss-logging]]
                  ;; immutant is using outdated wunderboss version which have security issues
                  [org.projectodd.wunderboss/wunderboss-core "0.13.1" :exclusions [io.undertow/undertow-servlet
@@ -25,13 +25,13 @@
                                                                                   ch.qos.logback/logback-classic]]
                  [org.projectodd.wunderboss/wunderboss-clojure "0.13.1"]
                  [org.projectodd.wunderboss/wunderboss-web-undertow "0.13.1"]
-                 [io.undertow/undertow-core "2.2.14.Final"]
-                 [io.undertow/undertow-servlet "2.2.14.Final"]
-                 [io.undertow/undertow-websockets-jsr "2.2.14.Final"]
+                 [io.undertow/undertow-core "2.2.18.Final"]
+                 [io.undertow/undertow-servlet "2.2.18.Final"]
+                 [io.undertow/undertow-websockets-jsr "2.2.18.Final"]
                  ;; immutant is pulling libs with security issues, bump these
-                 [commons-fileupload "1.3.3"]
-                 [commons-io "2.7"]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
+                 [commons-fileupload "1.4"]
+                 [commons-io "2.11.0"]
+                 [javax.servlet/javax.servlet-api "4.0.1"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort

--- a/interceptor/project.clj
+++ b/interceptor/project.clj
@@ -15,13 +15,13 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/core.async "1.5.648" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
 
                  ;; Error interceptor tooling
-                 [org.clojure/core.match "0.3.0" :exclusions [[org.clojure/clojurescript]]]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]]
+                 [org.clojure/core.match "1.0.0" :exclusions [[org.clojure/clojurescript]]]
+                 [org.clojure/tools.analyzer.jvm "1.2.2"]]
   :min-lein-version "2.0.0"
   :pedantic? :abort
   :global-vars {*warn-on-reflection* true}

--- a/jetty/project.clj
+++ b/jetty/project.clj
@@ -16,17 +16,19 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
-                 [org.eclipse.jetty/jetty-server "9.4.48.v20220622"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.48.v20220622"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/core.async "1.5.648"]
+                 [org.slf4j/slf4j-api "1.7.36"]
+                 [io.pedestal/pedestal.log "0.5.10"]
+                 [org.ow2.asm/asm "9.3"]
+                 [org.eclipse.jetty/jetty-server "10.0.11" :exclusions [org.slf4j/slf4j-api]]
+                 [org.eclipse.jetty/jetty-servlet "10.0.11" :exclusions [org.slf4j/slf4j-api]]
                  [org.eclipse.jetty.alpn/alpn-api "1.1.3.v20160715"]
-                 [org.eclipse.jetty/jetty-alpn-server "9.4.48.v20220622"]
-                 [org.eclipse.jetty.http2/http2-server "9.4.48.v20220622"]
-                 [org.eclipse.jetty.websocket/websocket-api "9.4.48.v20220622"]
-                 [org.eclipse.jetty.websocket/websocket-servlet "9.4.48.v20220622"]
-                 [org.eclipse.jetty.websocket/websocket-server "9.4.48.v20220622"]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
+                 [org.eclipse.jetty/jetty-alpn-server "10.0.11" :exclusions [org.slf4j/slf4j-api]]
+                 [org.eclipse.jetty.http2/http2-server "10.0.11" :exclusions [org.slf4j/slf4j-api]]
+                 [org.eclipse.jetty.websocket/websocket-servlet "10.0.11" :exclusions [org.slf4j/slf4j-api]]
+                 [org.eclipse.jetty.websocket/websocket-jetty-server "10.0.11" :exclusions [org.slf4j/slf4j-api]]
+                 [javax.servlet/javax.servlet-api "4.0.1"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort

--- a/jetty/src/io/pedestal/http/jetty/container.clj
+++ b/jetty/src/io/pedestal/http/jetty/container.clj
@@ -13,8 +13,7 @@
   (:require [io.pedestal.http.container :as container]
             [clojure.core.async :as async])
   (:import (java.nio.channels ReadableByteChannel)
-           (java.nio ByteBuffer)
-           (org.eclipse.jetty.server Response)))
+           (java.nio ByteBuffer)))
 
 (extend-protocol container/WriteNIOByteBody
   org.eclipse.jetty.server.Response

--- a/jetty/src/io/pedestal/http/jetty/util.clj
+++ b/jetty/src/io/pedestal/http/jetty/util.clj
@@ -11,12 +11,8 @@
 
 (ns io.pedestal.http.jetty.util
   (:import (java.util EnumSet)
-           (javax.servlet Servlet Filter DispatcherType)
-           (org.eclipse.jetty.servlet ServletContextHandler FilterHolder)
-           (org.eclipse.jetty.server HttpConfiguration
-                                     SecureRequestCustomizer
-                                     ConnectionFactory
-                                     HttpConnectionFactory)))
+           (javax.servlet Filter DispatcherType)
+           (org.eclipse.jetty.servlet ServletContextHandler FilterHolder)))
 
 (def dispatch-types {:forward DispatcherType/FORWARD
                      :include DispatcherType/INCLUDE
@@ -44,7 +40,7 @@
               {:accepted-keywords (keys dispatch-types)
                :attempted dispatches}))))
 
-(defn ^FilterHolder filter-holder [servlet-filter init-params]
+(defn ^FilterHolder filter-holder [^Filter servlet-filter init-params]
   (let [holder (FilterHolder. servlet-filter)]
     (doseq [[k v] init-params]
       (.setInitParameter holder k v))
@@ -68,8 +64,7 @@
     (cond
       (class? servlet-filter) (.addFilter context ^Class servlet-filter ^String path ^EnumSet dispatch-set)
       (instance? FilterHolder servlet-filter) (.addFilter context ^FilterHolder servlet-filter ^String path ^EnumSet dispatch-set)
-      (string? servlet-filter) (.addFilter context ^String servlet-filter ^String path ^EnumSet dispatch-set)
-      :else (.addFilter context servlet-filter path dispatch-set))
+      (string? servlet-filter) (.addFilter context ^String servlet-filter ^String path ^EnumSet dispatch-set))
     context))
 
 (defn ^ServletContextHandler add-server-filters

--- a/log/project.clj
+++ b/log/project.clj
@@ -15,12 +15,12 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  ;; logging
-                 [org.slf4j/slf4j-api "1.7.35"]
+                 [org.slf4j/slf4j-api "1.7.36"]
                  ;; metrics
-                 [io.dropwizard.metrics/metrics-core "4.1.0"]
-                 [io.dropwizard.metrics/metrics-jmx "4.1.0"]
+                 [io.dropwizard.metrics/metrics-core "4.2.11"]
+                 [io.dropwizard.metrics/metrics-jmx "4.2.11"]
                  ;; tracing
                  [io.opentracing/opentracing-api "0.33.0"]
                  [io.opentracing/opentracing-util "0.33.0"]]

--- a/route/project.clj
+++ b/route/project.clj
@@ -15,8 +15,8 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.analyzer.jvm]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/core.async "1.5.648" :exclusions [org.clojure/tools.analyzer.jvm]]
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.11-SNAPSHOT"]
                  [org.clojure/core.incubator "0.1.4"]]

--- a/service-tools/project.clj
+++ b/service-tools/project.clj
@@ -24,12 +24,12 @@
                  [ns-tracker "0.4.0"]
 
                  ;; Logging
-                 [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.35"]
-                 [org.slf4j/jcl-over-slf4j "1.7.35"]
-                 [org.slf4j/log4j-over-slf4j "1.7.35"]
+                 [ch.qos.logback/logback-classic "1.2.11" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.36"]
+                 [org.slf4j/jcl-over-slf4j "1.7.36"]
+                 [org.slf4j/log4j-over-slf4j "1.7.36"]
 
-                 [javax.servlet/javax.servlet-api "3.1.0" :scope "test"]]
+                 [javax.servlet/javax.servlet-api "4.0.1" :scope "test"]]
 
   :aliases {"docs" ["with-profile" "docs" "codox"]}
   :pedantic? :abort

--- a/service/project.clj
+++ b/service/project.clj
@@ -16,31 +16,34 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
 
                  [io.pedestal/pedestal.log "0.5.11-SNAPSHOT"]
                  [io.pedestal/pedestal.interceptor "0.5.11-SNAPSHOT"]
                  [io.pedestal/pedestal.route "0.5.11-SNAPSHOT"]
 
+                 [org.ow2.asm/asm "9.3"]
+
                  ;; channels
                  [org.clojure/core.async "1.5.648" :exclusions [org.clojure/tools.analyzer.jvm]]
 
                  ;; interceptors
-                 [ring/ring-core "1.9.4" :exclusions [[org.clojure/clojure]
+                 [ring/ring-core "1.9.5" :exclusions [[org.clojure/clojure]
                                                       [org.clojure/tools.reader]
                                                       [crypto-random]
                                                       [crypto-equality]]]
 
-                 [cheshire "5.9.0"]
-                 [org.clojure/tools.reader "1.3.2"]
-                 [org.clojure/tools.analyzer.jvm "0.7.2"]
-                 [com.cognitect/transit-clj "0.8.313"]
+                 [cheshire "5.11.0"]
+                 [org.clojure/tools.reader "1.3.6"]
+                 [org.clojure/tools.analyzer.jvm "1.2.2"]
+                 [com.cognitect/transit-clj "1.0.329"]
                  [commons-codec "1.15"]
-                 [crypto-random "1.2.0" :exclusions [[commons-codec]]]
-                 [crypto-equality "1.0.0"]]
+                 [commons-io "2.11.0"]
+                 [crypto-random "1.2.1" :exclusions [[commons-codec]]]
+                 [crypto-equality "1.0.1"]]
   :min-lein-version "2.0.0"
   :java-source-paths ["java"]
-  :javac-options ["-target" "1.8" "-source" "1.8"]
+  :javac-options ["-target" "11" "-source" "11"]
   :jvm-opts ["-D\"clojure.compiler.direct-linking=true\""]
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort
@@ -50,48 +53,41 @@
             "dumbrepl" ["trampoline" "run" "-m" "clojure.main/main"]
             "docs" ["with-profile" "docs" "codox"]}
   :profiles {:default [:dev :provided :user :base]
-             :provided {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
+             :provided {:dependencies [[javax.servlet/javax.servlet-api "4.0.1"]]}
              :dev {:source-paths ["dev" "src" "bench"]
-                   :dependencies [[criterium "0.4.5"]
-                                  [org.clojure/java.classpath "0.3.0"]
-                                  [org.clojure/tools.namespace "0.2.11"]
-                                  ;; TODO: clj-http 3.10.0 is available but
-                                  ;; gzip compression test fails. Even though
-                                  ;; `accept-encoding: gzip, deflate` is set by clj-http
-                                  ;; (in HttpRequest), there is an issue with either
-                                  ;; test setup or response processing (in clj-http).
-                                  ;; This requires further investigation.
-                                  [clj-http "2.0.0" :exclusions [[potemkin]
-                                                                 [clj-tuple]]]
+                   :dependencies [[criterium "0.4.6"]
+                                  [org.clojure/java.classpath "1.0.0"]
+                                  [org.clojure/tools.namespace "1.3.0"]
+                                  [clj-http "3.12.3"]
                                   ;; TODO: While com.ning/async-http-client 1.9.40 is available,
                                   ;; an arity error is encountered when running `lein bench-service`.
                                   ;; Furthermore, the project has been moved to
                                   ;; https://github.com/AsyncHttpClient/async-http-client
                                   ;; So benchmarking should be updated to use that.
-                                  [com.ning/async-http-client "1.8.13"]
-                                  [org.eclipse.jetty/jetty-servlets "9.4.48.v20220622"]
+                                  [com.ning/async-http-client "1.9.40"]
+                                  [org.eclipse.jetty/jetty-servlets "10.0.11" :exclusions [org.slf4j/slf4j-api]]
                                   [io.pedestal/pedestal.jetty "0.5.11-SNAPSHOT"]
                                   [io.pedestal/pedestal.immutant "0.5.11-SNAPSHOT"]
                                   [io.pedestal/pedestal.tomcat "0.5.11-SNAPSHOT"]
-                                  ;;[javax.servlet/javax.servlet-api "3.1.0"]
+                                  [javax.servlet/javax.servlet-api "4.0.1"]
                                   ;; Logging:
-                                  [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
-                                  [org.clojure/tools.logging "0.4.0"]
-                                  [org.slf4j/jul-to-slf4j "1.7.35"]
-                                  [org.slf4j/jcl-over-slf4j "1.7.35"]
-                                  [org.slf4j/log4j-over-slf4j "1.7.35"]
+                                  [ch.qos.logback/logback-classic "1.2.11" :exclusions [org.slf4j/slf4j-api]]
+                                  [org.clojure/tools.logging "1.2.4"]
+                                  [org.slf4j/jul-to-slf4j "1.7.36"]
+                                  [org.slf4j/jcl-over-slf4j "1.7.36"]
+                                  [org.slf4j/log4j-over-slf4j "1.7.36"]
 
                                   ;; only used for route-bench - remove when no longer needed
                                   [incanter/incanter-core "1.9.3"]
                                   [incanter/incanter-charts "1.9.3"]
 
                                   ;; only used for tracing test
-                                  [io.jaegertracing/jaeger-client "1.0.0"]]
+                                  [io.jaegertracing/jaeger-client "1.8.1" :exclusions [org.jetbrains.kotlin/kotlin-stdlib-common]]]
                    :repositories [["sonatype-oss"
                                    "https://oss.sonatype.org/content/groups/public/"]]}
              :docs {:pedantic? :ranges
                     :plugins [[lein-codox "0.9.5"]]
-                    :dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}}
+                    :dependencies [[javax.servlet/javax.servlet-api "4.0.1"]]}}
   ;:jvm-opts ^:replace ["-D\"clojure.compiler.direct-linking=true\""
   ;                     "-d64" "-server"
   ;                     "-Xms1g"                             ;"-Xmx1g"

--- a/service/test/io/pedestal/http/jetty_test.clj
+++ b/service/test/io/pedestal/http/jetty_test.clj
@@ -109,6 +109,14 @@
         (is (= (:status response) 200))
         (is (= (:body response) "Hello World")))))
 
+  (testing "HTTPS server with SNI validation"
+    (with-server hello-world {:port 4347
+                              :container-options {:ssl-port 4348
+                                                  :sni-hostcheck? true
+                                                  :keystore "test/io/pedestal/http/keystore.jks"
+                                                  :key-password "password"}}
+                 (is (thrown? Exception (http/get "https://localhost:4348" {:insecure? true})))))
+
   (testing "HTTPS server with different options"
     (with-server hello-world {:port 4347
                               :container-options {:ssl? true

--- a/tomcat/project.clj
+++ b/tomcat/project.clj
@@ -16,10 +16,10 @@
   :scm "https://github.com/pedestal/pedestal"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.apache.tomcat.embed/tomcat-embed-jasper "9.0.58"]
                  [org.apache.tomcat.embed/tomcat-embed-core "9.0.58"]
-                 [javax.servlet/javax.servlet-api "3.1.0"]]
+                 [javax.servlet/javax.servlet-api "4.0.1"]]
   :min-lein-version "2.0.0"
   :global-vars {*warn-on-reflection* true}
   :pedantic? :abort


### PR DESCRIPTION
We intentionally hold back on tomcat 10.x as there is more porting work than to simply
bump the dependencies up.

It is suggested that if this is merged, the minor version should be bumped before the next release.

Signed-off-by: Greg Haskins <greg@manetu.com>