### PR TITLE
Allow response map to omit :header and :body, but validate that it is a map with a numeric :status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Other changes:
 - Use of many deprecated functions and macros now cause deprecation warnings to be printed to stderr
 - Metrics and tracing have been reimplemented from the ground up around [Open Telemetry](https://opentelemetry.io/)
 - Libraries pedestal.log and pedestal.error contain [clj-kondo](https://github.com/clj-kondo/clj-kondo) configuration files
+- New function `io.pedestal.http/respond-with` to streamline adding a :response to the interceptor context
 
 [Closed Issues](https://github.com/pedestal/pedestal/milestone/12?closed=1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Namespace io.pedestal.http.jetty.websockets has been removed, and replaced with io.pedestal.http.websockets
 - Namespace io.pedestal.interceptor.error has been moved to a new library, io.pedestal/pedestal.error
 - Library pedestal.service no longer has a dependency on org.clojure/core.match; the new pedestal.error library has that dependency
+- Interceptors that attach an invalid :response value (not a map, for example) will now cause an exception to be thrown
+- Interceptors may now attach a partial :response map, containing just a :status key
 
 Other changes:
 - When using io.pedestal.http/dev-interceptors, uncaught exceptions are now formatted using

--- a/docs/modules/reference/pages/response-map.adoc
+++ b/docs/modules/reference/pages/response-map.adoc
@@ -15,6 +15,8 @@ When an interceptor attaches a response map (or a handler function returns a res
 If the response fails this above validations, an exception is thrown. footnote:[Prior to Pedestal 0.7,
 an invalid :response would be ignored instead, and the https://github.com/pedestal/pedestal/issues/830[execution would continue], subverting the developer's expectations.]
 
+The function api:respond-with[] is the easiest way to add a response map to the interceptor context.
+
 [cols="s,d,d,d", options="header", grid="rows"]
 |===
 | Key | Always Present? | Type | Description
@@ -40,10 +42,3 @@ WARNING: Application code that returns a header should use the proper case versi
 to lower case, outgoing response headers are left as-is, and some standard interceptors expects
 certain headers to be present with the correct name (such as `Content-Type`).
 
-## Response Validity
-
-Response validity has different semantics depending on the Pedestal layer in question.
-Pedestal's core HTTP processing layer only requires the :status key for a response to be considered valid.
-This is the semantic used by the default `not-found` interceptor.
-Meanwhile, Pedestal's lower-level servlet-specific termination check abides by the Ring response specification,
-requiring  :status and :headers keys with valid values.

--- a/docs/modules/reference/pages/response-map.adoc
+++ b/docs/modules/reference/pages/response-map.adoc
@@ -2,10 +2,18 @@
 :reftext: response map
 :navtitle: Response Map
 
-The response map is attached to the xref:context-map.adoc by any
-interceptor in the interceptor chain. The response map describes the outgoing
+The response map is attached to the xref:context-map.adoc[] by any
+xref:interceptors.adoc[interceptor] in the interceptor chain. The response map describes the outgoing
 HTTP response. If no response map is attached to the context by the time
-processing is done or if the attached response map is not valid Pedestal generates a 404 response.
+processing is done, then Pedestal generates a 404 response.
+
+When an interceptor attaches a response map (or a handler function returns a response map), the map is validated:
+
+- Must be a map
+- Must contain a positive integer value for the :status
+
+If the response fails this above validations, an exception is thrown. footnote:[Prior to Pedestal 0.7,
+an invalid :response would be ignored instead, and the https://github.com/pedestal/pedestal/issues/830[execution would continue], subverting the developer's expectations.]
 
 [cols="s,d,d,d", options="header", grid="rows"]
 |===

--- a/docs/modules/reference/pages/response-map.adoc
+++ b/docs/modules/reference/pages/response-map.adoc
@@ -12,7 +12,7 @@ When an interceptor attaches a response map (or a handler function returns a res
 - Must be a map
 - Must contain a positive integer value for the :status
 
-If the response fails this above validations, an exception is thrown. footnote:[Prior to Pedestal 0.7,
+If the response fails the above validations, an exception is thrown. footnote:[Prior to Pedestal 0.7,
 an invalid :response would be ignored instead, and the https://github.com/pedestal/pedestal/issues/830[execution would continue], subverting the developer's expectations.]
 
 The function api:respond-with[] is the easiest way to add a response map to the interceptor context.

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -469,3 +469,16 @@
 
 (defn servlet-service [service servlet-req servlet-resp]
   (.service ^Servlet (::servlet service) servlet-req servlet-resp))
+
+(defn respond-with
+  "Utility function to add a :response map to the interceptor context."
+  {:added "0.7.0"}
+  ([context status]
+   (assoc context :response {:status status}))
+  ([context status body]
+   (assoc context :response {:status status
+                             :body   body}))
+  ([context status headers body]
+   (assoc context :response {:status  status
+                             :headers headers
+                             :body    body})))

--- a/tests/test/io/pedestal/interceptor/terminator_test.clj
+++ b/tests/test/io/pedestal/interceptor/terminator_test.clj
@@ -1,0 +1,80 @@
+(ns io.pedestal.interceptor.terminator-test
+  "Tests for chain termination logic."
+  (:require [clojure.test :refer [deftest is]]
+            [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.interceptor.chain :as chain]
+            [clojure.core.async :refer [go >! chan]]
+            [io.pedestal.test-common :refer [<!!?]]
+            [io.pedestal.http.impl.servlet-interceptor :as si])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn- execute [& interceptors]
+  (let [context (#'si/terminator-inject {})]
+    (:response
+      (chain/execute context (mapv interceptor interceptors)))))
+
+(def tail
+  {:name  :taild
+   :enter #(assoc % :response {:status 401 :body "TAIL"})})
+
+(deftest fall-through-to-last
+  (is (match? {:status 401
+               :body "TAIL"}
+              (execute {:name  :do-nothing
+                        :enter identity}
+                       tail))))
+
+(deftest valid-response-map
+  (is (= {:status 303}
+         (execute {:name  :valid
+                   :enter #(assoc % :response {:status 303})}
+                  tail))))
+
+(deftest not-a-map
+  ;; It tooks some juggling in interceptor.chain to ensure that an exception
+  ;; thrown from the termination check fn was associated with the interceptor
+  ;; as shown here.
+  (when-let [e (is (thrown-with-msg? ExceptionInfo #"Interceptor attached a :response that is not a map"
+                                     (execute {:name  :not-a-map
+                                               :enter #(assoc % :response 401)})))]
+    (is (match?
+          {:exception-type :clojure.lang.ExceptionInfo
+           :interceptor    :not-a-map
+           :response       401
+           :stage          :enter}
+          (ex-data e)))))
+
+(deftest invalid-status-key
+  ;; It tooks some juggling in interceptor.chain to ensure that an exception
+  ;; thrown from the termination check fn was associated with the interceptor
+  ;; as shown here.
+  (when-let [e (is (thrown-with-msg? ExceptionInfo #"Interceptor attached a :response that is not a map"
+                                     (execute {:name  :invalid-status
+                                               :enter #(assoc % :response :not-found)})))]
+    (is (match?
+          {:interceptor    :invalid-status
+           :response       :not-found}
+          (ex-data e)))))
+
+(deftest async-termination
+  (let [ch (chan)]
+    (execute
+      {:name  :capture
+       :leave (fn [context]
+                (go
+                  (>! ch (:response context))
+                  context))}
+      {:name  :valid=async
+       :enter (fn [context]
+                (go
+                  (assoc context :response {:status 303
+                                            :body   "ASYNC"})))}
+      tail)
+    (is (match?
+          {:status 303
+           :body   "ASYNC"}
+          (<!!? ch)))))
+
+
+
+

--- a/tests/test/io/pedestal/interceptor/terminator_test.clj
+++ b/tests/test/io/pedestal/interceptor/terminator_test.clj
@@ -1,3 +1,14 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
 (ns io.pedestal.interceptor.terminator-test
   "Tests for chain termination logic."
   (:require [clojure.test :refer [deftest is]]
@@ -103,7 +114,3 @@
       (is (match? {:interceptor :invalid-async
                    :response    :invalid}
                   (ex-data e))))))
-
-
-
-

--- a/tests/test/io/pedestal/interceptor_test.clj
+++ b/tests/test/io/pedestal/interceptor_test.clj
@@ -16,6 +16,7 @@
             [io.pedestal.internal :as i]
             [clojure.core.async :as async
              :refer [<! >! go chan timeout <!! >!!]]
+            [io.pedestal.test-common :refer [<!!?]]
             [io.pedestal.interceptor :as interceptor :refer [interceptor]]
             [io.pedestal.interceptor.chain :as chain :refer (execute execute-only enqueue)]))
 
@@ -539,12 +540,6 @@
                                 (step :e)
                                 (step :f)])))))
 
-(defn <!!?
-  [ch]
-  (async/alt!!
-    ch ([context] context)
-
-    (async/timeout 75) ::timed-out))
 
 (deftest interceptor-leave-ordering-after-a-change-in-bindings-async
   (let [step     (fn [interceptor-name]

--- a/tests/test/io/pedestal/test_common.clj
+++ b/tests/test/io/pedestal/test_common.clj
@@ -10,9 +10,17 @@
 ; You must not remove this notice, or any other, from this software.
 
 (ns io.pedestal.test-common
-  (:require [clj-commons.ansi :as ansi]))
+  (:require [clj-commons.ansi :as ansi]
+            [clojure.core.async :as async]))
 
 (defn no-ansi-fixture
   [f]
   (binding [ansi/*color-enabled* false]
     (f)))
+
+(defn <!!?
+  [ch]
+  (async/alt!!
+    ch ([context] context)
+
+    (async/timeout 75) ::timed-out))


### PR DESCRIPTION
Also adds a `io.pedestal.http/respond-with` function to make it easier to avoid this.

Fixes #830