### PR TITLE
Re-implement response generating functions in io.pedestal.http

### DIFF
--- a/docs/modules/reference/pages/response-bodies.adoc
+++ b/docs/modules/reference/pages/response-bodies.adoc
@@ -23,7 +23,15 @@ type of the value in the :body key of the xref:response-map.adoc[].
 | {core_async} channel | nil | see below | yes
 |===
 
+== Core Async Channel
+
 When a {core_async} channel delivers a message, that message is written
 to the stream, using any of the synchronous dispatches above. The
 message from the channel must not be another channel, it must be a value that
 can be immediately acted upon.
+
+== Function
+
+When the body is, in fact, a function, then Pedestal will invoke the function with a
+java.lang.OutputStream; the function's responsibility is to write the actual response to that stream.
+

--- a/docs/modules/reference/pages/response-map.adoc
+++ b/docs/modules/reference/pages/response-map.adoc
@@ -32,8 +32,8 @@ The function api:respond-with[] is the easiest way to add a response map to the 
 
 | :body
 | N
-| String, ISeq, File, InputStream
-| The body of the response sent to the client.
+| String, ISeq, File, InputStream, etc.
+| The body of the response sent to the client; see xref:response-bodies.adoc[] for more details.
 |===
 
 

--- a/service/src/io/pedestal/http/response.clj
+++ b/service/src/io/pedestal/http/response.clj
@@ -1,0 +1,60 @@
+; Copyright 2024 Nubank NA
+;
+; The use and distribution terms for this software are covered by the
+; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
+; which can be found in the file epl-v10.html at the root of this distribution.
+;
+; By using this software in any fashion, you are agreeing to be bound by
+; the terms of this license.
+;
+; You must not remove this notice, or any other, from this software.
+
+(ns io.pedestal.http.response
+  "Utilities used to write Ring responses."
+  {:added  "0.7.0"
+   :no-doc true}
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [cognitect.transit :as transit]
+            [ring.util.response :as ring-response])
+  (:import (java.io OutputStreamWriter)))
+
+;; Support for things in io.pedestal.http that are deprecated in 0.7.0
+
+(defn print-fn
+  [f]
+  (fn [output-stream]
+    (with-open [writer (OutputStreamWriter. output-stream)]
+      (binding [*out* writer]
+        (f))
+      (.flush writer))))
+
+(defn data-response
+  "Given printing function f (which writes to *out*), returns a response wrapped around
+  a function that will stream a response to.
+
+  This is sloppy and the corresponding i.o.p.http functions have been deprecated or rewritten."
+  [f content-type]
+  (ring-response/content-type
+    (ring-response/response (print-fn f))
+    content-type))
+
+;; Modern stuff
+
+(defn- stream-xform
+  [obj writer-fn]
+  (fn [output-stream]
+    (with-open [writer (io/writer output-stream)]
+      (writer-fn obj writer)
+      (.flush writer))))
+
+(defn stream-json
+  [obj]
+  (stream-xform obj json/generate-stream))
+
+(defn stream-transit
+  [obj transit-format transit-opts]
+  (fn [output-stream]
+    (transit/write
+      (transit/writer output-stream transit-format transit-opts)
+      obj)))

--- a/tests/test/io/pedestal/http_test.clj
+++ b/tests/test/io/pedestal/http_test.clj
@@ -22,6 +22,7 @@
             [io.pedestal.http.route :as route]
             [cheshire.core :as cheshire]
             [io.pedestal.http.body-params :refer [body-params]]
+            [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [ring.util.response :as ring-resp])
   (:import (java.io ByteArrayOutputStream File FileInputStream IOException)
            (java.nio ByteBuffer)
@@ -241,7 +242,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream
+           (do (servlet-interceptor/write-body-to-stream
                  (-> obj
                      service/edn-response
                      :body)
@@ -252,7 +253,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream
+           (do (servlet-interceptor/write-body-to-stream
                  (-> obj
                      service/edn-response
                      :body)
@@ -263,7 +264,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream
+           (do (servlet-interceptor/write-body-to-stream
                  (-> obj
                      ring-resp/response
                      :body)
@@ -279,13 +280,13 @@
 (deftest json-response-test
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
+    (servlet-interceptor/write-body-to-stream
+      (-> obj
+          service/json-response
+          :body)
+      output-stream)
     (is (= (cheshire/generate-string obj)
-           (do (io.pedestal.http.impl.servlet-interceptor/write-body-to-stream
-                 (-> obj
-                     service/json-response
-                     :body)
-                 output-stream)
-               (slurp-output-stream output-stream))))))
+           (slurp-output-stream output-stream)))))
 
 (defn- create-temp-file [content]
   (let [f (File/createTempFile "pedestal-" nil)]


### PR DESCRIPTION
This also adds missing documentation about using a function as the :body of a response.