### PR TITLE
Small optimization for io.pedestal.http.body-params/body-params

### DIFF
--- a/service/src/io/pedestal/http/body_params.clj
+++ b/service/src/io/pedestal/http/body_params.clj
@@ -160,8 +160,7 @@
 
 (def ^{:deprecated "0.7.0"} transit-parser
   "Take a request and parse its body as JSON transit."
-  (i/deprecated `transit-parser
-    (custom-transit-parser :json)))
+  (custom-transit-parser :json))
 
 (defn form-parser
   "Take a request and parse its body as a form."

--- a/tests/dev/io/pedestal/http/body_params_bench.clj
+++ b/tests/dev/io/pedestal/http/body_params_bench.clj
@@ -1,0 +1,38 @@
+(ns io.pedestal.http.body-params-bench
+  (:require [clojure.core.cache.wrapped :as cache]
+            [io.pedestal.http.body-params :as bp]
+            [criterium.core :as c]))
+
+(def parser-for #'bp/parser-for)
+
+(def sample-size 1000)
+
+(def content-types
+  (->> (cycle ["application/edn"
+               "application/json"
+               "application/x-www-form-urlencoded"
+               "application/transit+json"
+               "application/transit+msgpack"])
+       (take sample-size)))
+
+(def parser-map (bp/default-parser-map))
+
+(comment
+  (c/quick-bench
+
+    (let [*cache (cache/lru-cache-factory {})]
+      (mapv #(parser-for parser-map %) content-types)
+      :done))
+
+  ;; Original code: 463 µs
+  ;;
+  ;; Using search-for-parser, reduce-kv: 319 µs
+
+  ;; Using default lru-cache: 729 µs
+
+  ;; No cache, but search-for-parser: 302 µs
+
+  ;; search-for-parser inlined: 328 µs
+
+  ;; Revert that, back to search-for-parser: 316 µs
+  )


### PR DESCRIPTION
After looking into #805, some simple experiments showed that the overhead of maintaining the cache (using org.clojure/core.cache) was much larger than the savings from avoiding the RE matching; I did find a modest optimization by using reduce-kv.