### PR TITLE
Add dev-mode printing of routing table

### DIFF
--- a/docs/modules/guides/pages/live-repl.adoc
+++ b/docs/modules/guides/pages/live-repl.adoc
@@ -270,7 +270,7 @@ function - on every request.  If you like, you can abbreviate `(deref (var route
 
 ## Using routes-from
 
-It's not very desirable to have to keep two separate functions, one for production, and one for REPL oriented
+It's not very desirable to have to keep two separate start functions, one for production, and one for REPL oriented
 development ... especially given how badly throughput will be affected if the local REPL version leaks through to
 production.
 
@@ -292,14 +292,21 @@ api:routes-from[ns=io.pedestal.http.route] macro:
 `routes-from` is aware of the xref:reference:dev-mode.adoc[Pedestal execution mode].  By default, `routes-from` operates in production mode, so
 `(route/routes-from routes)` evaluates to `routes`.
 
-However, in local development mode, `(route/routes-from routes)` expands to `#(expand-routes (deref (var routes)))` ... the
-same code we used above, to delay route evaluation.
+However, in local development mode, `(route/routes-from routes)` expands (approximately) to `#(expand-routes (deref (var routes)))` ... the same code we used above, to delay route evaluation.
 
+Further,in local development mode, `routes-from` will print the formatted routing table to the console at startup, and at any later time that the routing table changes:
 
+```
+Routing table:
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃ Path   ┃ Name                    ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ :get   ┃ /hello ┃ :io.example.hello/hello ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━┛
+```
 
-
-
-
+This output is especially useful to know the correct route name to pass to
+api:url-for[ns=io.pedestal.http.route].
 
 ## Wrap Up
 

--- a/route/src/io/pedestal/http/route/internal.clj
+++ b/route/src/io/pedestal/http/route/internal.clj
@@ -1,0 +1,83 @@
+; Copyright 2024 Nubank NA
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.route.internal
+  "Internal utilities, not for reuse, subject to change at any time."
+  {:no-doc true
+   :added  "0.7.0"})
+
+(defn- column-width
+  [title-width k values]
+  (reduce max title-width (map #(-> % k str count) values)))
+
+(defn- padded [s width ^String p]
+  (let [b (StringBuilder. (str s))]
+    (while (< (.length b) width)
+      (.append b p))
+    (.toString b)))
+
+(defn print-routing-table
+  [expanded-routes]
+  (let [path-width   (column-width 4 :path expanded-routes)
+        name-width   (column-width 4 :route-name expanded-routes)
+        method-width (column-width 6 :method expanded-routes)]
+    (println (str "┏━"
+                  (padded nil method-width "━")
+                  "━┳━"
+                  (padded nil path-width "━")
+                  "━┳"
+                  (padded nil name-width "━")
+                  "━━┓"))
+    (println (str "┃ "
+                  (padded "Method" method-width " ")
+                  " ┃ "
+                  (padded "Path" path-width " ")
+                  " ┃ "
+                  (padded "Name" name-width " ")
+                  " ┃"))
+    (println (str "┣━"
+                  (padded nil method-width "━")
+                  "━╋━"
+                  (padded nil path-width "━")
+                  "━╋━"
+                  (padded nil name-width "━")
+                  "━┫"))
+    (doseq [{:keys [method path route-name]} (sort-by :path expanded-routes)]
+      (println (str "┃ "
+                    (padded method method-width " ")
+                    " ┃ "
+                    (padded path path-width " ")
+                    " ┃ "
+                    (padded route-name name-width " ")
+                    " ┃"
+                    )))
+    (println (str "┗━"
+                  (padded nil method-width "━")
+                  "━┻━"
+                  (padded nil path-width "━")
+                  "━┻"
+                  (padded nil name-width "━")
+                  "━━┛"))))
+
+
+(defn print-routing-table-on-change
+  "Checks if the routing table has changed visibly and prints it if so. Returns the new routing
+  table."
+  [*prior-routes new-routes]
+  (let [new-routes' (->> new-routes
+                         ;; Ignore keys that aren't needed (and cause comparison problems).
+                         (map #(select-keys % [:method :path :route-name]))
+                         set)]
+    (when (not= @*prior-routes new-routes')
+      (println "Routing table:")
+      (print-routing-table new-routes')
+      (reset! *prior-routes new-routes')))
+  new-routes)

--- a/tests/test/io/pedestal/http/route_repl_test.clj
+++ b/tests/test/io/pedestal/http/route_repl_test.clj
@@ -45,21 +45,50 @@
         alt-routes #{["/bye" :get #'bye-handler :route-name ::bye]}]
     (is (fn? f))
 
-    (is (= (simplify (route/expand-routes sample-routes))
-           (simplify (f))))
+    (let [out-str (with-out-str
+                    (is (= (simplify (route/expand-routes sample-routes))
+                           (simplify (f)))))]
+      (is (= "Routing table:
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃ Path   ┃ Name                                    ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ :get   ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+" out-str))
+      )
+
+    (let [out-str (with-out-str (f))]
+      ;; Unchanged routing table, no output.
+      (is (= "" out-str)))
 
     ;; Test that the function de-refs the Var, rather than capturing the value
     ;; at macro expansion time.
     (with-redefs [sample-routes alt-routes]
-
-      (is (= (simplify (route/expand-routes alt-routes))
-             (simplify (f)))))))
+      (let [out-str (with-out-str
+                      (is (= (simplify (route/expand-routes alt-routes))
+                             (simplify (f)))))]
+        (is (= "Routing table:
+┏━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃ Path ┃ Name                                  ┃
+┣━━━━━━━━╋━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ :get   ┃ /bye ┃ :io.pedestal.http.route-repl-test/bye ┃
+┗━━━━━━━━┻━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+" out-str))
+        ))))
 
 (deftest local-symbol-is-simply-wrapped-as-function
   (let [local-routes #{["/hi" :get #'hello-handler :route-name ::hi]}
         f            (routes-from local-routes)]
-    (is (= (simplify (route/expand-routes local-routes))
-           (simplify (f))))))
+    (let [out-str (with-out-str
+                    (is (= (simplify (route/expand-routes local-routes))
+                           (simplify (f)))))]
+      (is (= "Routing table:
+┏━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃ Path ┃ Name                                 ┃
+┣━━━━━━━━╋━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃ :get   ┃ /hi  ┃ :io.pedestal.http.route-repl-test/hi ┃
+┗━━━━━━━━┻━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+" out-str)))))
 
 (deftest production-mode
   (let [output (with-redefs [dev-mode? false]

--- a/tests/test/io/pedestal/http/route_repl_test.clj
+++ b/tests/test/io/pedestal/http/route_repl_test.clj
@@ -94,3 +94,15 @@
   (let [output (with-redefs [dev-mode? false]
                  (eval `(routes-from sample-routes)))]
     (is (identical? sample-routes output))))
+
+(deftest fn-router-invokes-fn-at-creation
+  (let [*invoke-count (atom 0)
+        f             (fn []
+                        (swap! *invoke-count inc)
+                        (route/expand-routes sample-routes))]
+    ; Create a router interceptor
+    (route/router f)
+    ;; The routing spec fn is invoked immediately, even before a
+    ;; request is routed.
+    (is (= 1 @*invoke-count))))
+


### PR DESCRIPTION
When in dev-mode, the `routes-from` macro will now print a sorted, formatted table from the expanded routing specification:

```
Routing table:
┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Method ┃ Path   ┃ Name                    ┃
┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━┫
┃ :get   ┃ /hello ┃ :io.example.hello/hello ┃
┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

This is output at startup, and on any subsequent request where the routing table has visibly changed (any method, path, or route name has changed).


