### PR TITLE
Bump versions for core.async and tools.reader, to avoid Clojure 11 warnings

### DIFF
--- a/interceptor/deps.edn
+++ b/interceptor/deps.edn
@@ -11,13 +11,11 @@
 
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/core.async {:mvn/version "0.4.490"
-                                :exclusions [org.clojure/tools.analyzer.jvm]}
+        org.clojure/core.async {:mvn/version "1.5.648"}
         io.pedestal/pedestal.log {:mvn/version "0.5.11-SNAPSHOT"}
         ;; Error interceptor tooling
         org.clojure/core.match {:mvn/version "0.3.0"
-                                :exclusions [org.clojure/clojurescript]}
-        org.clojure/tools.analyzer.jvm {:mvn/version "0.7.2"}}
+                                :exclusions [org.clojure/clojurescript]}}
  :aliases
  {:local
   {:override-deps {io.pedestal/pedestal.log {:local/root "../log"}}}}}

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -11,8 +11,7 @@
 
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/core.async {:mvn/version "0.4.490"
-                                :exclusions [org.clojure/tools.analyzer.jvm]}
+        org.clojure/core.async {:mvn/version "1.5.648"}
         io.pedestal/pedestal.log {:mvn/version "0.5.11-SNAPSHOT"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.5.11-SNAPSHOT"}
         org.clojure/core.incubator {:mvn/version "0.1.4"}}

--- a/service/deps.edn
+++ b/service/deps.edn
@@ -17,8 +17,7 @@
 
         ;; channels
 
-        org.clojure/core.async {:mvn/version "1.5.648"
-                                :excludions [org.clojure/tools.analyzer.jvm]}
+        org.clojure/core.async {:mvn/version "1.5.648"}
 
         ;; interceptors
 
@@ -28,8 +27,7 @@
                                      crypto-random/crypto-random
                                      crypto-randon/crypto-equality]}
         cheshire/cheshire {:mvn/version "5.9.0"}
-        org.clojure/tools.reader {:mvn/version "1.3.2"}
-        org.clojure/tools.analyzer.jvm {:mvn/version "0.7.2"}
+        org.clojure/tools.reader {:mvn/version "1.3.6"}
         com.cognitect/transit-clj {:mvn/version "0.8.313"}
         commons-codec/commons-codec {:mvn/version "1.15"}
         crypto-random/crypto-random {:mvn/version "1.2.0"


### PR DESCRIPTION
This a deps.edn version of #717 .