### PR TITLE
Add route/*print-routing-table*

### DIFF
--- a/common/deps.edn
+++ b/common/deps.edn
@@ -10,4 +10,4 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:deps {org.clojure/clojure    {:mvn/version "1.11.2"}
-        org.clj-commons/pretty {:mvn/version "2.3.0"}}}
+        org.clj-commons/pretty {:mvn/version "2.4.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
           io.aviso/logging {:mvn/version "1.0"}
           borkdude/rewrite-edn {:mvn/version "0.4.7"}
           clj-kondo/clj-kondo {:mvn/version "2024.03.13"}
-          org.clj-commons/pretty {:mvn/version "2.3.0"}
+          org.clj-commons/pretty {:mvn/version "2.4.0"}
           babashka/fs {:mvn/version "0.5.20"}}}
 
   ;; Invoked via clj -T:build cve-check

--- a/docs/modules/guides/pages/embedded-template.adoc
+++ b/docs/modules/guides/pages/embedded-template.adoc
@@ -121,14 +121,14 @@ You can also fire up a REPL and start the service:
 
 
 ```
-> clj -A:test:dev-mode
+> clj -A:test
 Clojure 1.11.1
 user=> (use 'dev)
 nil
 user=> (go)
 Routing table:
 ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃ Path   ┃ Name                                 ┃
+┃ Method ┃  Path  ┃                 Name                 ┃
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃ :get   ┃ /hello ┃ :com.blueant.peripheral.routes/hello ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -142,9 +142,7 @@ a brief welcoming page.
 The `dev` namespace provides the functions `go`, `start`, and `stop`.
 
 The :test alias sets up the classpath so that the `dev` namespace is
-available.
-
-The :dev-mode alias enables
+available, and enables
 xref:live-repl.adoc[REPL oriented development mode], including
 the output of the routing table as the service started.
 
@@ -169,7 +167,7 @@ Jaeger is running, execute `docker stop jaeger` to stop it.
 Stop your old REPL session, if necessary, and start a new one:
 
 ```
-> clj -A:test:dev-mode:otel-agent
+> clj -A:test:otel-agent
 OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
 [otel.javaagent 2024-03-01 16:32:45:144 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 2.1.0
 Clojure 1.11.1
@@ -178,7 +176,7 @@ nil
 user=> (go)
 Routing table:
 ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃ Path   ┃ Name                                 ┃
+┃ Method ┃  Path  ┃                 Name                 ┃
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃ :get   ┃ /hello ┃ :com.blueant.peripheral.routes/hello ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

--- a/embedded/resources/io/pedestal/embedded/build/deps.tmpl
+++ b/embedded/resources/io/pedestal/embedded/build/deps.tmpl
@@ -9,7 +9,7 @@
   {:extra-paths ["test"
                  "test-resources"
                  "dev"]
-   :jvm-opts ["-Dclj-commons.ansi.enabled=false"]
+   :jvm-opts ["-Dio.pedestal.dev-mode=true"]
    :extra-deps {org.clojure/test.check     {:mvn/version "1.1.1"}
                 nubank/matcher-combinators {:mvn/version "3.9.1"}
                 io.github.cognitect-labs/test-runner
@@ -26,11 +26,8 @@
               ;; https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
               "-javaagent:target/opentelemetry-javaagent.jar"]}
 
-  :dev-mode
-  { :jvm-opts ["-Dio.pedestal.dev-mode=true"]}
-
   :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
                  slipset/deps-deploy           {:mvn/version "0.2.0"}
-                 org.clj-commons/pretty        {:mvn/version "2.3.0"}
+                 org.clj-commons/pretty        {:mvn/version "2.4.0"}
                  clj-kondo/clj-kondo           {:mvn/version "2024.03.13"}}
           :ns-default build}}}

--- a/embedded/resources/io/pedestal/embedded/test/service_test.tmpl
+++ b/embedded/resources/io/pedestal/embedded/test/service_test.tmpl
@@ -8,6 +8,7 @@
 (def ^:dynamic *server* nil)
 
 (use-fixtures :once
+              test/disable-routing-table-output-fixture
               (fn [f]
                 (let [server (-> (service-map nil)
                                  http/create-server

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -13,7 +13,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/core.async {:mvn/version "1.6.681"}
-        org.clj-commons/pretty {:mvn/version "2.3.0"}
+        org.clj-commons/pretty {:mvn/version "2.4.0"}
         io.pedestal/pedestal.log {:mvn/version "0.7.0-SNAPSHOT"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.7.0-SNAPSHOT"}}
  :aliases

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -28,6 +28,13 @@
   (:import (clojure.lang APersistentMap APersistentSet APersistentVector Fn Sequential)
            (java.net URLEncoder URLDecoder)))
 
+(def ^{:added "0.7.0"
+       :dynamic true} *print-routing-table*
+  "If true, then the routing table is printed to the console at startup, and when it changes.
+
+  Defaults to [[dev-mode?]]."
+  dev-mode?)
+
 ;;; Parsing URL query strings (RFC 3986)
 
 ;; Java's URLEncoder/URLDecoder are only correct when applied on
@@ -509,7 +516,7 @@
                        router-type
                        (router-type router-implementations))
          routing-table' (cond-> routing-table
-                          dev-mode? internal/wrap-routing-table)]
+                          *print-routing-table* internal/wrap-routing-table)]
      (router-spec routing-table' router-ctor))))
 
 (defn- attach-bad-request-response
@@ -524,8 +531,6 @@
   HTTP request into a map. Keys in the map are query-string parameter
   names, as keywords, and values are strings. The map is assoc'd into
   the request at :query-params."
-  ;; This doesn't need to be a function but it's done that way for
-  ;; consistency with 'method-param'
   (interceptor/interceptor
     {:name  ::query-params
      :enter (fn [ctx]

--- a/service/src/io/pedestal/test.clj
+++ b/service/src/io/pedestal/test.clj
@@ -13,10 +13,12 @@
 
 (ns ^{:doc "Pedestal testing utilities to simplify working with pedestal apps."}
   io.pedestal.test
-  (:require [io.pedestal.http.servlet :as servlets]
+  (:require [io.pedestal.http.route :as route]
+            [io.pedestal.http.servlet :as servlets]
             [io.pedestal.log :as log]
             [clojure.string :as cstr]
             [clojure.java.io :as io]
+            [clj-commons.ansi :as ansi]
             [clojure.core.async :as async]
             [io.pedestal.http.container :as container])
   (:import (jakarta.servlet.http HttpServletRequest HttpServletResponse)
@@ -283,3 +285,13 @@
   [interceptor-service-fn verb url & options]
   (-> (apply raw-response-for interceptor-service-fn verb url options)
       (update :body #(.toString ^ByteArrayOutputStream % "UTF-8"))))
+
+(defn disable-routing-table-output-fixture
+  "A test fixture that disables printing of the routing table, even when development mode
+   is enabled.  It also disables ANSI colors in any Pedestal console output
+   (such as deprecation warnings)."
+  {:added "0.7.0"}
+  [f]
+  (binding [route/*print-routing-table* false
+            ansi/*color-enabled*        false]
+    (f)))

--- a/tests/test/io/pedestal/http/route_repl_test.clj
+++ b/tests/test/io/pedestal/http/route_repl_test.clj
@@ -17,7 +17,11 @@
             [io.pedestal.http.route :as route :as route]
             [io.pedestal.environment :refer [dev-mode?]]))
 
-(use-fixtures :once tc/no-ansi-fixture
+(use-fixtures :once
+              tc/no-ansi-fixture
+              (fn [f]
+                (binding [route/*print-routing-table* true]
+                  (f)))
               (fn [f]
                 (with-redefs [dev-mode? true]
                   (f))))
@@ -95,7 +99,7 @@
     ;; Note: sorted by path
     (is (= "
 ┏━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┓
-┃ App name ┃ Scheme ┃     Host ┃ Port ┃ Method ┃    Path ┃ Name       ┃
+┃ App name ┃ Scheme ┃   Host   ┃ Port ┃ Method ┃   Path  ┃    Name    ┃
 ┣━━━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━╋━━━━━━╋━━━━━━━━╋━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃    :main ┃ :https ┃     main ┃ 8080 ┃   :get ┃       / ┃ :root-page ┃
 ┃   :admin ┃  :http ┃ internal ┃ 9090 ┃  :post ┃  /reset ┃ :reset     ┃
@@ -112,7 +116,7 @@
     (is (= "
 Routing table:
 ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃   Path ┃ Name                                    ┃
+┃ Method ┃  Path  ┃                   Name                  ┃
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃   :get ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -132,7 +136,7 @@ Routing table:
         _               (is (= "
 Routing table:
 ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃   Path ┃ Name                                    ┃
+┃ Method ┃  Path  ┃                   Name                  ┃
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃   :get ┃ /hello ┃ :io.pedestal.http.route-repl-test/hello ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -149,7 +153,7 @@ Routing table:
     (is (= out-str "
 Routing table:
 ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃   Path ┃ Name                                    ┃
+┃ Method ┃  Path  ┃                   Name                  ┃
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃  :post ┃ /login ┃ :io.pedestal.http.route-repl-test/login ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛


### PR DESCRIPTION
Bump clj-commons/pretty dependency to latest
Adjust output (column titles are centered now)
Add texst fixture to disable printing of routing table Update embedded template for above changes

Fixes #831 