### PR TITLE
More documentation for handling of params from the parsed body of the request

### DIFF
--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -237,7 +237,11 @@
   * :path-params-decoder: An interceptor to decode path params. Default [[path-params-decoder]].
      If nil, this interceptor is not added.
   * :tracing: An interceptor to handle telemetry request tracing; this is added as the first interceptor. Defaults
-    to [[request-tracing-interceptor]] and can be set to nil to eliminate entirely (added in 0.7.0)."
+    to [[request-tracing-interceptor]] and can be set to nil to eliminate entirely (added in 0.7.0).
+
+
+  Note that none of the default interceptors will parse the content of the request body (for POST or other requests);
+  individual _routes_ that are of type POST should include the [[body-params]] interceptor to do so."
   [service-map]
   (let [{interceptors          ::interceptors
          request-logger        ::request-logger
@@ -337,6 +341,8 @@
 
 ;;TODO: Make this a multimethod
 (defn interceptor-chain-provider
+  "Called from [[create-provider]], uses the ::chain-provider or ::type key of the service map
+  to create the chain provider. "
   [service-map]
   (let [{::keys [chain-provider type]} service-map]
     (cond
@@ -350,8 +356,8 @@
                           "Try setting :type to :jetty in your service map."))))))
 
 (defn create-provider
-  "Creates the base Interceptor Chain provider, connecting a backend to the interceptor
-  chain."
+  "Applies [[default-interceptors]] (if not already applied) and creates the interceptor chain
+  provider (the basis for starting an embedded servlet container)."
   [service-map]
   (-> service-map
       default-interceptors

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -54,7 +54,7 @@
         io.pedestal/pedestal.common {:local/root "../common"}
         io.pedestal/pedestal.error {:local/root "../error"}
 
-        io.github.hlship/trace {:mvn/version "1.1"}
+        io.github.hlship/trace {:mvn/version "1.2"}
 
         ;; This is primarily to pick up the logging dependencies it provides.
         io.pedestal/pedestal.service-tools {:local/root "../service-tools"}
@@ -74,8 +74,7 @@
  {:coverage
   {:paths      ["test" "resources"]
    :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}}
-   :jvm-opts   ["-Dio.pedestal.dev-mode=true"
-                "-Dcollecting-coverage=true"]
+   :jvm-opts   ["-Dcollecting-coverage=true"]
    :main-opts  ["--main" "cloverage.coverage"
                 "--test-ns-path" "test"
                 "--ns-regex" "\\Qio.pedestal.\\E.*"
@@ -91,10 +90,9 @@
 
   ;; clj -X:test
   :test
-  {:jvm-opts ["-Dio.pedestal.dev-mode=true"]                ;; Needed for io.pedestal.http.route-repl-test
-
+  {
    ;; Need extra test runner to avoid test hangs
-   :exec-fn  io.pedestal.test-runner/test}
+   :exec-fn io.pedestal.test-runner/test}
 
   :otel
   ;; Enable the implementations of OpenTelemetry and configure sources, to allow experimenting at the REPL.

--- a/tests/resources/data_readers.clj
+++ b/tests/resources/data_readers.clj
@@ -1,0 +1,1 @@
+{trace/result net.lewisship.trace/trace-result-reader}

--- a/tests/test/io/pedestal/http/route_repl_test.clj
+++ b/tests/test/io/pedestal/http/route_repl_test.clj
@@ -15,7 +15,6 @@
             [io.pedestal.http.route.internal :as internal]
             [io.pedestal.test-common :as tc]
             [io.pedestal.http.route :as route :as route]
-            [io.pedestal.http.route.internal :as i]
             [io.pedestal.environment :refer [dev-mode?]]))
 
 (use-fixtures :once tc/no-ansi-fixture
@@ -92,7 +91,7 @@
 
         out-str (with-out-str
                   (println)
-                  (i/print-routing-table routes))]
+                  (internal/print-routing-table routes))]
     ;; Note: sorted by path
     (is (= "
 ┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓

--- a/tests/test/io/pedestal/http/route_repl_test.clj
+++ b/tests/test/io/pedestal/http/route_repl_test.clj
@@ -12,12 +12,16 @@
 (ns io.pedestal.http.route-repl-test
   "Tests for dev-mode related macros in io.pedestal.http.route."
   (:require [clojure.test :refer [deftest is use-fixtures]]
+            [io.pedestal.http.route.internal :as internal]
             [io.pedestal.test-common :as tc]
-            [io.pedestal.http.route :as route :refer [routes-from]]
+            [io.pedestal.http.route :as route :as route]
             [io.pedestal.http.route.internal :as i]
             [io.pedestal.environment :refer [dev-mode?]]))
 
-(use-fixtures :once tc/no-ansi-fixture)
+(use-fixtures :once tc/no-ansi-fixture
+              (fn [f]
+                (with-redefs [dev-mode? true]
+                  (f))))
 
 (deftest dev-mode-enabled
   ;; Sanity check that dev-mode is enabled when running tests or a REPL.
@@ -38,76 +42,39 @@
 (def sample-routes
   #{["/hello" :get [#'hello-handler] :route-name ::hello]})
 
-(defn- simplify
+(defn- exercise
   [expanded-routes]
   ;; These two keys do not compare well.
   (mapv #(dissoc % :path-re :interceptors) expanded-routes))
 
+(defmacro routes-from
+  [expr]
+  (internal/routes-from-expr expr &env `route/expand-routes))
+
 (deftest symbol-points-to-var
-  (let [f (routes-from sample-routes)
+  (let [f          (routes-from sample-routes)
         alt-routes #{["/bye" :get #'bye-handler :route-name ::bye]}]
     (is (fn? f))
 
-    (let [out-str (with-out-str
-                    (is (= (simplify (route/expand-routes sample-routes))
-                           (simplify (f)))))]
-      (is (= "Routing table:
-┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃   Path ┃ Name                                    ┃
-┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-┃   :get ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
-┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-" out-str))
-      )
-
-    (let [out-str (with-out-str (f))]
-      ;; Unchanged routing table, no output.
-      (is (= "" out-str)))
+    (is (= (exercise (route/expand-routes sample-routes))
+           (exercise (f))))
 
     ;; Test that the function de-refs the Var, rather than capturing the value
     ;; at macro expansion time.
     (with-redefs [sample-routes alt-routes]
-      (let [out-str (with-out-str
-                      (is (= (simplify (route/expand-routes alt-routes))
-                             (simplify (f)))))]
-        (is (= "Routing table:
-┏━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃ Path ┃ Name                                  ┃
-┣━━━━━━━━╋━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-┃   :get ┃ /bye ┃ :io.pedestal.http.route-repl-test/bye ┃
-┗━━━━━━━━┻━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-" out-str))
-        ))))
+      (is (= (exercise (route/expand-routes alt-routes))
+             (exercise (f)))))))
 
 (deftest local-symbol-is-simply-wrapped-as-function
   (let [local-routes #{["/hi" :get #'hello-handler :route-name ::hi]}
-        f (routes-from local-routes)
-        out-str (with-out-str
-                  (is (= (simplify (route/expand-routes local-routes))
-                         (simplify (f)))))]
-    (is (= "Routing table:
-┏━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃ Path ┃ Name                                 ┃
-┣━━━━━━━━╋━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-┃   :get ┃  /hi ┃ :io.pedestal.http.route-repl-test/hi ┃
-┗━━━━━━━━┻━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-" out-str))))
+        f            (routes-from local-routes)]
+    (is (= (exercise (route/expand-routes local-routes))
+           (exercise (f))))))
 
 (deftest production-mode
   (let [output (with-redefs [dev-mode? false]
-                 (eval `(routes-from sample-routes)))]
+                 (eval `(route/routes-from sample-routes)))]
     (is (identical? sample-routes output))))
-
-(deftest fn-router-invokes-fn-at-creation
-  (let [*invoke-count (atom 0)
-        f (fn []
-            (swap! *invoke-count inc)
-            (route/expand-routes sample-routes))]
-    ; Create a router interceptor
-    (route/router f)
-    ;; The routing spec fn is invoked immediately, even before a
-    ;; request is routed.
-    (is (= 1 @*invoke-count))))
 
 (deftest outputs-extra-columns-when-different
   (let [routes (concat
@@ -136,4 +103,57 @@
 ┃   :admin ┃  :http ┃ internal ┃ 9090 ┃   :get ┃ /status ┃ :status    ┃
 ┗━━━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━┻━━━━━━┻━━━━━━━━┻━━━━━━━━━┻━━━━━━━━━━━━┛
 " out-str))))
+
+(deftest static-routes-printed-once
+  (let [expanded-routes (route/expand-routes sample-routes)
+        out-str         (with-out-str
+                          (println)
+                          (is (= expanded-routes
+                                 (internal/wrap-routing-table expanded-routes))))]
+    (is (= "
+Routing table:
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃   Path ┃ Name                                    ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃   :get ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+" out-str))))
+
+(deftest dynamic-routes-printed-at-startup-and-when-changed
+  (let [expanded-routes (route/expand-routes sample-routes)
+        *routes         (atom expanded-routes)
+        *wrapped        (atom nil)
+        f               (fn []
+                          @*routes)
+        out-str         (with-out-str
+                          (println)
+                          (reset! *wrapped
+                                  (internal/wrap-routing-table f)))
+        wrapped         @*wrapped
+        _               (is (= "
+Routing table:
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃   Path ┃ Name                                    ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃   :get ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+" out-str))
+        out-str         (with-out-str
+                          (is (= expanded-routes (wrapped))))
+        ;; No change, no output
+        _               (is (= out-str ""))
+        new-routes      (route/expand-routes #{["/login" :post hello-handler :route-name ::login]})
+        _               (reset! *routes new-routes)
+        out-str         (with-out-str
+                          (println)
+                          (is (= new-routes (wrapped))))]
+    (is (= out-str "
+Routing table:
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃   Path ┃ Name                                    ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃  :post ┃ /login ┃ :io.pedestal.http.route-repl-test/login ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+"))))
+
 


### PR DESCRIPTION
This was discussed in the Antora documentation but no docstring at all on the key function.

Also, refinements to the way that we print out the routing table in dev mode.