### PR TITLE
Correct content type in hello-world-content-types.adoc

### DIFF
--- a/docs/modules/guides/examples/todo-api/src/main-complete.clj
+++ b/docs/modules/guides/examples/todo-api/src/main-complete.clj
@@ -92,7 +92,7 @@
                         (get-in context [:request :database])
                         db-id))]
        (cond-> context
-         the-list (assoc context :result the-list))))})
+         the-list (assoc :result the-list))))})
 
 (def list-item-view
   {:name :list-item-view

--- a/docs/modules/guides/examples/todo-api/src/main.clj
+++ b/docs/modules/guides/examples/todo-api/src/main.clj
@@ -112,7 +112,7 @@
                         (get-in context [:request :database])
                         db-id))]
        (cond-> context                                      ;; <4>
-         the-list (assoc context :result the-list))))})
+         the-list (assoc :result the-list))))})
 ;; end::list_view[]
 
 

--- a/docs/modules/guides/pages/hello-world-content-types.adoc
+++ b/docs/modules/guides/pages/hello-world-content-types.adoc
@@ -277,7 +277,7 @@ X-XSS-Protection: 1; mode=block
 X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 Content-Security-Policy: object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;
-Content-Type: text/plain
+Content-Type: text/html
 Transfer-Encoding: chunked
 
 Hello, world!


### PR DESCRIPTION
In the code snippet below, we have hard-codded the content type to `text/html` as follows
```Clojure
(defn ok [body]
  {:status 200 :body body
   :headers {"Content-Type" "text/html"}})  
```
This must mean the following response from curl should also have its content type set to `text/html`, right?