### PR TITLE
Fix Pedestal Issue #610

### DIFF
--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -247,7 +247,6 @@
         path-parts (do (log/debug :in :link-str
                                   :path-parts path-parts
                                   :context-path-parts context-path-parts)
-                       ;;(concat context-path-parts path-parts)
                        (cond
                          (and context-path-parts (= "" (first path-parts))) (concat context-path-parts (rest path-parts))
                          context-path-parts (concat context-path-parts path-parts)

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -249,7 +249,7 @@
                                   :context-path-parts context-path-parts)
                        ;;(concat context-path-parts path-parts)
                        (cond
-                         (and context-path-parts (empty? (first path-parts))) (concat context-path-parts (rest path-parts))
+                         (and context-path-parts (= "" (first path-parts))) (concat context-path-parts (rest path-parts))
                          context-path-parts (concat context-path-parts path-parts)
                          :else path-parts))
         _ (when (and (true? strict-path-params?)

--- a/tests/test/io/pedestal/http/route_test.clj
+++ b/tests/test/io/pedestal/http/route_test.clj
@@ -1331,3 +1331,12 @@
           false
           (catch java.lang.AssertionError ae
             true)))))
+
+(deftest url-for-concatenates-context-path-and-route-path-test
+  ;; Also tests a fix for Pedestal Issue 610 where routes whose first segment is a path parameter
+  ;; throw an exception when a context path is supplied.
+  ;; see https://github.com/pedestal/pedestal/issues/610
+
+  (let [routes (route/expand-routes #{["/:a-parameter" :get `home-page]})]
+    (is (= "/some/context/a-value"
+           ((route/url-for-routes routes) ::home-page :params {:a-parameter "a-value"} :context "some/context")))))


### PR DESCRIPTION
https://github.com/pedestal/pedestal/issues/610

`url-for` throws and exception when a context path is supplied and used for a route with a path parameter in the first segment.

The logic appeared to assume that path segments are always strings and was using `empty?` to check for the empty string.  `empty?` expects a sequence.  A keyword is not a sequence, so empty was throwing an exception.