### PR TITLE
Add clj-kondo linting configuration for `interceptor.error/error-dispatch` and `log/<level>` macros

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,4 @@
-; Copyright 2022 Cognitect, Inc.
+; Copyright 2024 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,12 @@
+; Copyright 2022 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+{:config-paths ["clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor"]}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp/
 .*.swo
 *.tmp
 *.bak
+.clj-kondo/.cache/
 
 # Editors (IntelliJ / Eclipse)
 */.idea

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/config.edn
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/config.edn
@@ -1,4 +1,4 @@
-; Copyright 2022 Cognitect, Inc.
+; Copyright 2024 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/config.edn
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/config.edn
@@ -1,0 +1,14 @@
+; Copyright 2022 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+{:hooks {:analyze-call
+         {io.pedestal.interceptor.error/error-dispatch
+          hooks.io.pedestal.interceptor.error/error-dispatch}}}

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/hooks/io/pedestal/interceptor/error.clj_kondo
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/hooks/io/pedestal/interceptor/error.clj_kondo
@@ -1,4 +1,4 @@
-; Copyright 2022 Cognitect, Inc.
+; Copyright 2024 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/hooks/io/pedestal/interceptor/error.clj_kondo
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor/hooks/io/pedestal/interceptor/error.clj_kondo
@@ -1,0 +1,26 @@
+; Copyright 2022 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns hooks.io.pedestal.interceptor.error
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn error-dispatch
+  "Expands (error-dispatch [ctx ex] match-forms)
+  to (fn [ctx ex] (case [ctx ex] match-forms)) keeping spirit of
+  error-dispatch per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & match-forms] (rest (:children node))]
+    (when-not (= 2 (count (:children binding-vec)))
+      (throw (ex-info "error-dispatch only takes ctx and ex." {})))
+    {:node (api/list-node [(api/token-node 'fn)
+                           binding-vec
+                           (api/list-node (concat [(api/token-node 'case) binding-vec]
+                                                  match-forms))])}))

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/config.edn
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/config.edn
@@ -1,4 +1,4 @@
-; Copyright 2022 Cognitect, Inc.
+; Copyright 2024 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/config.edn
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/config.edn
@@ -9,5 +9,10 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-{:config-paths ["clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.interceptor"
-                "clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log"]}
+{:hooks
+ {:analyze-call
+  {io.pedestal.log/trace hooks.io.pedestal.log/log-expr
+   io.pedestal.log/debug hooks.io.pedestal.log/log-expr
+   io.pedestal.log/info  hooks.io.pedestal.log/log-expr
+   io.pedestal.log/warn  hooks.io.pedestal.log/log-expr
+   io.pedestal.log/error hooks.io.pedestal.log/log-expr}}}

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/hooks/io/pedestal/log.clj_kondo
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/hooks/io/pedestal/log.clj_kondo
@@ -1,4 +1,4 @@
-; Copyright 2022 Cognitect, Inc.
+; Copyright 2024 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/hooks/io/pedestal/log.clj_kondo
+++ b/clj-kondo-resources/clj-kondo.exports/io.pedestal/pedestal.log/hooks/io/pedestal/log.clj_kondo
@@ -1,0 +1,26 @@
+; Copyright 2022 Cognitect, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns hooks.io.pedestal.log
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn log-expr
+  "Expands (log-expr :a :A :b :B ... )
+  to (hash-map :a :A :b :B ... ) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[k v & _kvs] (rest (:children node))]
+    (when-not (and k v)
+      (throw (ex-info "No kv pair provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'hash-map)
+                     (rest (:children node))))]
+      {:node (vary-meta new-node assoc :clj-kondo/ignore [:unused-value])})))


### PR DESCRIPTION
This commit adds a `clj-kondo.exports` folder as explained in `clj-kondo` documentation. Ideally, if this is bundled into the jar when library versions are cut, then users will be able to import the config in their own projects[^1]. This commit shows the example layout of the config, but more work needs to be done to bundle this into `resources` available in the final jars.

We use the `:analyze-call` hook[^2] to rewrite the call to `error-dispatch` as an anonymous function with a `case` statement. This matches the spirit of the macro-expansion and works for linting purposes.

Related to: #780

[^1]: Exporting and importing clj-kondo configuration: https://github.com/clj-kondo/clj-kondo/blob/be6efa075a0a2b903ab220ce7c7e61a242bd9126/doc/config.md#exporting-and-importing-configuration 
[^2]: An explanation of the `:analyze-call` hook:
https://github.com/clj-kondo/clj-kondo/blob/be6efa075a0a2b903ab220ce7c7e61a242bd9126/doc/hooks.md#analyze-call