### PR TITLE
Cleanup before 0.7.0-rc-1

### DIFF
--- a/common/src/io/pedestal/internal.clj
+++ b/common/src/io/pedestal/internal.clj
@@ -14,7 +14,8 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [clj-commons.ansi :refer [perr]]))
+            [clj-commons.ansi :refer [perr]]
+            [clj-commons.format.exceptions :as e]))
 
 (defn vec-conj
   [v value]
@@ -34,9 +35,9 @@
     (nil? val) nil
 
     (string? val)
-    (let [slashx (string/index-of val "/")
-          ns-str (when slashx
-                   (subs val 0 slashx))
+    (let [slashx     (string/index-of val "/")
+          ns-str     (when slashx
+                       (subs val 0 slashx))
           symbol-str (if slashx
                        (subs val (inc slashx))
                        val)]
@@ -89,6 +90,27 @@
        (when default-var-name
          (resolver nil nil default-var-name)))))
 
+(defn- truncate-to
+  [limit coll]
+  (let [n (count coll)]
+    (if (<= n limit)
+      coll
+      (drop (- n limit) coll))))
+
+(defn- call-stack
+  [t limit]
+  (let [elements (->> (e/expand-stack-trace t)
+                      (drop-while #(string/starts-with? (:name %) "io.pedestal.internal/")))
+        names    (->> (#'e/transform-stack-trace-elements
+                        elements nil)
+                      (remove :omitted)
+                      (map #'e/format-stack-frame)
+                      (map :name)
+                      distinct
+                      reverse
+                      (truncate-to limit))]
+    (interpose " -> " names)))
+
 (def *deprecations (atom #{}))
 
 (defn deprecation-warning
@@ -99,7 +121,10 @@
       [:yellow
        [:bold "WARNING: "]
        label
-       " is deprecated and may be removed in a future release"])))
+       " is deprecated and may be removed in a future release"]
+
+      "\nCall stack: ... "
+      (call-stack (RuntimeException.) 4))))
 
 (defmacro deprecated
   [label & body]
@@ -111,3 +136,6 @@
   []
   (swap! *deprecations empty))
 
+(comment
+
+  (reset-deprecations))

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = What is Pedestal?
+:page-role: -toc
 
 image::animated-front-page-sample.gif[float="right",width=300]
 
@@ -11,59 +12,40 @@ We wrote Pedestal to bring Clojure's key attributes, *Focus*, *Empowerment*, and
 
 This documentation is for Pedestal version *{libs_version}*.
 
-++++
-<div class="features-section">
-  <h2>Features</h2>
+== Features
 
-  <div class="main-feature-row">
-    <div class="main-feature">
-      <h3>Ready for Production</h3>
-      <div class="paragraph">Pedestal runs where Java runs: Applications can be deployed as standalone Clojure applications, or WAR files in a servlet container.
-Pedestal integrates with
-<a href="https://opentelemetry.io/">Open Telemetry</a> to give you visibility into your running services.</div>
-    </div>
-    <div class="main-feature">
-      <h3>Secure by Default</h3>
-      <div class="paragraph">Pedestal automatically uses secure headers, enables
-        <a href="https://en.wikipedia.org/wiki/Cross-site_request_forgery">
-cross site request forgery</a> protection, and other best practices. It works with
-<a href="https://en.wikipedia.org/wiki/Cross-origin_resource_sharing">cross-origin resource sharing</a>
-to allow secure front end applications.</div>
-    </div>
-  </div>
+=== Ready for Production
 
-  <div class="main-feature-row">
-    <div class="main-feature">
-      <h3>Easy Ramp Up</h3>
-      <div class="paragraph">
-A simple Pedestal app fits into a few lines of Clojure; Pedestal includes
-a <a href="https://github.com/seancorfield/deps-new">deps-new</a> template for getting you started.
+Pedestal runs where Java runs: Applications can be deployed as standalone Clojure applications, or as WAR files in a servlet container.
+Pedestal integrates with {otel} to give you visibility into your running services.
+
+=== Secure By Default
+
+Pedestal automatically uses secure headers,
+enables https://en.wikipedia.org/wiki/Cross-site_request_forgery[cross site request forgery] protection,
+and other best practices.
+
+It works with https://en.wikipedia.org/wiki/Cross-origin_resource_sharing[cross-origin resource sharing] to
+allow secure front end applications.
+
+=== Easy Ramp Up
+
+A simple Pedestal app fits into a few lines of Clojure; Pedestal includes a
+xref:guides:embedded-template.adoc[deps-new template] for getting you started.
 When you need more power, it's ready for you.
-</div>
-    </div>
 
-    <div class="main-feature">
-      <h3>Testable</h3>
-      <div class="paragraph">Pedestal's core interceptor model breaks request processing into small pieces that are simple, often free of side effects, and therefore easy to
-test; then lets you stack those pieces up to form your full application.</div>
-    </div>
-  </div>
+=== Testable
+
+Pedestal's core interceptor model breaks request processing into small pieces that are simple, often free of side effects, and therefore easy to
+test; then lets you stack those pieces up to form your full application.
 
 
-  <div class="main-feature-row">
-    <div class="main-feature">
-      <h3>Streaming</h3>
-      <div class="paragraph">Pedestal supports creating dynamic applications with server-sent events and WebSockets. Pedestal leverages Clojure's extraordinary asynchronous capabilities and Java's efficient NIO operations.</div>
-    </div>
+=== Streaming
 
-<div class="main-feature">
-      <h3>Composable and Extensible</h3>
-      <div class="paragraph">Pedestal is built from components that connect via protocols, giving you the flexibility to swap out any part with something
-customized to your application.</div>
-</div>
-    </div>
+Pedestal supports creating dynamic applications with server-sent events and WebSockets.
+Pedestal leverages Clojure's extraordinary asynchronous capabilities and Java's efficient NIO operations.
 
-  </div>
+=== Composable and Extensible
 
-</div>
-++++
+Pedestal is built from components that connect via protocols, giving you the flexibility to swap out any part with something
+customized to your application.

--- a/service/src/io/pedestal/http/cors.clj
+++ b/service/src/io/pedestal/http/cors.clj
@@ -25,6 +25,8 @@
   [header-names]
   (str/join ", " (map convert-header-name header-names)))
 
+(def ^:private preflight-fn (metrics/counter ::preflight nil))
+
 (defn- preflight
   [{request :request :as context} origin {:keys [creds max-age methods]}]
   (let [requested-headers (get-in request [:headers "access-control-request-headers"])
@@ -43,6 +45,7 @@
               :headers (:headers request)
               :cors-headers cors-headers)
     (log/meter ::preflight)
+    (preflight-fn)
     (assoc context :response {:status 200
                               :headers cors-headers})))
 

--- a/tests/dev/playground.clj
+++ b/tests/dev/playground.clj
@@ -15,6 +15,7 @@
             [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.tracing :as tel]
+            [io.pedestal.internal :as i]
             [net.lewisship.trace :refer [trace]]
             [clojure.core.async :refer [go <! timeout]]
             [io.pedestal.tracing :as t])
@@ -94,9 +95,17 @@
     :not-running))
 
 
+(defn deprecated-fn
+  []
+  (i/deprecated (random-uuid))
+  :done)
+
 (comment
   (start)
   (stop)
+
+  (deprecated-fn)
+  (i/reset-deprecations)
 
 
   (m/increment-counter ::hit-rate nil)

--- a/tests/test/io/pedestal/http/tracing_test.clj
+++ b/tests/test/io/pedestal/http/tracing_test.clj
@@ -14,9 +14,11 @@
             [mockfn.macros :refer [verifying]]
             [mockfn.matchers :refer [exactly any]]
             [io.pedestal.tracing :as t]
+            [io.pedestal.tracing.spi :as spi]
             [io.pedestal.http.tracing :refer [request-tracing-interceptor]]
             [io.pedestal.interceptor :as i]
-            [io.pedestal.interceptor.chain :as chain]))
+            [io.pedestal.interceptor.chain :as chain])
+  (:import (io.opentelemetry.api.trace SpanBuilder)))
 
 (defn- execute
   [context & interceptors]
@@ -172,5 +174,6 @@
         (is (= thrown-exception
                (ex-cause e)))))))
 
-
-
+(deftest span-with-nil-tracing-source
+  (is (instance? SpanBuilder
+                 (spi/create-span nil nil nil))))

--- a/tests/test/io/pedestal/http_test.clj
+++ b/tests/test/io/pedestal/http_test.clj
@@ -22,7 +22,6 @@
             [io.pedestal.http.route :as route]
             [cheshire.core :as cheshire]
             [io.pedestal.http.body-params :refer [body-params]]
-            [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [ring.util.response :as ring-resp])
   (:import (java.io ByteArrayOutputStream File FileInputStream IOException)
            (java.nio ByteBuffer)
@@ -242,7 +241,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (servlet-interceptor/write-body-to-stream
+           (do (si/write-body-to-stream
                  (-> obj
                      service/edn-response
                      :body)
@@ -253,7 +252,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (servlet-interceptor/write-body-to-stream
+           (do (si/write-body-to-stream
                  (-> obj
                      service/edn-response
                      :body)
@@ -264,7 +263,7 @@
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
     (is (= (with-out-str (pr obj))
-           (do (servlet-interceptor/write-body-to-stream
+           (do (si/write-body-to-stream
                  (-> obj
                      ring-resp/response
                      :body)
@@ -280,7 +279,7 @@
 (deftest json-response-test
   (let [obj           {:a 1 :b 2 :c [1 2 3]}
         output-stream (ByteArrayOutputStream.)]
-    (servlet-interceptor/write-body-to-stream
+    (si/write-body-to-stream
       (-> obj
           service/json-response
           :body)

--- a/tests/test/io/pedestal/metrics/otel_test.clj
+++ b/tests/test/io/pedestal/metrics/otel_test.clj
@@ -14,11 +14,13 @@
             [io.pedestal.metrics :as metrics]
             [matcher-combinators.matchers :as m]
             [io.pedestal.metrics.otel :as otel]
+            [io.pedestal.tracing.spi :as tracing.spi]
             [io.pedestal.telemetry.internal :refer [convert-key]]
             [clojure.test :refer [deftest is are use-fixtures]])
   (:import (clojure.lang ExceptionInfo)
            (io.opentelemetry.api.metrics DoubleGaugeBuilder DoubleHistogramBuilder LongCounter LongCounterBuilder LongGaugeBuilder LongHistogram LongHistogramBuilder Meter
                                          ObservableLongGauge ObservableLongMeasurement)
+           (io.opentelemetry.api.trace Span SpanBuilder)
            (java.util.function Consumer)))
 
 (def *now (atom 0))
@@ -354,3 +356,6 @@
       (is (match? [[:record "histogram.test" 42 clojure-domain-attributes]]
                    (events)))))
 
+(deftest span-with-nil-tracing-source
+  (is (instance? SpanBuilder
+                 (tracing.spi/create-span nil nil nil))))

--- a/tests/test/io/pedestal/metrics/otel_test.clj
+++ b/tests/test/io/pedestal/metrics/otel_test.clj
@@ -14,13 +14,11 @@
             [io.pedestal.metrics :as metrics]
             [matcher-combinators.matchers :as m]
             [io.pedestal.metrics.otel :as otel]
-            [io.pedestal.tracing.spi :as tracing.spi]
             [io.pedestal.telemetry.internal :refer [convert-key]]
             [clojure.test :refer [deftest is are use-fixtures]])
   (:import (clojure.lang ExceptionInfo)
            (io.opentelemetry.api.metrics DoubleGaugeBuilder DoubleHistogramBuilder LongCounter LongCounterBuilder LongGaugeBuilder LongHistogram LongHistogramBuilder Meter
                                          ObservableLongGauge ObservableLongMeasurement)
-           (io.opentelemetry.api.trace Span SpanBuilder)
            (java.util.function Consumer)))
 
 (def *now (atom 0))
@@ -356,6 +354,3 @@
       (is (match? [[:record "histogram.test" 42 clojure-domain-attributes]]
                    (events)))))
 
-(deftest span-with-nil-tracing-source
-  (is (instance? SpanBuilder
-                 (tracing.spi/create-span nil nil nil))))


### PR DESCRIPTION
* Documentation improvements
* Fix some gaps in test code coverage
* When emitting a deprecation warning, identify the (last few) stack frames leading up to the deprecated function