### PR TITLE
Add `io.pedestal.interceptor.chain/add-observer` to observe interceptor activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Other changes:
 - In `io.pedestal.interceptor.chain`:
     - New macros `bind` and `unbind` make it easier for interceptors to manipulate dynamic variables exposed to following interceptors 
     - New function `on-enter-async` is used to register a callback from when execution first goes asynchronous
-    - New function `queue` is used to peek at what interceptors remain on the queue 
+    - New function `queue` is used to peek at what interceptors remain on the queue
+    - New function `add-observer` to add a callback after each interceptor executes in each stage
+- New function `io.pedestal.interceptor.chain.debug/debug-observer` to observe changes to the context made by interceptors 
 - New service map keys have been introduced:
   - Support handling of uncaught exceptions
   - May now specify an initial context map
@@ -33,7 +35,7 @@ Other changes:
 - Added a deps-new template, io.pedestal/embedded, for creating a new Pedestal project around embedded Jetty
 - Use of many deprecated functions and macros now cause deprecation warnings to be printed to stderr
 - Metrics and tracing have been reimplemented from the ground up around [Open Telemetry](https://opentelemetry.io/)
-- Libraries pedestal.log and pedestal.error contain [clj-kondo](https://github.com/clj-kondo/clj-kondo) configuration files
+- Libraries pedestal.log and pedestal.error contain [clj-kondo](https://github.com/clj-kondo/clj-kondo) configuration files to inform clj-kondo about their macros
 - New function `io.pedestal.http/respond-with` to streamline adding a :response to the interceptor context
 
 [Closed Issues](https://github.com/pedestal/pedestal/milestone/12?closed=1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Other changes:
     - New function `on-enter-async` is used to register a callback from when execution first goes asynchronous
     - New function `queue` is used to peek at what interceptors remain on the queue
     - New function `add-observer` to add a callback after each interceptor executes in each stage
-- New function `io.pedestal.interceptor.chain.debug/debug-observer` to observe changes to the context made by interceptors 
+- New function `io.pedestal.interceptor.chain.debug/debug-observer` to observe changes to the context made by interceptors
+- New function `io.pedestal.http/enable-debug-interceptor-observer` to setup `debug-observer`
 - New service map keys have been introduced:
   - Support handling of uncaught exceptions
   - May now specify an initial context map

--- a/docs/modules/guides/pages/embedded-template.adoc
+++ b/docs/modules/guides/pages/embedded-template.adoc
@@ -146,9 +146,33 @@ available, and enables
 xref:live-repl.adoc[REPL oriented development mode], including
 the output of the routing table as the service started.
 
+Because the application is running in debug mode,
+Pedestal has enabled extra logging output about the execution of each interceptor, and how the interceptor changed the
+context map.
+
+```
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.cors/dev-allow-origin, :stage :enter, :execution-id 1, :context-changes {:added {[:request :headers "origin"] ""}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.tracing/tracing, :stage :enter, :execution-id 1, :context-changes {:added {[:bindings] ..., [:io.pedestal.http.tracing/otel-context-cleanup] ..., [:io.pedestal.http.tracing/prior-otel-context] ..., [:io.pedestal.http.tracing/otel-context] ..., [:io.pedestal.http.tracing/span] ...}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http/log-request, :stage :enter, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.route/query-params, :stage :enter, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.route/method-param, :stage :enter, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.ring-middlewares/resource, :stage :enter, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.route/router, :stage :enter, :execution-id 1, :context-changes {:added {[:request :url-for] ..., [:request :path-params] [], [:route] ..., [:url-for] ...}, :changed {[:bindings] ..., [:io.pedestal.interceptor.chain/queue] ...}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.route/path-params-decoder, :stage :enter, :execution-id 1, :context-changes {:changed {[:request :path-params] {:from [], :to {}}}, :added {[:io.pedestal.http.route/path-params-decoded?] true}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor "#Interceptor{}", :stage :enter, :execution-id 1, :context-changes {:added {[:response] {:status 200, :body ...}}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.secure-headers/secure-headers, :stage :leave, :execution-id 1, :context-changes {:added {[:response :headers] {"Strict-Transport-Security" "max-age=31536000; includeSubdomains", "X-Frame-Options" "DENY", "X-Content-Type-Options" "nosniff", "X-XSS-Protection" "1; mode=block", "X-Download-Options" "noopen", "X-Permitted-Cross-Domain-Policies" "none", "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"}}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.ring-middlewares/content-type-interceptor, :stage :leave, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http/not-found, :stage :leave, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.tracing/tracing, :stage :leave, :execution-id 1, :context-changes {:changed {[:bindings] ...}, :removed {[:io.pedestal.http.tracing/otel-context-cleanup] ..., [:io.pedestal.http.tracing/prior-otel-context] ..., [:io.pedestal.http.tracing/otel-context] ..., [:io.pedestal.http.tracing/span] ...}}, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.impl.servlet-interceptor/ring-response, :stage :leave, :execution-id 1, :context-changes nil, :line 128}
+DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.impl.servlet-interceptor/stylobate, :stage :leave, :execution-id 1, :context-changes nil, :line 128}
+```
+
+
 ## Gathering Telemetry
 
-The template includes very basic support for {otel} telemetry.  For local work, this is best accomplished
+The template includes very basic support for  gathering and reporting telementry using {otel}.
+For local work, this is best accomplished
 by running a Docker container with the link:https://www.jaegertracing.io/[Jaeger] server running; the container
 will collect telemetry from the running application, and also provides a user interface to examine
 the traces produced by the application.

--- a/embedded/resources/io/pedestal/embedded/root/test-resources/logback-test.xml
+++ b/embedded/resources/io/pedestal/embedded/root/test-resources/logback-test.xml
@@ -12,5 +12,6 @@
 
     <logger name="org.eclipse.jetty" level="warn"/>
     <logger name="io.pedestal" level="warn"/>
+    <logger name="io.pedestal.interceptor.chain.debug" level="debug"/>
 
 </configuration>

--- a/embedded/resources/io/pedestal/embedded/src/service.tmpl
+++ b/embedded/resources/io/pedestal/embedded/src/service.tmpl
@@ -9,7 +9,7 @@
   "Creates a service map for the {{name}} service.
 
   Options:
-    dev-mode: enables dev-interceptors if true, defaults from
+    dev-mode: enables dev-interceptors and interceptor logging if true, defaults from
     Pedestal's development mode."
   [opts]
   (let [{:keys [dev-mode]
@@ -21,5 +21,6 @@
          ::http/resource-path "public"
          ::http/join? false}
          http/default-interceptors
-         (cond-> dev-mode http/dev-interceptors))))
+         (cond-> dev-mode (-> http/dev-interceptors
+                              http/enable-debug-interceptor-observer)))))
 

--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -493,8 +493,8 @@
   :context-in       | map               | The context passed to the interceptor
   :context-out      | map               | The context returned from the interceptor
 
-  The observer is only notified about interceptor _executions_; when an interceptor does not provide a callback
-  for a stage, it is not invoked, and no notification is sent.
+  The observer is only invoked for interceptor _executions_; when an interceptor does not provide a callback
+  for a stage, the interceptor is not invoked, and so the observer is not invoked.
 
   The value returned by the observer is ignored.
 
@@ -503,7 +503,7 @@
 
   When multiple observer functions are added, they are invoked in an unspecified order.
 
-  The [[debug-observer]] function is a useful example.
-  "
+  The [[debug-observer]] function is a useful observer provided by Pedesta, which identifies
+  interceptors and how they each modified the context."
   [context observer-fn]
   (update context ::observer-fn merge-observer observer-fn))

--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -502,6 +502,8 @@
   had thrown the exception.
 
   When multiple observer functions are added, they are invoked in an unspecified order.
+
+  The [[debug-observer]] function is a useful example.
   "
   [context observer-fn]
   (update context ::observer-fn merge-observer observer-fn))

--- a/interceptor/src/io/pedestal/interceptor/chain/debug.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain/debug.clj
@@ -100,10 +100,10 @@
 
   Options map:
 
-  | Key   | Type            | Description
-  |---    |---              |---
-  | :omit | set or function | Identifies key paths, as vectors, to omit in the description.
-
+  | Key            | Type            | Description
+  |---             |---              |---
+  | :omit          | set or function | Identifies key paths, as vectors, to omit in the description.
+  | :changes-only? | boolean         | If true, then log only when the context changes.
 
   The :omit option is used to prevent certain key paths from appearing in the result delta; the value
   for these is replaced with `...`.  It is typically a set, but can also be a function that accepts

--- a/interceptor/src/io/pedestal/interceptor/chain/debug.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain/debug.clj
@@ -1,0 +1,129 @@
+; Copyright 2024 Nubank NA
+
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.interceptor.chain.debug
+  "Tools to help debug interceptor chain execution."
+  {:added "0.7.0"}
+  (:require [clojure.set :as set]
+            [io.pedestal.log :as log]))
+
+(declare delta*)
+
+(def ^:private omitted-value '...)
+
+(def default-omit-set
+  "The default key paths to be omitted when producing delta output."
+  #{[:response :body]
+    [:request :body]})
+
+
+(defn- omit-values
+  [omit-set key-path value]
+  (cond
+    (omit-set key-path)
+    omitted-value
+
+    (map? value)
+    (reduce-kv (fn [m k v]
+                 (assoc m k
+                        (omit-values omit-set (conj key-path k) v)))
+               {}
+               value)
+
+    :else
+    value))
+
+(defn- delta-maps
+  [omit-set deltas key-path original modified]
+  (let [o-keys      (-> original keys set)
+        m-keys      (-> modified keys set)
+        shared-keys (set/intersection o-keys m-keys)]
+    (reduce (fn [m k]
+              (cond
+                (and (contains? shared-keys k))
+                (delta* omit-set
+                        m
+                        (conj key-path k)
+                        (get original k)
+                        (get modified k))
+
+                (contains? m-keys k)
+                (let [key-path' (conj key-path k)]
+                  (assoc-in m [:added key-path']
+                            (omit-values omit-set key-path' (get modified k))))
+
+                :else
+                (let [key-path' (conj key-path k)]
+                  (assoc-in m [:removed key-path']
+                            (omit-values omit-set key-path' (get original k))))))
+            deltas
+            (set/union o-keys m-keys))))
+
+(defn- delta*
+  [omit-set deltas key-path original modified]
+  (cond
+    (= original modified)
+    deltas
+
+    (and (map? original) (map? modified))
+    (delta-maps omit-set deltas key-path original modified)
+
+    :else
+    (assoc-in deltas [:changed key-path]
+              (if (omit-set key-path)
+                omitted-value
+                {:from original
+                 :to   modified}))))
+
+(defn- delta
+  "Return map with keys :added, :removed, and :changed ..."
+  [omit-set original modified]
+  (delta* (or omit-set default-omit-set) {} [] original modified))
+
+(defn debug-observer
+  "Returns an observer function that logs, at debug level, the interceptor name, stage, execution id,
+  and a description of context changes.
+
+  The context changes are in the form of a map.
+  The :added key is a map of key path to added values.
+  The :removed key is a map of key path to removed values.
+  The :changed key is a map of key path to a value change, a map of :from and :to.
+
+
+  Options map:
+
+  | Key   | Type            | Description
+  |---    |---              |---
+  | :omit | set or function | Identifies key paths, as vectors, to omit in the description.
+
+
+  The :omit option is used to prevent certain key paths from appearing in the result delta; the value
+  for these is replaced with `...`.  It is typically a set, but can also be a function that accepts
+  a key path vector.
+
+  The default for :omit is `#{[:response :body] [:request :body]}`. This omits data that can be both
+  sensitive and verbose."
+  ([]
+   (debug-observer nil))
+  ([options]
+   (let [{:keys [omit changes-only?]} options
+         always? (not changes-only?)]
+     (fn [event]
+       (let [{:keys [execution-id stage interceptor-name context-in context-out]} event
+             changes? (not= context-in context-out)]
+         (when (or always? changes?)
+           (log/debug
+             :interceptor interceptor-name
+             :stage stage
+             :execution-id execution-id
+             :context-changes (when changes?
+                                (delta omit context-in context-out)))))))))
+

--- a/tests/resources/logback-test.xml
+++ b/tests/resources/logback-test.xml
@@ -11,5 +11,6 @@
     </root>
 
     <logger name="org.eclipse.jetty.servlets.DoSFilter" level="ERROR"/>
+    <logger name="io.pedestal.interceptor.chain.debug" level="debug"/>
 
 </configuration>

--- a/tests/test/io/pedestal/interceptor/observer_test.clj
+++ b/tests/test/io/pedestal/interceptor/observer_test.clj
@@ -176,7 +176,7 @@
 (deftest debug-observer
   (mock/providing [(log/make-logger "io.pedestal.interceptor.chain.debug") capture-logger
                    (log/make-logger (m/any)) mock/fall-through]
-    (execute (chain/add-observer nil (debug/debug-observer))
+    (execute (chain/add-observer nil (debug/debug-observer {:omit #{[:response :body]}}))
              {:name  ::content-type
               :leave #(assoc-in % [:response :headers "Content-Type"] "application/edn")}
              {:name  ::change-status

--- a/tests/test/io/pedestal/interceptor/observer_test.clj
+++ b/tests/test/io/pedestal/interceptor/observer_test.clj
@@ -1,0 +1,122 @@
+(ns io.pedestal.interceptor.observer-test
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [io.pedestal.interceptor.chain :as chain]
+            [io.pedestal.interceptor :refer [interceptor]]))
+
+(def *events (atom []))
+
+(use-fixtures :each
+              (fn [f]
+                (swap! *events empty)
+                (f)))
+
+(defn- event-observer
+  [event]
+  (swap! *events conj event))
+
+(defn- names-and-stages
+  []
+  (mapv (juxt :interceptor-name :stage) @*events))
+
+(defn- execute
+  [context & interceptors]
+  (chain/execute context (mapv interceptor interceptors)))
+
+(deftest observes-each-stage
+  (execute (chain/add-observer nil event-observer)
+           {:name  ::outer
+            :enter identity
+            :leave identity}
+           {:name  ::middle
+            :leave identity}
+           {:name  ::inner
+            :enter identity})
+
+  (is (= [[::outer :enter]
+          [::inner :enter]
+          [::middle :leave]
+          [::outer :leave]]
+         (names-and-stages))))
+
+(deftest observes-errors
+  (execute (chain/add-observer nil event-observer)
+           {:name  ::outer
+            :enter identity
+            :error (fn [context _]
+                     context)}
+           {:name  ::middle
+            :enter identity
+            :leave identity}
+           {:name  ::failure
+            :enter (fn [_context]
+                     (throw (RuntimeException. "Ignore: just testing exception handling")))})
+  (is (= [[::outer :enter]
+          [::middle :enter]
+          ;; No notification for ::failure interceptor as the exception occurred there.
+          ;; No notification for ::middle, as it doesn't provide an :error handler.
+          [::outer :error]]
+         (names-and-stages))))
+
+(deftest old-and-new-contexts-are-passed
+  (execute (chain/add-observer nil event-observer)
+           {:name  ::outer
+            :enter #(assoc % :foo :bar)
+            :leave identity}
+           {:name  ::inner
+            :leave #(assoc % :gnip :gnop)})
+
+  (is (= [[::outer :enter]
+          [::inner :leave]
+          [::outer :leave]])
+      (names-and-stages))
+
+  (is (match?
+        [{:new-context {:foo :bar}}
+         {:old-context {:foo :bar}
+          :new-context {:foo  :bar
+                        :gnip :gnop}}
+         {:old-context {:foo  :bar
+                        :gnip :gnop}
+          :new-context {:foo  :bar
+                        :gnip :gnop}}]
+        @*events)))
+
+(deftest calls-multiple-observers
+  (let [*events-1 (atom [])
+        *events-2 (atom [])
+        context (-> {}
+                    (chain/add-observer #(swap! *events-1 conj %))
+                    (chain/add-observer #(swap! *events-2 conj %)))]
+    (execute context
+             {:name  ::outer
+              :enter identity
+              :leave identity}
+             {:name  ::middle
+              :leave identity}
+             {:name  ::inner
+              :enter identity})
+
+    (is (= 4 (count @*events-1)))
+
+    (is (= @*events-1 @*events-2))))
+
+(deftest can-add-observers-mid-stream
+  (execute {}
+           {:name  ::outer
+            :enter identity
+            :leave identity}
+           ;; The notification is based on the new context returned by this interceptor, so
+           ;; the ::observer :enter stage will be visible to the observer function.
+           {:name  ::observer
+            :enter #(chain/add-observer % event-observer)}
+           {:name  ::middle
+            :leave identity}
+           {:name  ::inner
+            :enter identity})
+
+
+  (is (= [[::observer :enter]
+          [::inner :enter]
+          [::middle :leave]
+          [::outer :leave]]
+         (names-and-stages))))

--- a/tests/test/io/pedestal/interceptor_test.clj
+++ b/tests/test/io/pedestal/interceptor_test.clj
@@ -17,6 +17,7 @@
             [clojure.core.async :as async
              :refer [<! >! go chan timeout <!! >!!]]
             [io.pedestal.test-common :refer [<!!?]]
+            [io.pedestal.test-common :refer [<!!?]]
             [io.pedestal.interceptor :as interceptor :refer [interceptor]]
             [io.pedestal.interceptor.chain :as chain :refer (execute execute-only enqueue)]))
 
@@ -260,15 +261,6 @@
     (is (= 1
            (-> thread-ids distinct count)))))
 
-(defn <!!!
-  "<!! with a timeout to keep tests from hanging."
-  ([ch]
-   (<!!! ch 1000))
-  ([ch timeout]
-   (async/alt!!
-     ch ([val _] val)
-     (async/timeout timeout) ::timeout)))
-
 (deftest failed-channel-produces-error
   (println "This test will produce an uncaught exception, which can be ignored.")
   (let [result-chan (chan)
@@ -288,7 +280,7 @@
                           [:enter :b]
                           [:error :b :from nil]
                           [:leave :a]]}
-                (<!!! result-chan)))))
+                (<!!? result-chan)))))
 
 (deftest one-way-async-channel-enter
   (let [result-chan (chan)
@@ -319,7 +311,7 @@
                                             (two-channeler :c)
                                             (tracer :d)])
                                   :leave)
-        result      (<!!! result-chan)
+        result      (<!!? result-chan)
         thread-ids  (result ::thread-ids)]
     (is (match? {::trace [[:leave :d]
                           [:leave :c]
@@ -465,7 +457,7 @@
                       (observer :d :enter false)
                       (observer :e :leave true)]]
     (execute {} interceptors)
-    (is (nil? (<!!! chan)))
+    (is (nil? (<!!? chan)))
 
     (is (match? [{:name :a :stage :enter :value :default}
                  ;; :first

--- a/tests/test/io/pedestal/test_common.clj
+++ b/tests/test/io/pedestal/test_common.clj
@@ -19,8 +19,10 @@
     (f)))
 
 (defn <!!?
-  [ch]
-  (async/alt!!
-    ch ([context] context)
-
-    (async/timeout 75) ::timed-out))
+  "<!! with a timeout to keep tests from hanging."
+  ([ch]
+   (<!!? ch 1000))
+  ([ch timeout]
+   (async/alt!!
+     ch ([val _] val)
+     (async/timeout timeout) ::timeout)))


### PR DESCRIPTION
This also adds a `debug-observer` that logs (or `tap>`s) information about interceptors and how they have affected the context.