### PR TITLE
Bump pretty to 3.0.0

### DIFF
--- a/common/deps.edn
+++ b/common/deps.edn
@@ -10,4 +10,4 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:deps {org.clojure/clojure    {:mvn/version "1.11.2"}
-        org.clj-commons/pretty {:mvn/version "2.5.1"}}}
+        org.clj-commons/pretty {:mvn/version "3.0.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
           io.aviso/logging {:mvn/version "1.0"}
           borkdude/rewrite-edn {:mvn/version "0.4.8"}
           clj-kondo/clj-kondo {:mvn/version "2024.03.13"}
-          org.clj-commons/pretty {:mvn/version "2.5.1"}
+          org.clj-commons/pretty {:mvn/version "3.0.0"}
           babashka/fs {:mvn/version "0.5.20"}}}
 
   ;; Invoked via clj -T:build cve-check

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -13,7 +13,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.2"}
         org.clojure/core.async {:mvn/version "1.6.681"}
-        org.clj-commons/pretty {:mvn/version "2.5.1"}
+        org.clj-commons/pretty {:mvn/version "3.0.0"}
         io.pedestal/pedestal.log {:mvn/version "0.7.0-rc-1"}
         io.pedestal/pedestal.interceptor {:mvn/version "0.7.0-rc-1"}}
  :aliases


### PR DESCRIPTION
org.clj-commons/pretty 3.0.0 includes making public APIs needed by pedestal to generate the "Call stack:" part of the deprecation warning.