### PR TITLE
Move specs into their own namespaces

### DIFF
--- a/docs/modules/reference/nav.adoc
+++ b/docs/modules/reference/nav.adoc
@@ -7,6 +7,7 @@
 *** xref:interceptors.adoc[]
 *** xref:chain-providers.adoc[]
 *** xref:error-handling.adoc[]
+*** xref:specs.adoc[]
 *** xref:dev-mode.adoc[]
 
 ** HTTP Handling

--- a/docs/modules/reference/pages/specs.adoc
+++ b/docs/modules/reference/pages/specs.adoc
@@ -1,0 +1,22 @@
+= Specs
+
+Limited parts of Pedestal are described using
+link:https://clojure.org/guides/spec[Clojure specs].
+
+This includes the structure of the
+xref:service-map.adoc[], and the various kinds of
+xref:routing-quick-reference.adoc[route specifications].
+
+Use of spec is entirely optional; specs are confined to their own namespaces
+which are not loaded by the library itself.  You can, in your own application's tests, load these namespaces and instrument functions as appropriate.
+
+Spec namespaces:
+
+* api:*[ns=io.pedestal.interceptor.specs]
+* api:*[ns=io.pedestal.route.specs]
+* api:*[ns=io.pedestal.http.impl.servlet-interceptor.specs]
+* api:*[ns=io.pedestal.http.specs]
+* api:*[ns=io.pedestal.websocket.specs]
+
+
+

--- a/interceptor/src/io/pedestal/interceptor.clj
+++ b/interceptor/src/io/pedestal/interceptor.clj
@@ -14,8 +14,7 @@
 (ns io.pedestal.interceptor
   "Public API for creating interceptors, and various utility fns for
   common interceptor creation patterns."
-  (:require [clojure.spec.alpha :as s]
-            [io.pedestal.internal :as i])
+  (:require [io.pedestal.internal :as i])
   (:import (clojure.lang Cons Fn IPersistentList IPersistentMap Symbol Var)
            (java.io Writer)))
 
@@ -108,5 +107,3 @@
    :post [(valid-interceptor? %)]}
   (-interceptor t))
 
-(s/def ::interceptor #(satisfies? IntoInterceptor %))
-(s/def ::interceptors (s/coll-of ::interceptor))

--- a/interceptor/src/io/pedestal/interceptor/specs.clj
+++ b/interceptor/src/io/pedestal/interceptor/specs.clj
@@ -1,0 +1,25 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.interceptor.specs
+  (:require [clojure.spec.alpha :as s]
+            [io.pedestal.interceptor :as i]))
+
+;; Things that can be converted into interceptors:
+(s/def ::interceptor #(satisfies? i/IntoInterceptor %))
+(s/def ::interceptors (s/coll-of ::interceptor))
+
+;; Things that are actually interceptors:
+(s/def ::interceptor-record i/interceptor?)
+
+(s/fdef i/interceptor
+        :args (s/cat :input-object ::interceptor)
+        :ret ::interceptor-record)

--- a/route/src/io/pedestal/http/route/specs.clj
+++ b/route/src/io/pedestal/http/route/specs.clj
@@ -16,7 +16,7 @@
   specs are optional unless this namespace is required."
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as string]
-            [io.pedestal.interceptor :as i]
+            [io.pedestal.interceptor.specs :as i]
             [io.pedestal.http.route.definition.table :as table]
             [io.pedestal.http.route.definition.terse :as terse]
             [io.pedestal.http.route.definition.verbose :as verbose]

--- a/service/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/service/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -24,7 +24,6 @@
             [io.pedestal.http.request :as request]
             [io.pedestal.http.request.map :as request-map]
             [ring.util.response :as ring-response]
-            [clojure.spec.alpha :as s]
             [io.pedestal.metrics :as metrics]
     ;; for side effects:
             io.pedestal.http.route
@@ -401,14 +400,11 @@
             (log/counter :io.pedestal/active-servlet-calls -1)
             (swap! *active-calls dec)))))))
 
-(s/def ::http-interceptor-service-fn-options
-  (s/keys :opt-un [::exception-analyzer]))
-
-(s/def ::exception-analyzer fn?)
 
 (defn http-interceptor-service-fn
   "Returns a function which can be used as an implementation of the
-  Servlet.service method. It executes the interceptors on an initial
+  Servlet.service method. It executes the interceptors (which must be
+  already converted into Interceptor records) on an initial
   context map containing :servlet, :servlet-config, :servlet-request,
   and :servlet-response. The [[stylobate]] and [[ring-response]] interceptors
   are prepended to the sequence of interceptors.

--- a/service/src/io/pedestal/http/impl/servlet_interceptor/specs.clj
+++ b/service/src/io/pedestal/http/impl/servlet_interceptor/specs.clj
@@ -1,0 +1,26 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.impl.servlet-interceptor.specs
+  (:require [clojure.spec.alpha :as s]
+            [io.pedestal.interceptor.specs :as interceptor]
+            [io.pedestal.http.impl.servlet-interceptor :as si]))
+
+(s/def ::http-interceptor-service-fn-options
+  (s/keys :opt-un [::exception-analyzer]))
+
+(s/def ::exception-analyzer fn?)
+
+(s/fdef si/http-interceptor-service-fn
+        :args (s/cat :interceptors (s/coll-of ::interceptor/interceptor-record)
+                     :default-context (s/? (s/nilable map?))
+                     :options (s/? (s/nilable ::http-interceptor-service-fn-options)))
+        :ret fn?)

--- a/service/src/io/pedestal/http/specs.clj
+++ b/service/src/io/pedestal/http/specs.clj
@@ -1,0 +1,83 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.specs
+  (:require [clojure.spec.alpha :as s]
+            [io.pedestal.http.impl.servlet-interceptor.specs :as servlet-interceptor]
+            [io.pedestal.interceptor.specs :as interceptor]
+            [io.pedestal.http.route.specs :as route]
+            [io.pedestal.websocket.specs :as ws]))
+
+(s/def ::service-map
+  (s/keys :req [::port]
+          :opt [::type
+                ::host
+                ::join?
+                ::container-options
+                ::websockets
+                ::interceptors
+                ;; These are placed here when the service is created (e.g., io.pedestal.jetty/service)
+                ::start-fn
+                ::stop-fn
+                ;; From here down is essentially just what the default-interceptors function needs
+                ::request-logger
+                ::router
+                ::file-path
+                ::resource-path
+                ::method-param-name
+                ::allowed-origins
+                ::not-found-interceptor
+                ::mime-types
+                ::enable-session
+                ::enable-csrf
+                ::secure-headers
+                ::path-params-decoder
+                ::initial-context
+                ::service-fn-options
+                ::tracing]))
+
+(s/def ::port pos-int?)
+(s/def ::type (s/or :fn fn?
+                    :kw simple-keyword?))
+(s/def ::host string?)
+(s/def ::join? boolean?)
+;; Each container will define its own container-options schema:
+(s/def ::container-options map?)
+(s/def ::websockets ::ws/websockets-map)
+(s/def ::interceptors ::interceptor/interceptors)
+
+(s/def ::request-logger ::interceptor/interceptor)
+(s/def ::routes (s/or :protocol ::route/route-specification
+                      :fn fn?
+                      :nil nil?
+                      ;; TODO: Shouldn't this be caught by the ExpandableRoutes check?
+                      :maps (s/coll-of map?)))
+(s/def ::resource-path string?)
+(s/def ::method-param-name string?)
+(s/def ::allowed-origins (s/or :strings (s/coll-of string?)
+                               :fn fn?
+                               ;; io.pedestal.http.cors/allow-origin has more details
+                               :map map?))
+(s/def ::not-found-interceptor ::interceptor/interceptor)
+(s/def ::mime-types (s/map-of string? string?))
+;; See io.pedestal.http.ring-middlewares/session for more details
+(s/def ::enable-session map?)
+;; See io.pedestal.http.body-params/body-params for more details
+(s/def ::enable-csrf map?)
+;; See io.pedestal.http.secure-headers/secure-headers for more details
+(s/def ::secure-headers map?)
+(s/def ::path-params-decoder ::interceptor/interceptor)
+(s/def ::initial-context map?)
+(s/def ::tracing ::interceptor/interceptor)
+
+(s/def ::service-fn-options ::servlet-interceptor/http-interceptor-service-fn-options)
+(s/def ::start-fn fn?)
+(s/def ::stop-fn fn?)

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -11,7 +11,6 @@
 
 (ns io.pedestal.websocket
   (:require [clojure.core.async :as async :refer [go-loop put!]]
-            [clojure.spec.alpha :as s]
             [io.pedestal.log :as log])
   (:import (io.pedestal.websocket FnEndpoint)
            (jakarta.websocket EndpointConfig SendHandler Session MessageHandler$Whole RemoteEndpoint$Async)
@@ -95,21 +94,6 @@
     (.put (.getUserProperties config) FnEndpoint/USER_ATTRIBUTE_KEY callback)
     (.addEndpoint container config)))
 
-(s/def ::endpoint-map (s/keys :opt-un [::on-open
-                                       ::on-close
-                                       ::on-error
-                                       ::on-text
-                                       ::on-binary]))
-
-;; TODO: Expand these as fspec's
-(s/def ::on-open fn?)
-(s/def ::on-close fn?)
-(s/def ::on-error fn?)
-(s/def ::on-text fn?)
-(s/def ::on-binary fn?)
-
-(s/def ::websockets-map
-  (s/map-of string? ::endpoint-map))
 
 (defn add-endpoints
   "Adds all websocket endpoints in the path-map."

--- a/service/src/io/pedestal/websocket/specs.clj
+++ b/service/src/io/pedestal/websocket/specs.clj
@@ -1,0 +1,29 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.websocket.specs
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::endpoint-map (s/keys :opt-un [::on-open
+                                       ::on-close
+                                       ::on-error
+                                       ::on-text
+                                       ::on-binary]))
+
+;; TODO: Expand these as fspec's
+(s/def ::on-open fn?)
+(s/def ::on-close fn?)
+(s/def ::on-error fn?)
+(s/def ::on-text fn?)
+(s/def ::on-binary fn?)
+
+(s/def ::websockets-map
+  (s/map-of string? ::endpoint-map))


### PR DESCRIPTION
This allows specs, and all the code related to specs, to be entirely optional.