### PR TITLE
Add missing test for indirect interceptors

### DIFF
--- a/tests/test/io/pedestal/interceptor_test.clj
+++ b/tests/test/io/pedestal/interceptor_test.clj
@@ -1,3 +1,4 @@
+; Copyright 2024 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2022 Cognitect, Inc.
 
@@ -483,3 +484,14 @@
         (execute [(interceptor {:name :a :enter enter})
                   (interceptor {:name :b :enter enter})]))
     (is (= 1 @*count))))
+
+(deftest indirect-interceptor
+  (let [indirect (interceptor/interceptor {:name ::indirect :enter identity})
+        f1       ^:interceptor (fn [] indirect)
+        f2       ^:interceptorfn (fn [] indirect)]
+
+    (is (identical? indirect
+                    (interceptor/-interceptor f1)))
+
+    (is (identical? indirect
+                    (interceptor/-interceptor f2)))))

--- a/tests/test/io/pedestal/interceptor_test.clj
+++ b/tests/test/io/pedestal/interceptor_test.clj
@@ -488,10 +488,11 @@
 (deftest indirect-interceptor
   (let [indirect (interceptor/interceptor {:name ::indirect :enter identity})
         f1       ^:interceptor (fn [] indirect)
-        f2       ^:interceptorfn (fn [] indirect)]
+        f2       ^:interceptorfn (fn [] {:name ::indirect :enter identity})]
 
     (is (identical? indirect
                     (interceptor/-interceptor f1)))
 
-    (is (identical? indirect
+    ;; This also shows that the result is converted (from a Map to an Interceptor).
+    (is (= indirect
                     (interceptor/-interceptor f2)))))


### PR DESCRIPTION
There was no test for putting :interceptor or :interceptorfn metadata on a function, which is interpreted as an indirect interceptor (the function is invoked, the result converted to an interceptor).