### PR TITLE
Allow global override of event map formatter

### DIFF
--- a/docs/modules/reference/pages/logging.adoc
+++ b/docs/modules/reference/pages/logging.adoc
@@ -10,7 +10,7 @@ https://www.slf4j.org[Simple Logging Facade for Java].
 This facade is an abstraction over several different libraries used for logging, such
 as https://logback.qos.ch/[Logback],
 https://logging.apache.org/log4j/2.x/[Apache Log4j]
-or built-in java.util.logging packages.
+or the built-in java.util.logging packages.
 
 As part of your application's dependencies, you can include an adapter to your preferred
 logging library (see the
@@ -47,15 +47,16 @@ api:info[],
 api:warn[],
 and
 api:error[].
-These macros are responsible for obtaining an api:LoggerSource[] instance based on the
-namespace name (unless overridden) and converting the passed keys and values into a Clojure map, which is printed to a string and logged as the event body.
+These macros are responsible for obtaining a api:LoggerSource[] instance based on the
+namespace name (unless overridden) and converting the passed keys and values into a Clojure map, which is printed to a string and logged as the event message.
 
 Added to the map is the extra key, :line, which identifies the line number in the source.
 
 Bear in mind that often, Java libraries do their own logging, and that logging will not be formatted
 as Clojure maps.
 
-It is common for loggers to add an :in key, whose value is symbol identifying the function
+It is common for loggers to add an :in key, whose value is symbol identifying the function containing
+the logging call.
 
 Example:
 
@@ -104,12 +105,12 @@ instance of java.lang.Exception.
 
 | :io.pedestal.log/logger
 | The logger instance to use, rather than the default. The logger must
-  extend the api:LoggerSource[] protocol.
+  satisfy the api:LoggerSource[] protocol.
   The default is a logger with name matching the namespace.
 
 | :io.pedestal.log/formatter
 | A function that can be passed an event map and return a string used when logging (the underlying logging
-  APIs expect a string message).  The default is clj:pr-str[].
+  APIs expect a string message).  The default is clj:pr-str[] (via api:default-formatter[]).
 |===
 
 == spy macro
@@ -118,7 +119,36 @@ The api:spy[] macro takes an expression, evaluates it, and returns it.  Before r
 (as key :spy) and the result (as key :value) at debug level. This is often useful during
 REPL-driven development.
 
-== Mapped Diagnostic Context
+== Overriding the LoggerSource
+
+The logging functionality is itself pluggable; what Pedestal supplies out of the box is an adapter
+for SLF4J in the form of a api:LoggerSource[] protocol, extended onto SLF4J's
+`org.slf4j.Logger` interface.
+
+If you wish to use pedestal-log with a different logging library, you may specify an override
+for the logger source; this is a function that is passed a logger name string, and returns
+an instance that extends api:LoggerSource[].
+
+The override can be specified as the fully qualified name of a Clojure function, either
+via system property `io.pedestal.log.overrideLogger` or by environment variable `PEDESTAL_LOGGER`.
+
+== Overriding the default event formatter
+
+By default, log event data is formatted to a string using `pr-str` (this default is
+provided by api:default-formatter[]), before being passed
+(via the methods of the api:LoggerSource[] protocol) to the underlying logging implementation.
+
+However, this can be overridden, which is useful for:
+
+- Identifying and removing or redacting personal data that should not be logged
+- Formatting the log output in a particular way, such as formatting as JSON rather than EDN
+
+The system property `io.pedestal.log.formatter`, or environment  variable `PEDESTAL_LOG_FORMATTER`,
+can specify a fully qualified function name; this function is passed the event map and returns a string,
+and will be used instead of `pr-str` as the default when the :io.pedestal.log/formatter key is not provided.
+
+
+== Mapped Diagnostic Context (SLF4J)
 
 The https://logback.qos.ch/manual/mdc.html[MDC] is a feature of SLF4J that is mapped onto different logging implementations, just like
 the Logger. An SLF4J MDC is essentially a map of string keys and string values stored as per-thread global state.
@@ -135,7 +165,7 @@ The default behavior is for the Pedestal MDC map to be formatted (as with an eve
 stored into the MDC using the key "io.pedestal". Thus the pattern `%X{io.pedestal}` will print
 out that Pedestal MDC.
 
-The macros api:with-context[] and api:with-context-kv[] allow values to bound to the Pedestal MDC, which are then copied into the "io.pedestal" key of the SLF4J MDC; at the end of the block,
+The macro api:with-context[] and allows values to bound to the Pedestal MDC, which are then copied into the "io.pedestal" key of the SLF4J MDC; at the end of the block,
 the prior state of the SLF4J and Pedestal MDCs are restored.
 
 [WARNING]
@@ -145,7 +175,7 @@ is stored per-thread, and there isn't an easy way to copy its value over to arbi
 ====
 
 
-.Special Keys used with `with-context` and `with-context-kv`
+.Special Keys used with `with-context`
 |===
 | Key | Value
 
@@ -154,7 +184,7 @@ is stored per-thread, and there isn't an easy way to copy its value over to arbi
 
 | :io.pedestal.log/formatter
 | A function that can be passed an MDC map and return a string used when setting the `io.pedestal`
-key of the SLF4J MDC.  The default is clj:pr-str[].
+key of the SLF4J MDC.  The default is clj:pr-str[] via api:default-formatter[].
 |===
 
 

--- a/log/src/io/pedestal/internal.clj
+++ b/log/src/io/pedestal/internal.clj
@@ -9,8 +9,9 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(ns  ^:no-doc io.pedestal.internal
-  "Internal utilities, not for reuse, subject to change at any time.")
+(ns ^:no-doc io.pedestal.internal
+  "Internal utilities, not for reuse, subject to change at any time."
+  (:require [clojure.string :as str]))
 
 (defn vec-conj
   [v value]
@@ -19,3 +20,33 @@
 (defn into-vec
   [v coll]
   (into (or v []) coll))
+
+(defn println-err [& s]
+  (binding [*out* *err*]
+    (apply println s)))
+
+(defn resolve-var-from
+  [property-name env-var]
+  (let [resolver (fn [from-source from-name s]
+                   (when s
+                     (try
+                       (let [slashx     (str/index-of s "/")
+                             ns-str     (when slashx
+                                          (subs s 0 slashx))
+                             symbol-str (if slashx
+                                          (subs s (inc slashx))
+                                          s)
+                             sym        (symbol ns-str symbol-str)
+                             v          (requiring-resolve sym)]
+                         (if v
+                           @v
+                           (println-err (format "WARNING: Symbol %s (from %s %s) does not exist"
+                                                s
+                                                from-source from-name))))
+                       (catch Exception e
+                         (println-err (format "ERROR: Could not resolve symbol %s (from %s %s): %s"
+                                              s
+                                              from-source from-name
+                                              (ex-message e)))))))]
+    (or (resolver "JVM property" property-name (System/getProperty property-name))
+        (resolver "environment variable" env-var (System/getenv property-name)))))

--- a/log/src/io/pedestal/internal.clj
+++ b/log/src/io/pedestal/internal.clj
@@ -49,6 +49,5 @@
 
 (defn resolve-var-from
   [property-name env-var]
-  (let [resolver]
-    (or (resolver "JVM property" property-name (System/getProperty property-name))
-        (resolver "environment variable" env-var (System/getenv env-var)))))
+  (or (resolver "JVM property" property-name (System/getProperty property-name))
+      (resolver "environment variable" env-var (System/getenv env-var))))

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -1,3 +1,4 @@
+; Copyright 2021-2023 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2018 Cognitect, Inc.
 
@@ -11,12 +12,11 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns io.pedestal.log
-  "Logging via slf4j. Each logging level is a macro: trace, debug,
-  info, warn, and error. Each namespace gets its own Logger. Arguments
-  are key-value pairs, which will be printed as with 'pr'. The special
-  key :exception should have a java.lang.Throwable as its value, and
-  will be passed separately to the underlying logging API.
-  One can override the logger via JVM or ENVAR settings."
+  "A logging wrapper around SLF4J (but adapatable to other logging systems).
+  Primary macros are [[trace]], [[debug]], [[info]], [[warn]], and [[error]].
+
+  Over time, this namespace has also accumulated other visibility-related functionality,
+  including metrics (via the Codahale library) and telemetry (via OpenTelemetry)."
   (:require [clojure.string :as string]
             [io.pedestal.internal :as i])
   (:import (org.slf4j Logger
@@ -27,18 +27,25 @@
                                  Gauge Counter Histogram Meter
                                  Slf4jReporter)
            (com.codahale.metrics.jmx JmxReporter)
-           (io.opentracing Scope
-                           Span
-                           SpanContext
-                           Tracer
-                           Tracer$SpanBuilder)
-           io.opentracing.log.Fields
+           (io.opentracing Span SpanContext Tracer Tracer$SpanBuilder)
            (io.opentracing.util GlobalTracer)
            (java.util Map)
            (java.util.concurrent TimeUnit)
            (clojure.lang IFn)))
 
 (defprotocol LoggerSource
+
+  "Adapts an underlying logger (such as defined by SLF4J) to io.pedestal.log.
+
+   For -trace, -debug, etc., the body will typically be a String, formatted from
+   the event map; if you write code that directly invokes these methods,
+   but use the io.pedestal.log implementation of LoggerSource for SLF4J, then
+   Strings will pass through unchanged, but other Clojure types will be converted to strings
+   via `pr-str`.
+
+   If you write your own LoggerSource, you understand the same requirements: io.pedestal.log's
+   macros will only supply a String body, but other code may pass other types."
+
   (-level-enabled? [t level-key]
                    "Given the log level as a keyword,
                    return a boolean if that log level is currently enabled.")
@@ -187,42 +194,40 @@
   (-clear-mdc [t] nil)
   (-set-mdc [t m] nil))
 
-;; Override the logger
-;; ---------------------
-;; Pedestal's logging is backed by a protocol, which you are free to extend
-;; for your own system.
-;; Per logging message, you can substitute in your own logger and bypass SLF4J,
-;; using the :io.pedestal.log/logger key.
-;; You can also override the logger for an entire application by setting the
-;; JVM Property 'io.pedestal.log.overrideLogger' or ENVAR 'PEDESTAL_LOGGER'
-;; to a symbol that resolves to a single-arity function
-;; (passed a string logger tag, the NS string of the log call).
-;; This function should return something that satisfies the LoggerSource protocol.
-;; The function will be called multiple times (as the logging macros are expanded).
-
-(def override-logger (try
-                       (some-> (or (System/getProperty "io.pedestal.log.overrideLogger")
-                                     (System/getenv "PEDESTAL_LOGGER"))
-                                 symbol
-                                 resolve)
-                       (catch java.lang.RuntimeException e
-                         nil)))
+(def override-logger
+  "Override of the default logger source, from symbol property io.pedestal.log.overrideLogger
+  or environment variable PEDESTAL_LOGGER."
+  (i/resolve-var-from "io.pedestal.log.overrideLogger" "PEDESTAL_LOGGER"))
 
 (def ^:private override-logger-delay
   "Improves the ergonomics of overriding logging by delaying
-  override logger resolution while maintaining backwards compatibility."
+  override logger resolution while maintaining backwards compatibility.
+
+  This replaces override-logger, as it allows runtime setting of the property, rather
+  than being locked into the property name when the namespace is first loaded."
   (delay (or override-logger
-             (some-> (or (System/getProperty "io.pedestal.log.overrideLogger")
-                         (System/getenv "PEDESTAL_LOGGER"))
-                     symbol
-                     requiring-resolve))))
+             (i/resolve-var-from "io.pedestal.log.overrideLogger" "PEDESTAL_LOGGER"))))
 
 (defn make-logger
   "Returns a logger which satisfies the LoggerSource protocol."
   [^String logger-name]
-  (or (let [override-logger @override-logger-delay]
-        (and override-logger (override-logger logger-name)))
-        (LoggerFactory/getLogger logger-name)))
+  (or (when-let [override-logger @override-logger-delay]
+        (override-logger logger-name))
+      (LoggerFactory/getLogger logger-name)))
+
+(def ^:private *default-formatter
+  (delay
+    (or (i/resolve-var-from "io.pedestal.log.formatter" "PEDESTAL_LOG_FORMATTER")
+        pr-str)))
+
+(defn default-formatter
+  "Returns the default formatter (used to convert the event map to a string) used when the
+  :io.pedestal.log/formatter key is not present in the log event.  The default is `pr-str`, but
+  can be overridden via JVM property io.pedestal.log.formatter or
+  environment variable PEDESTAL_LOG_FORMATTER."
+  {:since "0.7.0"}
+  []
+  @*default-formatter)
 
 (def log-level-dispatch
   {:trace -trace
@@ -273,9 +278,9 @@
                          ^String (name (ns-name *ns*)))
          logger (or (::logger keyvals-map)
                     (make-logger logger-name))]
-     (when (io.pedestal.log/-level-enabled? logger level)
+     (when (-level-enabled? logger level)
        (let [exception (:exception keyvals-map)
-             formatter (::formatter keyvals-map pr-str)
+             formatter (or (::formatter keyvals-map) (default-formatter))
              ;; You/Users have full control over binding *print-length*, use it wisely please
              msg (formatter (dissoc keyvals-map
                                     :exception ::logger ::logger-name ::formatter :level))
@@ -292,13 +297,16 @@
         exception' (:exception keyvals-map)
         logger' (gensym "logger")  ; for nested syntax-quote
         string' (gensym "string")
-        log-method' (symbol (str "io.pedestal.log/-" (name level)))
-        formatter (::formatter keyvals-map pr-str)]
+        log-method' (symbol "io.pedestal.log" (str "-" (name level)))
+        formatter   (::formatter keyvals-map)]
     `(let [~logger' ~(or (::logger keyvals-map)
                          `(make-logger ~(name (ns-name *ns*))))]
        (when (io.pedestal.log/-level-enabled? ~logger' ~level)
-         (let [~string' (binding [*print-length* 80]
-                          (~formatter ~(assoc (dissoc keyvals-map
+         (let [formatter# ~(if formatter
+                             formatter
+                             `(default-formatter))
+               ~string' (binding [*print-length* 80]
+                          (formatter# ~(assoc (dissoc keyvals-map
                                                  :exception
                                                  :io.pedestal.log/logger
                                                  :io.pedestal.log/formatter)
@@ -355,25 +363,45 @@
 ;; -------------------------
 
 (def ^:dynamic *mdc-context*
-  "This map is copied into the SLF4J MDC when the `with-context` or
-  `with-context-kv` macros are used.  You are free to take control of
+  "This map is copied into the SLF4J MDC by the `with-context` macro.
+
+  You are free to take control of
   it for MDC-related purposes as it doesn't directly affect Pedestal's
   logging implementation.
 
   This map also includes all options that were passed into `with-context`."
   {})
 
-(def mdc-context-key "io.pedestal")
+(def mdc-context-key
+  "The key to use when formatting [*mdc-context*] for storage into the
+  MDC (via [[-put-mdc]]).  io.pedestal.log uses only this single key of the
+  underlying LoggingMDC implementation."
+  "io.pedestal")
+
+(defn ^:no-doc format-mdc
+  "Used by macros to find the formatter stored in the MDC (or a default)
+  and format it, excluding the ::formatter and ::mdc keys."
+  [mdc-map]
+  (let [formatter (or (::formatter mdc-map)
+                      (default-formatter))]
+    (formatter (dissoc mdc-map ::formatter ::mdc))))
+
+(defn ^:no-doc put-formatted-mdc
+  [mdc-map]
+  (let [mdc (or (::mdc mdc-map)
+                (MDC/getMDCAdapter))]
+    (-put-mdc mdc mdc-context-key (format-mdc mdc-map))))
+
 
 (defmacro with-context
   "Given a map of keys/values/options and a body,
   Set the map into the MDC via the *mdc-context* binding.
-  The MDC used defaults to SLF4J MDC unless the `:io.pedestal.log/mdc`
+
+  The MDC used defaults to the SLF4J MDC unless the :io.pedestal.log/mdc
   option is specified (see Options).
-  All options from the map are removed when setting the MDC.
 
   By default, the map is formatted into a string value and stored
-  under the 'io.pedestal' key, via `io.pedestal.log/mdc-context-key`
+  under the \"io.pedestal\" key.
 
   Caveats:
   SLF4J MDC, only maintains thread-local bindings, users are encouraged to
@@ -388,48 +416,46 @@
 
   Options:
    :io.pedestal.log/formatter - a single-arg function that when given the map, returns a formatted string
-                                Defaults to `pr-str`
+                                Default (via [[default-formatter]]) is `pr-str`
    :io.pedestal.log/mdc - An object that satisfies the LoggingMDC protocol
-                          Defaults to the SLF4J MDC.
-
-  Note:
-  If you mix `with-context` with the more basic `with-context-kv`, you may see undesired keys/values in the log"
+                          Defaults to the SLF4J MDC."
   [ctx-map & body]
-  (let [formatter (::formatter ctx-map pr-str)]
-    (if (empty? ctx-map) ;; Optimize for the code-gen/dynamic case where the map may be empty
+  (if (empty? ctx-map)                                      ;; Optimize for the code-gen/dynamic case where the map may be empty
       `(do
          ~@body)
-      `(let [old-ctx# *mdc-context*
-             mdc# (or ~(::mdc ctx-map) (MDC/getMDCAdapter))]
-         (binding [*mdc-context* (merge *mdc-context* ~ctx-map)]
-           (-put-mdc mdc# mdc-context-key (~formatter (dissoc *mdc-context*
-                                                              :io.pedestal.log/formatter
-                                                              :io.pedestal.log/mdc)))
+      `(let [old-ctx# *mdc-context*]
+         ;; Note: /formatter goes into the MDC context but is filtered out when formatting.
+         ;; This is to allow formatting in the finally block to use the formatter, if any,
+         ;; of the old context.
+         (binding [*mdc-context* (merge old-ctx# ~ctx-map)]
+           (put-formatted-mdc *mdc-context*)
            (try
              ~@body
              (finally
-               (-put-mdc mdc# mdc-context-key ((:io.pedestal.log/formatter old-ctx# pr-str)
-                                               (dissoc old-ctx#
-                                                       :io.pedestal.log/formatter
-                                                       :io.pedestal.log/mdc))))))))))
+               ;; This still seems to be the hard way to do this, as it feels like we should just
+               ;; capture the previously written formatted string and revert to that on exit.
+               (put-formatted-mdc old-ctx#)))))))
+
 (defmacro with-context-kv
   "Given a key, value, and body,
   associates the key-value pair into the *mdc-context* only for the scope/execution of `body`,
-  and sets the *mdc-context* into the SLF4J MDC
-   under the 'io.pedestal' key (via `io.pedestal.log/mdc-context-key`) using `pr-str` on the map for the MDC value.
+  and formats and stores the *mdc-context* into the SLF4J MDC
+  under the 'io.pedestal' key (via `io.pedestal.log/mdc-context-key`) using the
+  formatter (from the :io.pedestal.log/formatter option, or [[default-formatter]].
 
-  Note:
-  No keys are are dissoc'd from *mdc-context* with this simplified version.
-  If you mix `with-context` and `with-context-kv`, you may see undesired keys/values in the log"
+  This macro has been deprecated, use [[with-context]] instead:
+  - This macro expands to nil if the provided k is nil; this is likely a day-1 bug
+  - This macro bypasses the LoggingMDC protocol, invoking SLF4J methods directly"
+  {:deprecated "0.7.0"}
   [k v & body]
   (when k
     `(let [old-ctx# *mdc-context*]
        (binding [*mdc-context* (assoc *mdc-context* ~k ~v)]
-         (org.slf4j.MDC/put mdc-context-key (pr-str *mdc-context*))
+         (MDC/put mdc-context-key (format-mdc *mdc-context*))
          (try
            ~@body
            (finally
-             (org.slf4j.MDC/put mdc-context-key (pr-str old-ctx#))))))))
+             (MDC/put mdc-context-key (format-mdc old-ctx#))))))))
 
 ;; Metrics
 ;; -----------

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -20,6 +20,7 @@
 
         org.clojure/java.classpath {:mvn/version "1.0.0"}
         org.clojure/tools.namespace {:mvn/version "1.4.4"}
+        org.clojure/data.json {:mvn/version "2.4.0"}
         ;; TODO: clj-http 3.10.0 is available but
         ;; gzip compression test fails. Even though
         ;; `accept-encoding: gzip, deflate` is set by clj-http

--- a/tests/test/io/pedestal/log_test.clj
+++ b/tests/test/io/pedestal/log_test.clj
@@ -1,6 +1,26 @@
+; Copyright 2021-2023 Nubank NA
+; Copyright 2018-2021 Relevance, Inc.
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (ns io.pedestal.log-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as string]
+            [clojure.test :refer [deftest is use-fixtures]]
+            [clojure.data.json :as json]
             [io.pedestal.log :as log]))
+
+(def *events (atom nil))
+
+(use-fixtures :each (fn [f]
+                      (reset! *events [])
+                      (f)))
 
 (deftest mdc-context-set-correctly
   (let [inner-value (atom nil)
@@ -20,3 +40,59 @@
   (is (nil? (log/-span nil "operation-name")))
   (is (nil? (log/-span nil "operation-name" nil)))
   (is (nil? (log/-span nil "operation-name" nil nil))))
+
+(defn event [& data]
+  (swap! *events conj (vec data))
+  nil)
+
+(def test-logger
+  (reify log/LoggerSource
+
+    (-level-enabled? [_ _] true)
+
+    (-info [_ body]
+      (event :info body))))
+
+
+(deftest honors-logger
+  ^{:line 8888} (log/info ::log/logger test-logger :key :value)
+  (is (= [[:info
+           "{:key :value, :line 8888}"]]
+         @*events))
+
+  (let [m (read-string (-> @*events first second))]
+    (is (= #{:line :key} (-> m keys set)))
+    (is (= :value (:key m)))))
+
+(defn special-formatter
+  [data]
+  (->> (assoc data :line :override)
+       (into (sorted-map))
+       pr-str
+       string/upper-case))
+
+(deftest can-override-formatter
+  (log/info ::log/logger test-logger
+            ::log/formatter special-formatter
+            :key :value
+            :more-info {:this :that})
+
+  (is (= [[:info
+           "{:KEY :VALUE, :LINE :OVERRIDE, :MORE-INFO {:THIS :THAT}}"]]
+         @*events)))
+
+(deftest uses-default-formatter-if-not-specified
+  (with-redefs [log/default-formatter (constantly json/json-str)
+                log/make-logger       (constantly test-logger)]
+    ^{:line 9999} (log/info :this :that)
+    (is (= [[:info
+             "{\"this\":\"that\",\"line\":9999}"]]
+           @*events))))
+
+(deftest use-log-directly
+  (log/log {:key            :value
+            ::log/logger    test-logger
+            ::log/formatter special-formatter} :info)
+  (is (= [[:info
+           "{:KEY :VALUE, :LINE :OVERRIDE}"]]
+         @*events)))


### PR DESCRIPTION
Fixes #666

The use of a default formatter applies to MDC events as well.

This also deprecates io.pedestal.log/with-context-kv, which is untested and looks broken.