### PR TITLE
Upgrade dependencies to fix CVEs

### DIFF
--- a/aws/deps.edn
+++ b/aws/deps.edn
@@ -18,6 +18,7 @@
         com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.499"}
         com.amazonaws/aws-lambda-java-core {:mvn/version "1.2.2"}
         com.amazonaws/aws-xray-recorder-sdk-core {:mvn/version "2.14.0"}
+        com.amazonaws/aws-java-sdk-xray {:mvn/version "1.12.560"}
 
         ;; Bring AWS libs inline with Pedestal Service
         com.fasterxml.jackson.core/jackson-core {:mvn/version "2.15.2"}

--- a/jetty/deps.edn
+++ b/jetty/deps.edn
@@ -13,14 +13,14 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         io.pedestal/pedestal.log {:mvn/version "0.6.0"}
         io.pedestal/pedestal.service {:mvn/version "0.6.0"}
-        org.eclipse.jetty/jetty-server {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty/jetty-server {:mvn/version "9.4.52.v20230823"}
+        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.52.v20230823"}
         org.eclipse.jetty.alpn/alpn-api {:mvn/version "1.1.3.v20160715"}
-        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.51.v20230217"}
-        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.52.v20230823"}
+        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.52.v20230823"}
+        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.52.v20230823"}
+        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.52.v20230823"}
+        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.52.v20230823"}
         javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}
  :aliases
  {:local

--- a/nvd_suppressions.xml
+++ b/nvd_suppressions.xml
@@ -4,29 +4,7 @@
   <!-- Feel free to tweak it, version-control it and remove any comment. -->
   <!-- You can find suppression examples in https://jeremylong.github.io/DependencyCheck/general/suppression.html -->
   <!-- We're suppressing these as there are no replacements.  It's a ticking time bomb that will eventually fail builds. -->
-  <suppress until="2023-01-01">
-    <notes><![CDATA[
-   file name: jackson-databind-2.15.2.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <cve>CVE-2023-35116</cve>
-  </suppress>
-  <suppress until="2023-09-01">
-    <notes><![CDATA[
-   file name: aws-java-sdk-xray-1.12.228.jar
-   ]]></notes>
-      <packageUrl regex="true">^pkg:maven/com\.amazonaws/aws\-java\-sdk\-xray@.*$</packageUrl>
-      <cve>CVE-2022-31159</cve>
-  </suppress>
-    <suppress until="2023-09-01">
-        <notes><![CDATA[
-   file name: jmespath-java-1.12.228.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.amazonaws/jmespath\-java@.*$</packageUrl>
-        <cve>CVE-2022-31159</cve>
-    </suppress>
-    <!-- This one is disputed as well. -->
-    <suppress until="2023-09-01">
+    <suppress until="2024-01-01">
         <notes><![CDATA[
    file name: jackson-databind-2.15.2.jar
    ]]></notes>

--- a/samples/http2-conscrypt/project.clj
+++ b/samples/http2-conscrypt/project.clj
@@ -28,7 +28,7 @@
                  ;;   Normally, you'd only take the version based on your OS,
                  ;;   but the Uberjar has all shared libs bundled up, which is nice for this example
                  [org.conscrypt/conscrypt-openjdk-uber "2.5.2"]
-                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.51.v20230217"]]
+                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.52.v20230823"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hp.server/run-dev"]}}

--- a/samples/servlet-filters-gzip/project.clj
+++ b/samples/servlet-filters-gzip/project.clj
@@ -21,8 +21,8 @@
                  ;; This samples is specific to jetty, so
                  ;; other options don't appear here.
                  [io.pedestal/pedestal.jetty "0.5.9"]
-                 [org.eclipse.jetty/jetty-servlets "9.4.51.v20230217"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.51.v20230217"]
+                 [org.eclipse.jetty/jetty-servlets "9.4.10.v20180503"]
+                 [org.eclipse.jetty/jetty-servlet "9.4.52.v20230823"]
                  [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.35"]
                  [org.slf4j/jcl-over-slf4j "1.7.35"]

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -33,7 +33,7 @@
         ;; https://github.com/AsyncHttpClient/async-http-client
         ;; So benchmarking should be updated to use that.
         com.ning/async-http-client {:mvn/version "1.8.13"}
-        org.eclipse.jetty/jetty-servlets {:mvn/version "9.4.51.v20230217"}
+        org.eclipse.jetty/jetty-servlets {:mvn/version "9.4.52.v20230823"}
 
         ;; Include *all* the other modules
         io.pedestal/pedestal.log {:local/root "../log"}

--- a/tomcat/deps.edn
+++ b/tomcat/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
 
-        org.apache.tomcat.embed/tomcat-embed-jasper {:mvn/version "9.0.76"}
-        org.apache.tomcat.embed/tomcat-embed-core {:mvn/version "9.0.76"}
+        org.apache.tomcat.embed/tomcat-embed-jasper {:mvn/version "9.0.80"}
+        org.apache.tomcat.embed/tomcat-embed-core {:mvn/version "9.0.80"}
 
         javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}
  :aliases


### PR DESCRIPTION
Upgrade dependencies to fix CVEs: 

- aws-java-sdk-xray
- jetty (various)
- tomcat-embed-jasper & tomcat-embed-core

Fixes https://github.com/pedestal/pedestal/issues/758