### PR TITLE
Add additional configuration and callbacks when setting up a websocket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ Other changes:
 
 [Closed Issues](https://github.com/pedestal/pedestal/milestone/12?closed=1)
 
+## 0.6.4 -- 14 May 2024
+
+This release is just to provide dependency upgrades to address CVEs in Jetty and Clojure.
+
+[Closed Issues](https://github.com/pedestal/pedestal/milestone/16?closed=1)
+
 ## 0.6.3 -- 30 Nov 2023
 
 A change has been made to the `path-params-decoder` to address the breaking change in 0.6.0; by

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -17,9 +17,10 @@ to Websocket handlers is defined in the xref:service-map.adoc[].
 In the service map, the :io.pedestal.http/websockets key
 maps string routes to endpoint maps.
 
-The endpoint map is a set of callbacks.  The path and endpoint map are ultimately passed to the api:add-endpoint[] function, which describes
+The endpoint map is a set of callbacks and configuration.  The path and endpoint map are ultimately passed to the api:add-endpoint[] function, which describes
 in detail how the callbacks are used.
 
+.Callbacks
 |===
 | Key | Signature | Description
 
@@ -44,7 +45,24 @@ in detail how the callbacks are used.
 | (Object, ByteBuffer) -> nil
 | Passed a binary message, as a single ByteBuffer.
 
+| :configure
+| (ServerEndpointConfig$Builder) -> nil
+| Allows additional configuration using an instance of `jakarta.websocket.server.ServerEndpointConfig.Builder`.
 
+
+|===
+
+.Configuration
+|===
+| Key | Type | Description
+
+| :subprotocols
+| vector of String
+| Optional, specifies sub-protocols for the websocket connection
+
+| :idle-timeout-ms
+| long
+| Sets the max idle timeout for the websocket to a fixed value.
 |===
 
 Essentially, the :on-open callback is invoked when the client initiates the connection.
@@ -55,7 +73,7 @@ It is the responsibility of the :on-open callback to create such a process.
 One common option is to use the api:on-open-start-ws-connection[] function to create the callback, or
 construct the :on-open callback around the api:start-ws-connection[] function.
 
-The :on-string and :on-binary callbacks are invoked when a text or binary message from the client
+The :on-text and :on-binary callbacks are invoked when a text or binary message from the client
 is received.
 
 

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -14,7 +14,7 @@
             [io.pedestal.log :as log])
   (:import (io.pedestal.websocket FnEndpoint)
            (jakarta.websocket EndpointConfig SendHandler Session MessageHandler$Whole RemoteEndpoint$Async)
-           (jakarta.websocket.server ServerContainer ServerEndpointConfig ServerEndpointConfig$Builder)
+           (jakarta.websocket.server ServerContainer  ServerEndpointConfig$Builder)
            (java.nio ByteBuffer)))
 
 (defn- message-handler
@@ -32,8 +32,9 @@
   (let [{:keys [on-open
                 on-close
                 on-error
-                on-text                                     ;; TODO: rename to `on-string`?
-                on-binary]} ws-map
+                on-text
+                on-binary
+                idle-timeout-ms]} ws-map
         maybe-invoke-callback (fn [f ^Session session event-value]
                                 (when f
                                   (let [session-object (-> session
@@ -45,6 +46,9 @@
                                                        (on-open session config))]
                                   ;; Store this for on-close, on-error
                                   (-> session .getUserProperties (.put session-object-key session-object))
+
+                                  (when idle-timeout-ms
+                                    (.setMaxIdleTimeout session (long idle-timeout-ms)))
 
                                   (when on-text
                                     (.addMessageHandler session String (message-handler session-object on-text)))
@@ -84,13 +88,28 @@
   :on-binary (Object, java.nio.ByteBuffer)
   : Passed a binary message as a single ByteBuffer.
 
+  :configure (jakarta.websocket.server.ServerEndpointConfig.Builder)
+  : Called at initialization time to perform any extra configuration of the endpoint (optional)
+
+  :subprotocols (vector of String, optional)
+  : Configures the subprotocols of the endpoint
+
+  :idle-timeout-ms (long)
+  : Time in milliseconds before an idle websocket is automatically closed.
+
   All callbacks are optional.  The :on-open callback is critical, as it performs all the one-time setup
-  for the WebSocket connection. The [[on-open-start-ws-connection]] function is a good starting place.
-  "
+  for the WebSocket connection. The [[on-open-start-ws-connection]] function is a good starting place."
   [^ServerContainer container ^String path ws-endpoint-map]
   (let [callback (make-endpoint-delegate-callback ws-endpoint-map)
-        config   ^ServerEndpointConfig (-> (ServerEndpointConfig$Builder/create FnEndpoint path)
-                                           .build)]
+        {:keys [subprotocols
+                configure]} #trace/result ws-endpoint-map
+        builder  (ServerEndpointConfig$Builder/create FnEndpoint path)
+        _        (do
+                   (when subprotocols
+                     (.subprotocols builder subprotocols))
+                   (when configure
+                     (configure builder)))
+        config   (.build builder)]
     (.put (.getUserProperties config) FnEndpoint/USER_ATTRIBUTE_KEY callback)
     (.addEndpoint container config)))
 
@@ -132,7 +151,8 @@
 
   Returns a channel used to send messages to the client.
 
-  The values written to the channel are either a payload (a String, ByteBuffer, or some object
+  The values written to the channel are either
+  a payload (a String, ByteBuffer, or some object
   that satisfies the WebSocketSendAsync protocol) or is a tuple of a payload and a response channel.
 
   When the response channel is non-nil, the result of the message send is written to it:

--- a/service/src/io/pedestal/websocket/specs.clj
+++ b/service/src/io/pedestal/websocket/specs.clj
@@ -16,7 +16,10 @@
                                        ::on-close
                                        ::on-error
                                        ::on-text
-                                       ::on-binary]))
+                                       ::on-binary
+                                       ::configure
+                                       ::subprotocols
+                                       ::idle-timeout-ms]))
 
 ;; TODO: Expand these as fspec's
 (s/def ::on-open fn?)
@@ -24,6 +27,10 @@
 (s/def ::on-error fn?)
 (s/def ::on-text fn?)
 (s/def ::on-binary fn?)
+(s/def ::configure fn?)
+(s/def ::idle-timeout-ms pos-int?)
+
+(s/def ::subprotocols (s/coll-of string? :kind vector?))
 
 (s/def ::websockets-map
   (s/map-of string? ::endpoint-map))

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -66,6 +66,9 @@
         ;; only used for tracing test
         io.jaegertracing/jaeger-client {:mvn/version "1.0.0"}
 
+        ;; For proper reloading of code in REPL
+        io.github.tonsky/clj-reload {:mvn/version "0.5.0"}
+
         io.github.cognitect-labs/test-runner
         {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
 

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -20,13 +20,13 @@
     [net.lewisship.trace :refer [trace]]
     [io.pedestal.websocket :as websocket])
   (:import (jakarta.websocket CloseReason CloseReason$CloseCodes)
-           #_:clj-kondo/ignore
+    #_:clj-kondo/ignore
            (java.net.http WebSocket)
            (java.nio ByteBuffer)))
 
 (def ws-uri "ws://localhost:8080/ws")
 
- (def events-chan nil)
+(def events-chan nil)
 
 (defn events-chan-fixture [f]
   (with-redefs [events-chan (chan 10)]
@@ -64,29 +64,29 @@
 
            (= ::timed-out kind#)
            (do
-             (report {:type :fail
-                      :message "Expected event was not delivered"
+             (report {:type     :fail
+                      :message  "Expected event was not delivered"
                       :expected expected-kind#
-                      :actual (conj skipped# event#)})
+                      :actual   (conj skipped# event#)})
              nil)
 
            :else
            (recur (conj skipped# event#)))))))
 
 (def default-endpoint-map
-  {:on-open (fn [session _config]
-              (trace :in :on-open :session session :config _config)
-              (put! events-chan [:open session])
-              nil)
-   :on-close (fn [_ _session reason]
-               (trace :in :on-close :session _session :reason reason)
-               (put! events-chan [:close
-                                  (-> reason .getCloseCode .getCode)
-                                  (-> reason .getReasonPhrase)]))
-   :on-error (fn [_ _session exception]
-               (put! events-chan [:error exception]))
-   :on-text (fn [_ text]
-              (put! events-chan [:text text]))
+  {:on-open   (fn [session _config]
+                (trace :in :on-open :session session :config _config)
+                (put! events-chan [:open session])
+                nil)
+   :on-close  (fn [_ _session reason]
+                (trace :in :on-close :session _session :reason reason)
+                (put! events-chan [:close
+                                   (-> reason .getCloseCode .getCode)
+                                   (-> reason .getReasonPhrase)]))
+   :on-error  (fn [_ _session exception]
+                (put! events-chan [:error exception]))
+   :on-text   (fn [_ text]
+                (put! events-chan [:text text]))
    :on-binary (fn [_ buffer]
                 (put! events-chan [:binary buffer]))})
 
@@ -94,10 +94,10 @@
 
 (defn ws-server
   [websockets]
-  (http/create-server {::http/type jetty/server
-                       ::http/join? false
-                       ::http/port 8080
-                       ::http/routes []
+  (http/create-server {::http/type       jetty/server
+                       ::http/join?      false
+                       ::http/port       8080
+                       ::http/routes     []
                        ::http/websockets websockets}))
 
 (defmacro with-server
@@ -109,33 +109,56 @@
        (finally
          (http/stop server#)))))
 
+(deftest configuration-options
+  (let [*builder (atom nil)
+        *session (atom nil)
+        ws-map   (update default-websockets-map "/ws" assoc
+                         :configure #(reset! *builder %)
+                         :subprotocols ["sub" "protocols"]
+                         :idle-timeout-ms 100000
+                         :on-open (fn [session _config]
+                                    (reset! *session session)
+                                    (put! events-chan [:open session])))]
+    (with-server ws-map
+                 (let [config (-> *builder deref .build)]
+                   (is (= "/ws" (.getPath config)))
+                   (is (= ["sub" "protocols"]
+                          (-> config .getSubprotocols vec))))
+
+                 (let [session @(ws/websocket ws-uri {})]
+                   (expect-event :open)
+                   (ws/send! session "hello")
+
+                   (let [session @*session]
+                     (is (= 100000 (.getMaxIdleTimeout session))))))))
+
 (deftest client-sends-text
   (with-server default-websockets-map
-    (let [session @(ws/websocket ws-uri {})]
-      (expect-event :open)
-      (ws/send! session "hello")
+               (let [session @(ws/websocket ws-uri {})]
+                 (expect-event :open)
+                 (ws/send! session "hello")
 
-      (is (= [:text "hello"]
-             (<event!!)))
+                 (is (= [:text "hello"]
+                        (<event!!)))
 
-      ;; Note: the status code value is tricky, must be one of a few preset values, or in the
-      ;; range 3000 to 4999.
-      @(ws/close! session 4000 "A valid reason")
+                 ;; Note: the status code value is tricky, must be one of a few preset values, or in the
+                 ;; range 3000 to 4999.
+                 @(ws/close! session 4000 "A valid reason")
 
-      (is (= [:close 4000 "A valid reason"]
-             (<event!!))))))
+                 (is (= [:close 4000 "A valid reason"]
+                        (<event!!))))))
 
 (deftest client-sends-binary
   (with-server default-websockets-map
-    (let [session @(ws/websocket ws-uri {})
-          buffer-bytes (.getBytes "A mind forever voyaging" "utf-8")
-          buffer (ByteBuffer/wrap buffer-bytes)]
+               (let [session      @(ws/websocket ws-uri {})
+                     buffer-bytes (.getBytes "A mind forever voyaging" "utf-8")
+                     buffer       (ByteBuffer/wrap buffer-bytes)]
 
-      (ws/send! session buffer)
-      (.rewind buffer)
+                 (ws/send! session buffer)
+                 (.rewind buffer)
 
-      (when-let [[buffer'] (expect-event :binary)]
-        (is (= buffer buffer'))))))
+                 (when-let [[buffer'] (expect-event :binary)]
+                   (is (= buffer buffer'))))))
 
 (defn- conversation-actions
   [action-map]
@@ -145,111 +168,111 @@
   (with-server {"/ws" (conversation-actions {:on-text (fn [send-ch text]
                                                         (put! events-chan [:text text])
                                                         (put! send-ch (str "Hello, " text)))})}
-    (let [session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
-                                                       (put! events-chan [:client-message data last?]))})]
-      (ws/send! session "Bob")
-      (is (= ["Bob"]
-             (expect-event :text)))
+               (let [session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
+                                                                  (put! events-chan [:client-message data last?]))})]
+                 (ws/send! session "Bob")
+                 (is (= ["Bob"]
+                        (expect-event :text)))
 
-      (when-let [[data last] (expect-event :client-message)]
-        (is (= "Hello, Bob" (str data)))
-        (is (true? last))))))
+                 (when-let [[data last] (expect-event :client-message)]
+                   (is (= "Hello, Bob" (str data)))
+                   (is (true? last))))))
 
 (deftest binary-conversation
   (let [response-buffer (ByteBuffer/wrap (.getBytes "We Agree" "utf-8"))]
     (with-server {"/ws" (conversation-actions {:on-binary (fn [send-ch data]
                                                             (put! events-chan [:binary data])
                                                             (put! send-ch response-buffer))})}
-      (let [buffer (ByteBuffer/wrap (.getBytes "WebSockets are nifty" "utf-8"))
-            session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
-                                                         (put! events-chan [:client-message data last?]))})]
-        (ws/send! session buffer)
-        (.rewind buffer)
+                 (let [buffer  (ByteBuffer/wrap (.getBytes "WebSockets are nifty" "utf-8"))
+                       session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
+                                                                    (put! events-chan [:client-message data last?]))})]
+                   (ws/send! session buffer)
+                   (.rewind buffer)
 
-        (when-let [[received-buffer] (expect-event :binary)]
-          (is (= buffer received-buffer)))
+                   (when-let [[received-buffer] (expect-event :binary)]
+                     (is (= buffer received-buffer)))
 
-        (when-let [[data last] (expect-event :client-message)]
-          (.rewind response-buffer)
-          (is (= response-buffer data))
-          (is (true? last)))))))
+                   (when-let [[data last] (expect-event :client-message)]
+                     (.rewind response-buffer)
+                     (is (= response-buffer data))
+                     (is (true? last)))))))
 
 (deftest closing-send-channel-shuts-down-connection
-  (with-server {"/ws" (conversation-actions {:on-text (fn [send-ch text]
-                                                        (put! events-chan [:text text])
-                                                        (when (= "DIE" text)
-                                                          (close! send-ch)))
+  (with-server {"/ws" (conversation-actions {:on-text  (fn [send-ch text]
+                                                         (put! events-chan [:text text])
+                                                         (when (= "DIE" text)
+                                                           (close! send-ch)))
                                              :on-close (fn [_ _ ^CloseReason reason]
                                                          (trace :event :on-close
                                                                 :reason reason)
                                                          (put! events-chan [:close (.getCloseCode reason)]))})}
-    (let [session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
-                                                       (put! events-chan [:client-message data last?]))
-                                         :on-error (fn [_ws err]
-                                                     ;; Doesn't get called when socket closed by server
-                                                     (trace :event :client-error
-                                                            :error err))
-                                         :on-close (fn [_ws status-code reason]
-                                                     (trace :event :client-on-close
-                                                            :reason reason)
-                                                     ;; Client on-close handler does not appear to be
-                                                     ;; invoked.
-                                                     (put! events-chan [:client-close status-code reason]))})]
-      (ws/send! session "Bob")
-      (is (= ["Bob"]
-             (expect-event :text)))
+               (let [session @(ws/websocket ws-uri {:on-message (fn [_ws data last?]
+                                                                  (put! events-chan [:client-message data last?]))
+                                                    :on-error   (fn [_ws err]
+                                                                  ;; Doesn't get called when socket closed by server
+                                                                  (trace :event :client-error
+                                                                         :error err))
+                                                    :on-close   (fn [_ws status-code reason]
+                                                                  (trace :event :client-on-close
+                                                                         :reason reason)
+                                                                  ;; Client on-close handler does not appear to be
+                                                                  ;; invoked.
+                                                                  (put! events-chan [:client-close status-code reason]))})]
+                 (ws/send! session "Bob")
+                 (is (= ["Bob"]
+                        (expect-event :text)))
 
-      (ws/send! session "DIE")
+                 (ws/send! session "DIE")
 
-      (is (= [CloseReason$CloseCodes/NORMAL_CLOSURE] (expect-event :close)))
+                 (is (= [CloseReason$CloseCodes/NORMAL_CLOSURE] (expect-event :close)))
 
-      ;; It appears that Hato fails to notify us when the web socket is closed by the server.
-      #_(is (= [WebSocket/NORMAL_CLOSURE nil] (expect-event :client-close))))))
+                 ;; It appears that Hato fails to notify us when the web socket is closed by the server.
+                 #_(is (= [WebSocket/NORMAL_CLOSURE nil] (expect-event :client-close))))))
 
 (deftest exception-during-open-is-identified
   (let [e (RuntimeException. "on-open exception")]
-    (with-server {"/ws" {:on-open (fn [_session _config]
-                                    (put! events-chan [:open])
-                                    (throw e))
+    (with-server {"/ws" {:on-open  (fn [_session _config]
+                                     (put! events-chan [:open])
+                                     (throw e))
                          :on-error (fn [_ _ t]
                                      (put! events-chan [:error t]))
                          :on-close (fn [_ _ ^CloseReason reason]
                                      (put! events-chan [:close (.getCloseCode reason)]))}}
-      (let [_session @(ws/websocket ws-uri {})]
-        (expect-event :open)
-        (when-let [[t] (expect-event :error)]
-          (is (= e
-                 ;; The actual exception gets wrapped a couple of times:
-                 (-> t .getCause .getCause))))))))
+                 (let [_session @(ws/websocket ws-uri {})]
+                   (expect-event :open)
+                   (when-let [[t] (expect-event :error)]
+                     (is (= e
+                            ;; The actual exception gets wrapped a couple of times:
+                            (-> t .getCause .getCause))))))))
 
 
 (deftest exception-during-on-text-is-identified
   (let [e (RuntimeException. "on-text exception")]
-    (with-server {"/ws" {:on-text (fn [_ text]
-                                    (put! events-chan [:text text])
-                                    (throw e))
+    (with-server {"/ws" {:on-text  (fn [_ text]
+                                     (put! events-chan [:text text])
+                                     (throw e))
                          :on-error (fn [_ _ t]
                                      (put! events-chan [:error (ex-message t)]))
                          :on-close (fn [_ _ ^CloseReason reason]
                                      (put! events-chan [:close (-> (.getCloseCode reason) .getCode)
                                                         (.getReasonPhrase reason)]))}}
-      (let [session @(ws/websocket ws-uri {:on-error (fn [_ws t]
-                                                       (put! events-chan [:client-error t]))
-                                           :on-close (fn [_ws status-code reason]
-                                                       (put! events-chan [:client-close status-code reason]))})]
-        (ws/send! session "CHOKE")
+                 (let [session @(ws/websocket ws-uri {:on-error (fn [_ws t]
+                                                                  (put! events-chan [:client-error t]))
+                                                      :on-close (fn [_ws status-code reason]
+                                                                  (put! events-chan [:client-close status-code reason]))})]
+                   (ws/send! session "CHOKE")
 
-        (is (= ["CHOKE"]
-               (expect-event :text)))
+                   (is (= ["CHOKE"]
+                          (expect-event :text)))
 
-        (let [[message] (expect-event :error)]
-          (is (= "Endpoint notification error" message)))
+                   (let [[message] (expect-event :error)]
+                     (is (= "Endpoint notification error" message)))
 
-        (is (= [1003
-                "Endpoint notification error"]
-               (expect-event :close)))
+                   (is (= [1003
+                           "Endpoint notification error"]
+                          (expect-event :close)))
 
-        ;; Looks like Jetty 11 doesn't pass this down
-        #_(is (= [1011 "on-text exception"]
-                 (expect-event :client-close)))
-        ))))
+                   ;; Looks like Jetty 11 doesn't pass this down
+                   #_(is (= [1011 "on-text exception"]
+                            (expect-event :client-close)))
+                   ))))


### PR DESCRIPTION
It is now possible to set:
- The sub-protocols for the websocket endpoint
- The idle timeout on websocket connections

In addition, there is a new callback to initialize the websocket endpoint further (to cover additional cases not handled by Pedestal, such as encoders).