### PR TITLE
Fix minor initialization bug in ClojureVarServlet

### DIFF
--- a/service/deps.edn
+++ b/service/deps.edn
@@ -9,7 +9,9 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-{:paths ["src" "target/classes"]
+{:paths ["src"
+         "java"
+         "target/classes"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         io.pedestal/pedestal.log {:mvn/version "0.6.0"}
         io.pedestal/pedestal.metrics {:local/root "../metrics"}
@@ -60,8 +62,7 @@
   ;; to compile our servlet and other classes.
   ;; When developing with Cursive you should enable the servlet-api alias in the Clojure Deps tool.
   :servlet-api
-  {:extra-paths ["java" "target/classes"]
-   :extra-deps {org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api {:mvn/version "5.0.2"}
+  {:extra-deps {org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api {:mvn/version "5.0.2"}
                 org.eclipse.jetty.toolchain/jetty-jakarta-websocket-api {:mvn/version "2.0.0"}}}
   ;; clj -T:build <command>
   :build {:deps {io.github.hlship/build-tools {:git/tag "0.9" :git/sha "4efa3c9"}}

--- a/service/java/io/pedestal/servlet/ClojureVarServlet.java
+++ b/service/java/io/pedestal/servlet/ClojureVarServlet.java
@@ -1,4 +1,5 @@
-/* Copyright 2013 Relevance, Inc.
+/* Copyright 2023 Nubank NA
+ * Copyright 2013 Relevance, Inc.
  * Copyright 2014-2019 Cognitect, Inc.
 
  * The use and distribution terms for this software are covered by the

--- a/tests/test/io/pedestal/clojure_var_servlet_test.clj
+++ b/tests/test/io/pedestal/clojure_var_servlet_test.clj
@@ -1,0 +1,104 @@
+(ns io.pedestal.clojure-var-servlet-test
+  (:require [clojure.test :refer [deftest is use-fixtures]])
+  (:import (io.pedestal.servlet ClojureVarServlet)
+           (jakarta.servlet ServletConfig ServletException ServletRequest ServletResponse)))
+
+(def *events (atom []))
+
+(use-fixtures :each (fn [f]
+                      (swap! *events empty)
+                      (f)))
+
+(defn- event [& args]
+  (swap! *events conj (vec args)))
+
+(defn matched?
+  [v]
+  (some #(= % v) @*events))
+
+(deftest can-instantiate-servlet
+  (is (some? (ClojureVarServlet.))))
+
+
+(defn- mock-servlet-config
+  [init service destroy]
+  (let [data {"init"    init
+              "service" service
+              "destroy" destroy}]
+    (reify ServletConfig
+
+      (getInitParameter [_ param-name]
+        (get data param-name)))))
+
+(defn init-fn
+  [servlet servlet-config]
+  (event :init servlet servlet-config))
+
+(defn service-fn
+  [servlet request response]
+  (event :service servlet request response))
+
+(defn destroy-fn
+  [servlet]
+  (event :destroy servlet))
+
+(defmacro as-str [v]
+  `(-> #'~v .toSymbol str))
+
+
+(deftest init-and-service
+  (let [config  (mock-servlet-config (as-str init-fn) (as-str service-fn) nil)
+        req     (reify ServletRequest)
+        res     (reify ServletResponse)
+        servlet (doto (ClojureVarServlet.)
+                  (.init config))]
+    (.service servlet req res)
+    (.destroy servlet)
+
+    (is (matched? [:init servlet config]))
+    (is (matched? [:service servlet req res]))))
+
+(deftest can-omit-init
+  (let [config  (mock-servlet-config nil (as-str service-fn) nil)
+        req     (reify ServletRequest)
+        res     (reify ServletResponse)
+        servlet (doto (ClojureVarServlet.)
+                  (.init config))]
+    (.service servlet req res)
+    (.destroy servlet)
+
+    (is (matched? [:service servlet req res]))))
+
+(deftest can-supply-destroy
+  (let [config  (mock-servlet-config nil (as-str service-fn) (as-str destroy-fn))
+        req     (reify ServletRequest)
+        res     (reify ServletResponse)
+        servlet (doto (ClojureVarServlet.)
+                  (.init config))]
+    (.service servlet req res)
+    (.destroy servlet)
+
+    (is (matched? [:service servlet req res]))
+    (is (matched? [:destroy servlet]))))
+
+(deftest invalid-symbol-name
+  (let [config (mock-servlet-config "this-is-not-valid" nil nil)]
+    (when-let [e (is (thrown? ServletException
+                              (doto (ClojureVarServlet.)
+                                (.init config))))]
+      (is (= "Invalid namespace-qualified symbol 'this-is-not-valid'" (ex-message e))))))
+
+(deftest namespace-does-not-exist
+  (let [config (mock-servlet-config "missing.namespace/does-not-exist" nil nil)]
+    (when-let [e (is (thrown? ServletException
+                              (doto (ClojureVarServlet.)
+                                (.init config))))]
+      (is (= "Failed to load namespace 'missing.namespace'" (ex-message e))))))
+
+(deftest service-is-required
+  (let [config (mock-servlet-config nil nil nil)]
+    (is (thrown-with-msg? ServletException #"Missing required parameter 'service'"
+                          (doto (ClojureVarServlet.)
+                            (.init config))))))
+
+


### PR DESCRIPTION
ClojureVarServlet is used when deploying a Pedestal service inside a container (rather than the normal approach, to use a container embedded in the application).

Updated some incorrect documentation and found a bug where if there was no slash in the function name (which is supposed to be fully qualified) it would throw an IndexOutOfBoundsException.

Fixes #755 