### PR TITLE
Updating libraries to solve vulnerability issues

### DIFF
--- a/aws/deps.edn
+++ b/aws/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.6.3"}
 

--- a/immutant/deps.edn
+++ b/immutant/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         io.pedestal/pedestal.service {:mvn/version "0.6.3"}
 
         potemkin/potemkin {:mvn/version "0.4.6"}

--- a/interceptor/deps.edn
+++ b/interceptor/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/core.async {:mvn/version "1.6.673"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         ;; Error interceptor tooling

--- a/jetty/deps.edn
+++ b/jetty/deps.edn
@@ -13,14 +13,14 @@
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         io.pedestal/pedestal.service {:mvn/version "0.6.3"}
-        org.eclipse.jetty/jetty-server {:mvn/version "9.4.53.v20231009"}
-        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.53.v20231009"}
+        org.eclipse.jetty/jetty-server {:mvn/version "9.4.54.v20240208"}
+        org.eclipse.jetty/jetty-servlet {:mvn/version "9.4.54.v20240208"}
         org.eclipse.jetty.alpn/alpn-api {:mvn/version "1.1.3.v20160715"}
-        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.53.v20231009"}
-        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.53.v20231009"}
-        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.53.v20231009"}
-        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.53.v20231009"}
-        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.53.v20231009"}
+        org.eclipse.jetty/jetty-alpn-server {:mvn/version "9.4.54.v20240208"}
+        org.eclipse.jetty.http2/http2-server {:mvn/version "9.4.54.v20240208"}
+        org.eclipse.jetty.websocket/websocket-api {:mvn/version "9.4.54.v20240208"}
+        org.eclipse.jetty.websocket/websocket-servlet {:mvn/version "9.4.54.v20240208"}
+        org.eclipse.jetty.websocket/websocket-server {:mvn/version "9.4.54.v20240208"}
         javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}
  :aliases
  {:clj11

--- a/jetty/deps.edn
+++ b/jetty/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         io.pedestal/pedestal.service {:mvn/version "0.6.3"}
         org.eclipse.jetty/jetty-server {:mvn/version "9.4.54.v20240208"}
@@ -24,7 +24,7 @@
         javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}}
  :aliases
  {:clj11
-  {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}}
 
   ;; clj -J-Dclojure.main.report=stderr -J-Dorg.slf4j.simpleLogger.log.org.apache.commons=error -X:nvd :classpath \""$(clojure -Alocal -Spath)\""
   :nvd

--- a/log/deps.edn
+++ b/log/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         ;; logging
         org.slf4j/slf4j-api {:mvn/version "1.7.35"}
         ;; metrics

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/core.async {:mvn/version "1.6.673"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.6.3"}}

--- a/samples/http2-conscrypt/project.clj
+++ b/samples/http2-conscrypt/project.clj
@@ -28,7 +28,7 @@
                  ;;   Normally, you'd only take the version based on your OS,
                  ;;   but the Uberjar has all shared libs bundled up, which is nice for this example
                  [org.conscrypt/conscrypt-openjdk-uber "2.5.2"]
-                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.53.v20231009"]]
+                 [org.eclipse.jetty/jetty-alpn-conscrypt-server "9.4.54.v20240208"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "hp.server/run-dev"]}}

--- a/samples/servlet-filters-gzip/project.clj
+++ b/samples/servlet-filters-gzip/project.clj
@@ -22,7 +22,7 @@
                  ;; other options don't appear here.
                  [io.pedestal/pedestal.jetty "0.5.9"]
                  [org.eclipse.jetty/jetty-servlets "9.4.10.v20180503"]
-                 [org.eclipse.jetty/jetty-servlet "9.4.53.v20231009"]
+                 [org.eclipse.jetty/jetty-servlet "9.4.54.v20240208"]
                  [ch.qos.logback/logback-classic "1.2.10" :exclusions [org.slf4j/slf4j-api]]
                  [org.slf4j/jul-to-slf4j "1.7.35"]
                  [org.slf4j/jcl-over-slf4j "1.7.35"]

--- a/service-tools/deps.edn
+++ b/service-tools/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         io.pedestal/pedestal.service {:mvn/version "0.6.3"}
 
         org.clojure/data.xml {:mvn/version "0.2.0-alpha5"}

--- a/service/deps.edn
+++ b/service/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src" "target/classes"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         io.pedestal/pedestal.log {:mvn/version "0.6.3"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.6.3"}
         io.pedestal/pedestal.route {:mvn/version "0.6.3"}

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -35,7 +35,7 @@
         ;; https://github.com/AsyncHttpClient/async-http-client
         ;; So benchmarking should be updated to use that.
         com.ning/async-http-client {:mvn/version "1.8.13"}
-        org.eclipse.jetty/jetty-servlets {:mvn/version "9.4.53.v20231009"}
+        org.eclipse.jetty/jetty-servlets {:mvn/version "9.4.54.v20240208"}
 
         ;; Include *all* the other modules
         io.pedestal/pedestal.log {:local/root "../log"}

--- a/tomcat/deps.edn
+++ b/tomcat/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.2"}
 
         org.apache.tomcat.embed/tomcat-embed-jasper {:mvn/version "9.0.80"}
         org.apache.tomcat.embed/tomcat-embed-core {:mvn/version "9.0.80"}


### PR DESCRIPTION
The goal of this PR is:
1. bump Jetty's libraries version in order to fix CVE-2024-22201 vulnerability;
2. bump Clojure version in order to fix CVE-2024-22871 vulnerability;

