### PR TITLE
Keep dependency versions in guides in sync with main project

### DIFF
--- a/build/build.clj
+++ b/build/build.clj
@@ -16,6 +16,7 @@
             [net.lewisship.build :refer [requiring-invoke deploy-jar]]
             [net.lewisship.trace :as trace :refer [trace]]
             [clojure.tools.build.api :as b]
+            [babashka.fs :as fs]
             [net.lewisship.build.versions :as v]))
 
 (trace/setup-default)
@@ -167,7 +168,12 @@
   (v/parse-version version)
   (doseq [dir module-dirs]
     (println "Updating" dir "...")
-    (requiring-invoke io.pedestal.build/update-version-in-deps dir version))
+    (requiring-invoke io.pedestal.build/update-version-in-deps (str dir "/deps.edn") version))
+
+   (doseq [path (->> (fs/glob "docs" "**/deps.edn")
+                     (map str))]
+     (println "Updating" path)
+     (requiring-invoke io.pedestal.build/update-version-in-deps path version))
 
   (println "Updating service-template (Leiningen template project) ...")
 

--- a/build/io/pedestal/build.clj
+++ b/build/io/pedestal/build.clj
@@ -26,11 +26,10 @@
                      k'))))))
 
 (defn update-version-in-deps
-  "Updates intra-module dependencies to use the provided version; this uses rewrite-edn to do so without losing
+  "Updates dependencies to use the provided version; this uses rewrite-edn to do so without losing
   formatting or comments."
-  [module-dir version]
-  (let [deps-path (str module-dir "/deps.edn")
-        nodes (-> deps-path
+  [deps-path version]
+  (let [nodes (-> deps-path
                   slurp
                   r/parse-string)
         ;; Since this is specific to io.pedestal, we don't have to worry about

--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,8 @@
    :deps {io.github.hlship/build-tools {:git/tag "0.10" :git/sha "9953da"}
           io.github.hlship/trace {:mvn/version "v1.0"}
           io.aviso/logging {:mvn/version "1.0"}
-          borkdude/rewrite-edn {:mvn/version "0.4.7"}}}
+          borkdude/rewrite-edn {:mvn/version "0.4.7"}
+          babashka/fs {:mvn/version "0.5.20"}}}
 
   ;; Invoked via clj -T:build cve-check
   :nvd

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -13,7 +13,7 @@ asciidoc:
     core_async: "link:https://github.com/clojure/core.async/[core.async]"
     clojure_spec: "link:https://clojure.org/guides/spec[Clojure spec]"
     repo_root: "https://github.com/pedestal/pedestal"
-    guides_examples_root: "{repo_root}/tree/master/modules/guides/examples"
+    guides_examples_root: "{repo_root}/tree/master/docs/modules/guides/examples"
     component_home: "https://github.com/stuartsierra/component/"
     # For api: inline macro
     default_api_ns: io.pedestal.http@  # @ signals it can be overridden by pages

--- a/docs/modules/guides/examples/component/deps.edn
+++ b/docs/modules/guides/examples/component/deps.edn
@@ -1,6 +1,11 @@
-{:deps
- { io.pedestal/pedestal.jetty {:mvn/version "0.6.1"}
-  com.stuartsierra/component {:mvn/version "1.1.0"}
-  org.slf4j/slf4j-simple {:mvn/version "2.0.9"}
-  com.stuartsierra/component.repl {:mvn/version "0.2.0"}}
- :paths ["src"]}
+{:paths ["src"]
+ :deps  {io.pedestal/pedestal.jetty      {:mvn/version "0.7.0-SNAPSHOT"}
+         com.stuartsierra/component      {:mvn/version "1.1.0"}
+         org.slf4j/slf4j-simple          {:mvn/version "2.0.9"}
+         com.stuartsierra/component.repl {:mvn/version "0.2.0"}}
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
+                                                       :git/sha "dfb30dd"}}
+   :exec-fn     cognitect.test-runner.api/test}}}

--- a/docs/modules/guides/examples/component/src/system.clj
+++ b/docs/modules/guides/examples/component/src/system.clj
@@ -4,8 +4,8 @@
             [com.stuartsierra.component.repl
              :refer [reset set-init start stop system]]     ;; <2>
             [io.pedestal.http :as http]                     ;; <3>
-            [pedestal]                                      ;; <4>
-            [routes]))                                      ;; <5>
+            pedestal                                        ;; <4>
+            routes))                                        ;; <5>
 ;; end::ns[]
 
 ;; tag::app[]

--- a/docs/modules/guides/examples/component/test/system_test.clj
+++ b/docs/modules/guides/examples/component/test/system_test.clj
@@ -5,9 +5,9 @@
             [io.pedestal.test :refer [response-for]]
             [com.stuartsierra.component :as component]
             [clojure.test :refer :all]
-            [routes]
-            [system]
-            [pedestal]))
+            routes
+            system
+            pedestal))
                                                                  ;; end::ns[]
 
                                                                  ;; tag::url-for[]

--- a/docs/modules/guides/examples/hello-content/deps.edn
+++ b/docs/modules/guides/examples/hello-content/deps.edn
@@ -1,5 +1,4 @@
-{:deps
- {io.pedestal/pedestal.jetty   {:mvn/version "0.6.1"}
-  org.clojure/data.json        {:mvn/version "2.4.0"}
-  org.slf4j/slf4j-simple       {:mvn/version "2.0.9"}}
- :paths ["src"]}
+{:paths ["src"]
+ :deps  {io.pedestal/pedestal.jetty {:mvn/version "0.7.0-SNAPSHOT"}
+         org.clojure/data.json      {:mvn/version "2.5.0"}
+         org.slf4j/slf4j-simple     {:mvn/version "2.0.10"}}}

--- a/docs/modules/guides/examples/hello-query/deps.edn
+++ b/docs/modules/guides/examples/hello-query/deps.edn
@@ -1,4 +1,3 @@
-{:deps
- {io.pedestal/pedestal.jetty   {:mvn/version "0.6.1"}
-  org.slf4j/slf4j-simple       {:mvn/version "2.0.9"}}
- :paths ["src"]}
+{:paths ["src"]
+ :deps  {io.pedestal/pedestal.jetty {:mvn/version "0.7.0-SNAPSHOT"}
+         org.slf4j/slf4j-simple     {:mvn/version "2.0.10"}}}

--- a/docs/modules/guides/examples/hello/deps.edn
+++ b/docs/modules/guides/examples/hello/deps.edn
@@ -1,4 +1,3 @@
-{:deps                                                ;; <1>
- {io.pedestal/pedestal.jetty   {:mvn/version "0.6.1"}
-  org.slf4j/slf4j-simple       {:mvn/version "2.0.9"}}
- :paths ["src"]}                                      ;; <2>
+{:paths ["src"] ;; <1>
+ :deps  {io.pedestal/pedestal.jetty {:mvn/version "0.7.0-SNAPSHOT"} ;; <2>
+         org.slf4j/slf4j-simple     {:mvn/version "2.0.10"}}}

--- a/docs/modules/guides/examples/todo-api/deps.edn
+++ b/docs/modules/guides/examples/todo-api/deps.edn
@@ -1,5 +1,4 @@
-{:deps
- {io.pedestal/pedestal.jetty   {:mvn/version "0.6.1"}
-  org.clojure/data.json        {:mvn/version "2.4.0"}
-  org.slf4j/slf4j-simple       {:mvn/version "2.0.9"}}
- :paths ["src"]}
+{:paths ["src"]
+ :deps  {io.pedestal/pedestal.jetty {:mvn/version "0.7.0-SNAPSHOT"}
+         org.clojure/data.json      {:mvn/version "2.5.0"}
+         org.slf4j/slf4j-simple     {:mvn/version "2.0.10"}}}

--- a/docs/modules/guides/pages/developing-at-the-repl.adoc
+++ b/docs/modules/guides/pages/developing-at-the-repl.adoc
@@ -367,7 +367,10 @@ test the complete interceptor chain for a given route and much more.
 
 Alternatively, you may want to learn to manage your applications stateful
 components (like the HTTP server) more effectively. Check out the guide
-on link:pedestal-with-component[Integrating Pedestal with Component] to learn
+on
+xref:pedestal-with-component.adoc[]
+to learn
 how easy it can be to incorporate Stuart Sierra's Reloaded workflow into
-your Pedestal development, and read link:live-repl.adoc[Reloading at the REPL]
+your Pedestal development, and read
+xref:live-repl.adoc[]
 for a non-component take on how to make live changes without restarting.

--- a/docs/modules/guides/pages/hello-world-content-types.adoc
+++ b/docs/modules/guides/pages/hello-world-content-types.adoc
@@ -30,19 +30,15 @@ After reading this guide, you will be able to:
 
 == Guide Assumptions
 
-Like link:hello-world[Hello World], this guide is for beginners who
+Like xref:hello-world.adoc[], this guide is for beginners who
 are new to Pedestal and may be new to Clojure. It doesn't assume any
 prior experience with a Clojure-based web framework. You should be
 familiar with the basics of HTTP: URLs, response codes, and content
 types.
 
 If you've already done some of those other things, you might want to
-skip ahead to link:your-first-api[Your First API] to start building
+skip ahead to xref:your-first-api.adoc[] to start building
 some logic and multiple routes.
-
-If you like to jump straight in to the deep end, you might be
-interested in the link:crash-course[Pedestal Crash Course] which
-assumes you know quite a bit about Clojure and web frameworks.
 
 This guide also assumes that you are in a Unix-like development
 environment, with Java installed. We've tested it on Mac OS X and
@@ -326,7 +322,7 @@ Could not locate clojure/data/json__init.class, clojure/data/json.clj or clojure
 
 That is how Clojure tells you it is missing a library. By looking at
 the library's https://github.com/clojure/data.json[project page], we see that the latest stable release is
-"2.4.0" (at least, it is when this guide is being written!). We can
+"2.5.0" (at least, it is when this guide is being written!). We can
 add the library in the dependencies part of our `deps.edn` file:
 
 [source,clojure]
@@ -510,7 +506,7 @@ include::example$hello-content/src/hello.clj[tags=ns;continuo;coerce_refactored_
 
 == The Path So Far
 
-In this guide, we built upon link:hello-world-query-parameters[Hello World, With Parameters] to add:
+In this guide, we built upon xref:hello-world-query-parameters.adoc[] to add:
 
 * Rudimentary content negotiation.
 * Response body transforms.

--- a/docs/modules/guides/pages/hello-world-query-parameters.adoc
+++ b/docs/modules/guides/pages/hello-world-query-parameters.adoc
@@ -29,10 +29,6 @@ If you've already done some of those other things, you might want to
 skip ahead to xref:your-first-api.adoc[] to start building
 some logic and multiple routes.
 
-If you like to jump straight in to the deep end, you might be
-interested in the link:crash-course[Pedestal Crash Course] which
-assumes you know quite a bit about Clojure and web frameworks.
-
 This guide also assumes that you are in a Unix-like development
 environment, with Java installed. We've tested it on Mac OS X and
 Linux (any flavor) with great results. We haven't yet tried it on the
@@ -59,7 +55,7 @@ our handler will return a 404 response instead of a cordial greeting.
 If you worked through xref:hello-world.adoc[], then you already
 have all the files you need. If not, take a moment to grab the sources
 from
-link:{guides_examples_root}/hello[that guide].
+link:{guides_examples_root}/hello[the repository].
 That will be our starting point for enhancements this time.
 
 == Accepting Parameters
@@ -123,11 +119,10 @@ Clojure 1.11.1
 user=> (require 'hello)
 nil
 user=> (hello/start-dev)
-[main] INFO org.eclipse.jetty.util.log - Logging initialized @16010ms to org.eclipse.jetty.util.log.Slf4jLog
-[main] INFO org.eclipse.jetty.server.Server - jetty-9.4.52.v20230823; built: 2023-08-23T19:29:37.669Z; git: abdcda73818a1a2c705da276edb0bf6581e7997e; jvm 11.0.19+7-LTS
-[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@1227013b{/,null,AVAILABLE}
-[main] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@4ab4f6d7{HTTP/1.1, (http/1.1, h2c)}{localhost:8890}
-[main] INFO org.eclipse.jetty.server.Server - Started @16147ms
+[main] INFO org.eclipse.jetty.server.Server - jetty-11.0.18; built: 2023-10-27T02:14:36.036Z; git: 5a9a771a9fbcb9d36993630850f612581b78c13f; jvm 11.0.19+7-LTS
+[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@549db1c6{/,null,AVAILABLE}
+[main] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@2d3b708a{HTTP/1.1, (http/1.1, h2c)}{localhost:8890}
+[main] INFO org.eclipse.jetty.server.Server - Started Server@5770b59f{STARTING}[11.0.18,sto=0] @15614ms
 #:io.pedestal.http{:port 8890, :service-fn #object[io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14835 0x4e27c500 "io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14835@4e27c500"], :host "localhost", :type :jetty, :start-fn #object[io.pedestal.http.jetty$server$fn__15089 0x6dbd38e8 "io.pedestal.http.jetty$server$fn__15089@6dbd38e8"], :interceptors [#Interceptor{:name :io.pedestal.http/log-request} #Interceptor{:name :io.pedestal.http/not-found} #Interceptor{:name :io.pedestal.http.ring-middlewares/content-type-interceptor} #Interceptor{:name :io.pedestal.http.route/query-params} #Interceptor{:name :io.pedestal.http.route/method-param} #Interceptor{:name :io.pedestal.http.secure-headers/secure-headers} #Interceptor{:name :io.pedestal.http.route/router} #Interceptor{:name :io.pedestal.http.route/path-params-decoder}], :routes ({:path "/greet", :method :get, :path-re #"/\Qgreet\E", :path-parts ["greet"], :interceptors [#Interceptor{}], :route-name :greet, :path-params []}), :servlet #object[io.pedestal.http.servlet.FnServlet 0x1a183473 "io.pedestal.http.servlet.FnServlet@1a183473"], :server #object[org.eclipse.jetty.server.Server 0x351bfccc "Server@351bfccc{STARTED}[9.4.52.v20230823]"], :join? false, :stop-fn #object[io.pedestal.http.jetty$server$fn__15091 0x2d7956fb "io.pedestal.http.jetty$server$fn__15091@2d7956fb"]}
 user=>
 ----

--- a/docs/modules/guides/pages/hello-world.adoc
+++ b/docs/modules/guides/pages/hello-world.adoc
@@ -262,8 +262,8 @@ service needs. This goes in the main directory `hello`:
 ----
 include::example$hello/deps.edn[]
 ----
-<1> Tell `clj` we need pedestal.jetty and a logging library.
-<2> Tell `clj` where our source code lives.
+<1> Tell `clj` where our source code lives.
+<2> Tell `clj` we need pedestal.jetty and a logging library.
 
 We talked about `pedestal.service` and `pedestal.route` before, but we
 have a new one here. Pedestal works with many different HTTP servers,
@@ -295,7 +295,8 @@ user=>
 
 [NOTE]
 The downloads only occur the _first_ time you run the service; you can also see
-that the pedestal.jetty library brings in further dependencies on the other parts of Pedestal: pedestal.log, pedestal.service, etc.
+that the pedestal.jetty library brings in further dependencies on the other parts of Pedestal: pedestal.log, pedestal.service, etc. The exact libraries and versions downloaded will vary with the exact version of
+Pedestal.
 
 The `clj` tool will download dependencies as needed, add them to the classpath
 and start a repl in the `user` namespace. Now we're able to 

--- a/docs/modules/guides/pages/pedestal-with-component.adoc
+++ b/docs/modules/guides/pages/pedestal-with-component.adoc
@@ -114,7 +114,7 @@ feed requests into the interceptor pipeline.
 
 If you've read some of the other guides, this implementation should
 look somewhat familiar. It's a combination of the server-specific code
-used in the link:hello-world[Hello World] guide.
+used in the xref:hello-world.adoc[] guide.
 
 ****
 Before we go on, remember the `test?` function? It's idiomatic in
@@ -232,7 +232,7 @@ and the function returns the new, but unstarted, system.
 
 We'll use `clj` tool to run our
 example. This should be familiar to you if you read through the
-link:hello-world[Hello World] guide.
+xref:hello-world.adoc[].
 
 From the project's root directory, fire up a repl, and start the system.
 ----
@@ -330,10 +330,10 @@ to write too much code. Let's do it!
 First create a `system_test.clj` file in the `src` directory.
 
 [source, clojure]
-.src/system_test.clj
+.test/system_test.clj
 
 ----
-include::example$component/src/system_test.clj[tags=ns]
+include::example$component/test/system_test.clj[tags=ns]
 ----
 The `system-test` namespace requires all the dependencies
 necessary for testing.
@@ -343,7 +343,7 @@ Now let's get to those helpers.
 The `url-for` helper allows us to refer to routes by
 _route-name_. This is very useful, and is almost always adapted into new projects.
 ----
-include::example$component/src/system_test.clj[tags=url-for]
+include::example$component/test/system_test.clj[tags=url-for]
 ----
 We need to expand the routes before invoking Pedestal's
 api:url-for-routes[ns=io.pedestal.http.route] function.
@@ -354,7 +354,7 @@ The `service-fn` helper extracts the Pedestal ::http/service-fn from
 the started system. This helper allows us to keep focus on our
 tests rather than test initialization.
 ----
-include::example$component/src/system_test.clj[tags=service-fn]
+include::example$component/test/system_test.clj[tags=service-fn]
 ----
 
 
@@ -362,13 +362,13 @@ The `with-system` macro allows us to start/stop systems between test
 executions. We'll model its design on macros like `with-open` and
 `with-redefs` so that its shape and usage is familiar.
 ----
-include::example$component/src/system_test.clj[tags=with-system]
+include::example$component/test/system_test.clj[tags=with-system]
 ----
 
 Now that we've got our helpers implemented, let's move on to our
 test. Create a test named `greeting-test`.
 ----
-include::example$component/src/system_test.clj[tags=test]
+include::example$component/test/system_test.clj[tags=test]
 ----
 <1> `sut` (for _system under test_) will be bound to the started
 system by `with-system`. Notice how :test is passed as the system
@@ -381,19 +381,18 @@ by name.
 <4> We should get back a '200' status.
 <5> We should get back a response body of 'Hello, world!'
 
-Now let's restart the repl and run our tests.
+Now let's restart run the tests from the command line:
 ----
-user=> (require 'system-test)
-nil
-user=> (clojure.test/run-tests 'system-test)
+> clj -X:test
+
+Running tests in #{"test"}
 
 Testing system-test
-[main] INFO io.pedestal.http - {:msg "GET /greet", :line 80}
+[main] INFO io.pedestal.http - {:msg "GET /greet", :line 90}
 
 Ran 1 tests containing 2 assertions.
 0 failures, 0 errors.
-{:test 1, :pass 2, :fail 0, :error 0, :type :summary}
-user=>
+>
 ----
 
 That's it! You now know the fundamentals necessary for implementing
@@ -442,17 +441,17 @@ include::example$component/src/system.clj[tags=init]
 
 
 [source,clojure,subs="-callouts"]
-.src/system_test.clj
+.test/system_test.clj
 ----
-include::example$component/src/system_test.clj[tags=ns]
+include::example$component/test/system_test.clj[tags=ns]
 
-include::example$component/src/system_test.clj[tags=url-for]
+include::example$component/test/system_test.clj[tags=url-for]
 
-include::example$component/src/system_test.clj[tags=service-fn]
+include::example$component/test/system_test.clj[tags=service-fn]
 
-include::example$component/src/system_test.clj[tags=with-system]
+include::example$component/test/system_test.clj[tags=with-system]
 
-include::example$component/src/system_test.clj[tags=test]
+include::example$component/test/system_test.clj[tags=test]
 ----
 
 

--- a/docs/modules/guides/pages/sse.adoc
+++ b/docs/modules/guides/pages/sse.adoc
@@ -20,7 +20,7 @@ After reading this guide, you will be able to:
 == Guide Assumptions
 
 This guide is for intermediate users who have worked through some
-sample applications or the first few link:hello-world[Hello World]
+sample applications or the first few xref:hello-world.adoc[]
 guides. In particular, you should know how to run a build, start a
 REPL, and start and stop your server.
 

--- a/docs/modules/guides/pages/war-deployment.adoc
+++ b/docs/modules/guides/pages/war-deployment.adoc
@@ -16,7 +16,8 @@ a particular internal layout and a `.war` extension.
 
 ## Step One: Prepare Your Project
 
-When running your application locally link:live-repl[at the REPL], you will want to
+When running your application locally
+xref:live-repl.adoc[at the REPL], you will want to
 have your choice of servlet container running inside your JVM, and so the
 servlet container, and the Pedestal adaptor for the container, will be a dependency
 of your project.

--- a/docs/modules/guides/pages/your-first-api.adoc
+++ b/docs/modules/guides/pages/your-first-api.adoc
@@ -31,11 +31,6 @@ HTTP: URLs, response codes, and content types.
 You do not need experience with any particular database or persistence
 framework.
 
-If you like to jump straight in to the deep end, you might be
-interested in the
-link:crash-course[Pedestal Crash Course] which
-assumes you know quite a bit about Clojure and web frameworks.
-
 This guide also assumes that you are in a Unix-like development
 environment, with Java installed. We've tested it on Mac OS X and
 Linux (any flavor) with great results. We haven't yet tried it on the
@@ -152,12 +147,11 @@ Clojure 1.11.1
 user=> (require 'main)
 nil
 user=> (main/start-dev)
-[main] INFO org.eclipse.jetty.util.log - Logging initialized @16482ms to org.eclipse.jetty.util.log.Slf4jLog
-[main] INFO org.eclipse.jetty.server.Server - jetty-9.4.52.v20230823; built: 2023-08-23T19:29:37.669Z; git: abdcda73818a1a2c705da276edb0bf6581e7997e; jvm 11.0.19+7-LTS
-[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@51e28071{/,null,AVAILABLE}
-[main] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@44ca5127{HTTP/1.1, (http/1.1, h2c)}{localhost:8890}
-[main] INFO org.eclipse.jetty.server.Server - Started @16639ms
-#:io.pedestal.http{:port 8890, :service-fn #object[io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14835 0xc1add62 "io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14835@c1add62"], :host "localhost", :type :jetty, :start-fn #object[io.pedestal.http.jetty$server$fn__15231 0x723c7f2f "io.pedestal.http.jetty$server$fn__15231@723c7f2f"], :interceptors [#Interceptor{:name :io.pedestal.http/log-request} #Interceptor{:name :io.pedestal.http/not-found} #Interceptor{:name :io.pedestal.http.ring-middlewares/content-type-interceptor} #Interceptor{:name :io.pedestal.http.route/query-params} #Interceptor{:name :io.pedestal.http.route/method-param} #Interceptor{:name :io.pedestal.http.secure-headers/secure-headers} #Interceptor{:name :io.pedestal.http.route/router} #Interceptor{:name :io.pedestal.http.route/path-params-decoder}], :routes ({:path "/todo/:list-id/:item-id", :method :delete, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :echo}], :route-name :list-item-delete, :path-params [:list-id :item-id]} {:path "/todo/:list-id/:item-id", :method :get, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :list-item-view} #Interceptor{:name :database-interceptor}], :route-name :database-interceptor, :path-params [:list-id :item-id]} {:path "/todo/:list-id/:item-id", :method :put, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :echo}], :route-name :list-item-update, :path-params [:list-id :item-id]} {:path "/todo/:list-id", :method :get, :path-constraints {:list-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)", :path-parts ["todo" :list-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :database-interceptor} #Interceptor{:name :list-view}], :route-name :list-view, :path-params [:list-id]} {:path "/todo/:list-id", :method :post, :path-constraints {:list-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)", :path-parts ["todo" :list-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :list-item-view} #Interceptor{:name :database-interceptor} #Interceptor{:name :list-item-create}], :route-name :list-item-create, :path-params [:list-id]} {:path "/todo", :method :get, :path-re #"/\Qtodo\E", :path-parts ["todo"], :interceptors [#Interceptor{:name :echo}], :route-name :list-query-form, :path-params []} {:path "/todo", :method :post, :path-re #"/\Qtodo\E", :path-parts ["todo"], :interceptors [#Interceptor{:name :database-interceptor} #Interceptor{:name :list-create}], :route-name :list-create, :path-params []}), :servlet #object[io.pedestal.http.servlet.FnServlet 0x5cb077e3 "io.pedestal.http.servlet.FnServlet@5cb077e3"], :server #object[org.eclipse.jetty.server.Server 0x737935a4 "Server@737935a4{STARTED}[9.4.52.v20230823]"], :join? false, :stop-fn #object[io.pedestal.http.jetty$server$fn__15233 0x278758da "io.pedestal.http.jetty$server$fn__15233@278758da"]}
+[main] INFO org.eclipse.jetty.server.Server - jetty-11.0.18; built: 2023-10-27T02:14:36.036Z; git: 5a9a771a9fbcb9d36993630850f612581b78c13f; jvm 11.0.19+7-LTS
+[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@6c8f2e4e{/,null,AVAILABLE}
+[main] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@1432a683{HTTP/1.1, (http/1.1, h2c)}{localhost:8890}
+[main] INFO org.eclipse.jetty.server.Server - Started Server@b025f2f{STARTING}[11.0.18,sto=0] @57816ms
+#:io.pedestal.http{:port 8890, :service-fn #object[io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14892 0x515f104c "io.pedestal.http.impl.servlet_interceptor$interceptor_service_fn$fn__14892@515f104c"], :host "localhost", :type :jetty, :start-fn #object[io.pedestal.http.jetty$server$fn__15680 0x1dde2d1 "io.pedestal.http.jetty$server$fn__15680@1dde2d1"], :interceptors [#Interceptor{:name :io.pedestal.http/log-request} #Interceptor{:name :io.pedestal.http/not-found} #Interceptor{:name :io.pedestal.http.ring-middlewares/content-type-interceptor} #Interceptor{:name :io.pedestal.http.route/query-params} #Interceptor{:name :io.pedestal.http.route/method-param} #Interceptor{:name :io.pedestal.http.secure-headers/secure-headers} #Interceptor{:name :io.pedestal.http.route/router} #Interceptor{:name :io.pedestal.http.route/path-params-decoder}], :routes ({:path "/todo/:list-id", :method :get, :path-constraints {:list-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)", :path-parts ["todo" :list-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :database-interceptor} #Interceptor{:name :list-view}], :route-name :list-view, :path-params [:list-id]} {:path "/todo/:list-id", :method :post, :path-constraints {:list-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)", :path-parts ["todo" :list-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :list-item-view} #Interceptor{:name :database-interceptor} #Interceptor{:name :list-item-create}], :route-name :list-item-create, :path-params [:list-id]} {:path "/todo", :method :post, :path-re #"/\Qtodo\E", :path-parts ["todo"], :interceptors [#Interceptor{:name :database-interceptor} #Interceptor{:name :list-create}], :route-name :list-create, :path-params []} {:path "/todo", :method :get, :path-re #"/\Qtodo\E", :path-parts ["todo"], :interceptors [#Interceptor{:name :echo}], :route-name :list-query-form, :path-params []} {:path "/todo/:list-id/:item-id", :method :delete, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :echo}], :route-name :list-item-delete, :path-params [:list-id :item-id]} {:path "/todo/:list-id/:item-id", :method :get, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :entity-render} #Interceptor{:name :list-item-view} #Interceptor{:name :database-interceptor}], :route-name :database-interceptor, :path-params [:list-id :item-id]} {:path "/todo/:list-id/:item-id", :method :put, :path-constraints {:list-id "([^/]+)", :item-id "([^/]+)"}, :path-re #"/\Qtodo\E/([^/]+)/([^/]+)", :path-parts ["todo" :list-id :item-id], :interceptors [#Interceptor{:name :echo}], :route-name :list-item-update, :path-params [:list-id :item-id]}), :servlet #object[io.pedestal.http.servlet.FnServlet 0x47caa1ff "io.pedestal.http.servlet.FnServlet@47caa1ff"], :server #object[org.eclipse.jetty.server.Server 0xb025f2f "Server@b025f2f{STARTED}[11.0.18,sto=0]"], :join? false, :stop-fn #object[io.pedestal.http.jetty$server$fn__15682 0x7330574d "io.pedestal.http.jetty$server$fn__15682@7330574d"]}
 user=>
 ----
 
@@ -594,13 +588,12 @@ We covered some more advanced concepts with interceptors this time:
 
 == Where To Next?
 
-Congratulations! You've finished the whole link:index#_getting_started[Getting
-Started] trail.
+Congratulations! You've finished the whole getting stated trail.
 
-For more guided learning, head back up to the link:index[Guides]
-page. Or, to go deep on some of these topics, check out any of the
+To go deep on some of these topics, check out any of the
 following references:
 
-* link:../reference/interceptors[Interceptors]
-* link:../reference/index#_routing_and_linking[Routing and Linking]
-* link:../reference/default-interceptors[Default Interceptors]
+* xref:reference:interceptors.adoc[]
+* xref:reference:routing-quick-reference.adoc[]
+* xref:reference:default-interceptors.adoc[]
+

--- a/service-template/project.clj
+++ b/service-template/project.clj
@@ -4,6 +4,8 @@
 
 
 
+
+
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-19 Cognitect, Inc.
 

--- a/service-template/src/leiningen/new/pedestal_service/project.clj
+++ b/service-template/src/leiningen/new/pedestal_service/project.clj
@@ -1,3 +1,5 @@
+
+
 (defproject {{raw-name}} "0.0.1-SNAPSHOT"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"


### PR DESCRIPTION
Changes the `update-version` tool to find and update any deps.edn files it finds inside `doc` directory.

Also, a number of fixes and improvements to the documentation.