### PR TITLE
Point api docs to the 0.7 subdir

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -15,5 +15,5 @@ asciidoc:
     component_home: "https://github.com/stuartsierra/component/"
     # For api: inline macro
     default_api_ns: io.pedestal.http@  # @ signals it can be overridden by pages
-    api_doc_root: http://pedestal.io/api
+    api_doc_root: http://pedestal.io/api/0.7
 


### PR DESCRIPTION
This points documentation to api/0.7 (I recently updated pedestal-docs to generate API docs to a sub-dir based on the major.minor version in the VERSION.txt file).

This will allow the eventual 0.6 docs to point to api/0.6.