### PR TITLE
Add new publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: Publish pedestal.io
+on:
+  push:
+    branches:
+      - master
+      # And, eventually, maint branches
+
+jobs:
+  notify-pedestal-io:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        repository: pedestal/pedestal-docs
+        token: $${ secrets.PUBLISH_PEDESTAL_IO_PAT }}
+        event-type: pedestal_master_commit


### PR DESCRIPTION
This uses a personal access token to publish an event to the pedestal/pedestal.io repository, causing it (If this all works properly) to re-publish the pedestal.io site.