### PR TITLE
Fix: Pedestal.log depends on Pedestal.common

### DIFF
--- a/log/deps.edn
+++ b/log/deps.edn
@@ -12,6 +12,7 @@
 
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        io.pedestal/pedestal.common {:mvn/version "0.7.0-SNAPSHOT"}
         ;; logging
         org.slf4j/slf4j-api {:mvn/version "2.0.7"}
         ;; metrics
@@ -23,4 +24,5 @@
         io.opentracing/opentracing-util {:mvn/version "0.33.0"}}
  :aliases
  {:local
-  {:override-deps {io.pedestal/pedestal.metrics {:local/root "../metrics"}}}}}
+  {:override-deps {io.pedestal/pedestal.metrics {:local/root "../metrics"}
+                   io.pedestal/pedestal.common {:local/root "../common"}}}}}


### PR DESCRIPTION
Add a dependency so that `io.pedestal.internal` resolves correctly