### PR TITLE
Add implemention of MetricSource SPI for DropWizard/Codahale MetricRegistry

### DIFF
--- a/log/deps.edn
+++ b/log/deps.edn
@@ -14,6 +14,8 @@
         ;; logging
         org.slf4j/slf4j-api {:mvn/version "2.0.7"}
         ;; metrics
+        io.pedestal/pedestal-metrics {:local/root "../metrics"}
+        #_ {:mvn/version "TBD"}
         io.dropwizard.metrics/metrics-core {:mvn/version "4.2.19"}
         io.dropwizard.metrics/metrics-jmx {:mvn/version "4.2.19"}
         ;; tracing

--- a/log/src/io/pedestal/metrics/codahale.clj
+++ b/log/src/io/pedestal/metrics/codahale.clj
@@ -1,0 +1,117 @@
+; Copyright 2023 NuBank NA
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.metrics.codahale
+  "Extends the [[MetricSource]] SPI to the Codahale metrics library supplied by DropWizard.
+
+   Note that Codahale metrics do not have an equivalent concept to tags, so any tags
+   are ignored.
+
+   This exists to make it possible to continue using Codahale metrics (the standard through Pedestal 0.6) with Pedestal 0.7."
+  {:since      "0.7.0"
+   :deprecated "0.7.0"}
+  (:require [io.pedestal.metrics.spi :as spi])
+  (:import (com.codahale.metrics Counter Gauge MetricRegistry Timer)
+           (io.pedestal.metrics.spi MetricSource)))
+
+(defprotocol MetricRegistrySource
+
+  (metric-registry ^MetricRegistry [source]
+    "Returns the underlying MetricRegistry from a MetricSource.
+
+    This is primarily intended for tests."))
+
+(defn- prepare-metric-name [n]
+  (cond
+    (string? n) n
+    (keyword? n) (subs (str n) 1)
+    (symbol? n) (str n)
+
+    :else
+    (throw (ex-info (str "Invalid metric name: " n)
+                    {:metric-name n}))))
+(defn- create-counter
+  [^MetricRegistry registry metric-name]
+  (let [counter (.counter registry (prepare-metric-name metric-name))]
+    (fn
+      ([] (.inc counter))
+      ([n] (.inc counter (long n))))))
+
+(defn- create-gauge
+  [^MetricRegistry registry metric-name value-fn]
+  (let [gauge (reify Gauge
+                (getValue [_]
+                  (value-fn)))]
+    (.register registry (prepare-metric-name metric-name) gauge)
+    nil))
+
+(defn- create-timer
+  [^MetricRegistry registry metric-name]
+  (let [timer (.timer registry (prepare-metric-name metric-name))]
+    (fn start-timer []
+      (let [context (.time timer)
+            *first?     (atom true)]
+        (fn stop-timer []
+          ;; Only the first call to the stop timer fn does anything, extra calls are ignored.
+          ;; Needed? This is more than the underlying API does!
+          (when (compare-and-set! *first? true false)
+            (.stop context)))))))
+
+(defn- write-to-cache
+  [*cache k v]
+  (swap! *cache assoc k v)
+  v)
+
+(defn- default-time-source
+  []
+  (System/nanoTime))
+
+(defn ^MetricSource wrap-registry
+  [^MetricRegistry registry]
+  (let [*counters (atom {})
+        *gauges   (atom #{})
+        *timers   (atom {})]
+    (reify
+
+      MetricRegistrySource
+      (metric-registry [_] registry)
+
+      spi/MetricSource
+
+      (counter [_ metric-name _tags]
+        (or (get @*counters metric-name)
+            (write-to-cache *counters metric-name (create-counter registry metric-name))))
+
+      (gauge [_ metric-name _tags value-fn]
+        (when-not (contains? @*gauges metric-name)
+          (create-gauge registry metric-name value-fn)
+          (swap! *gauges conj metric-name))
+        nil)
+
+      (timer [_ metric-name _tags]
+        (or (get @*timers metric-name)
+            (write-to-cache *timers metric-name (create-timer registry metric-name)))))))
+
+(defn get-counter
+  ^Counter [source metric-name]
+  (.counter (metric-registry source) (prepare-metric-name metric-name)))
+
+(defn get-gauge
+  ^Gauge [source metric-name]
+  (.gauge (metric-registry source) (prepare-metric-name metric-name)))
+
+(defn get-timer
+  ^Timer [source metric-name]
+  (.timer (metric-registry source) (prepare-metric-name metric-name)))
+
+(defn default-registry
+  ^MetricRegistry []
+  (MetricRegistry.))

--- a/tests/test/io/pedestal/metrics/codahale_test.clj
+++ b/tests/test/io/pedestal/metrics/codahale_test.clj
@@ -1,0 +1,117 @@
+(ns io.pedestal.metrics.codahale-test
+  (:require [io.pedestal.metrics :as metrics]
+            [io.pedestal.metrics.codahale :as c]
+            [clojure.test :refer [deftest is use-fixtures]]))
+
+(defn registry-fixture
+  [f]
+  (reset! *now (System/nanoTime))
+  (try
+    (binding [metrics/*default-metric-source* (c/wrap-registry (c/default-registry))]
+      (f))))
+
+(use-fixtures :each registry-fixture)
+
+(defn- get-counter
+  [metric-name]
+  (c/get-counter metrics/*default-metric-source* metric-name))
+
+(defn- get-gauge
+  [metric-name]
+  (c/get-gauge metrics/*default-metric-source* metric-name))
+
+(defn- get-timer
+  [metric-name]
+  (c/get-timer metrics/*default-metric-source* metric-name))
+
+(deftest counter-by-keyword-and-string-name-are-the-same
+  (let [metric-name "foo.bar.baz"
+        f1          (metrics/counter (keyword metric-name) nil)
+        f2          (metrics/counter metric-name nil)
+        counter     (get-counter metric-name)]
+    (is (= 0 (.getCount counter)))
+
+    (f1)
+
+    (is (= 1 (.getCount counter)))
+
+    (f2 5.0)
+
+    (is (= 6 (.getCount counter)))))
+
+(deftest gauge-monitor
+  (let [*monitored  (atom [])
+        value-fn    #(count @*monitored)
+        metric-name ::gauge
+        _           (metrics/gauge metric-name nil value-fn)
+        gauge       (get-gauge metric-name)]
+
+    (is (= 0 (.getValue gauge)))
+
+    (swap! *monitored conj 0)
+
+    (is (= 1 (.getValue gauge)))
+
+    (swap! *monitored conj 1 2 3)
+
+    (is (= 4 (.getValue gauge)))))
+
+(deftest duplicate-gauge-ignored
+  (let [*monitored  (atom [])
+        value-fn    #(count @*monitored)
+        metric-name ::gauge
+        _           (metrics/gauge metric-name nil value-fn)
+        gauge       (get-gauge metric-name)]
+
+    (is (= 0 (.getValue gauge)))
+
+    (swap! *monitored conj 0)
+
+    (is (= 1 (.getValue gauge)))
+
+    (metrics/gauge metric-name nil (constantly 9999))
+
+    (is (= 1 (.getValue gauge)))
+
+    (swap! *monitored conj 1 2 3)
+
+    (is (= 4 (.getValue gauge)))))
+
+(deftest timer
+  (let [metric-name ::db-read
+        timer-fn    (metrics/timer metric-name nil)
+        timer       (get-timer metric-name)
+        stop-fn     (timer-fn)]
+    (swap! *now + 15e8)
+    (stop-fn)
+
+    (is (= 1 (.getCount timer)))
+
+    ;; It's idempotent - this is an assurance added by io.pedestal.metrics.micrometer.
+
+    (stop-fn)
+
+    ;; Only check the count, because the observed values are inside a histogram.
+
+    (is (= 1 (.getCount timer)))))
+
+
+(deftest parallel-timers
+  (let [metric-name ::db-read
+        timer-fn    (metrics/timer metric-name nil)
+        timer       (get-timer metric-name)
+        ;; Both start at the "same" time
+        stop-fn-1   (timer-fn)
+        stop-fn-2   (timer-fn)]
+    (swap! *now + 15e8)
+    (stop-fn-1)
+
+    (let [after-fn1 (-> timer .getSnapshot .getMax)]
+      (swap! *now + 25e8)
+
+      (stop-fn-2)
+
+      (is (= 2 (.getCount timer)))
+
+      (is (< after-fn1 (-> timer .getSnapshot .getMax))
+          "The timer has tracked additional time"))))

--- a/tests/test/io/pedestal/metrics/codahale_test.clj
+++ b/tests/test/io/pedestal/metrics/codahale_test.clj
@@ -5,7 +5,6 @@
 
 (defn registry-fixture
   [f]
-  (reset! *now (System/nanoTime))
   (try
     (binding [metrics/*default-metric-source* (c/wrap-registry (c/default-registry))]
       (f))))
@@ -82,7 +81,6 @@
         timer-fn    (metrics/timer metric-name nil)
         timer       (get-timer metric-name)
         stop-fn     (timer-fn)]
-    (swap! *now + 15e8)
     (stop-fn)
 
     (is (= 1 (.getCount timer)))
@@ -103,12 +101,9 @@
         ;; Both start at the "same" time
         stop-fn-1   (timer-fn)
         stop-fn-2   (timer-fn)]
-    (swap! *now + 15e8)
     (stop-fn-1)
 
     (let [after-fn1 (-> timer .getSnapshot .getMax)]
-      (swap! *now + 25e8)
-
       (stop-fn-2)
 
       (is (= 2 (.getCount timer)))


### PR DESCRIPTION
This is a follow-on to #783 that provides a way to use the new io.pedestal.metrics namespace with DropWizard/Codahale metrics, as a transition path for people upgrading to Pedestal 0.7 with an investment in the old metrics.