### PR TITLE
Fix bug in io.pedestal.http/json-body that corrupted the body of the response

### DIFF
--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -133,7 +133,7 @@
     (fn [response]
       (-> response
           (ring-response/content-type "application/json;charset=UTF-8")
-          (assoc :body response/stream-json)))))
+          (update :body response/stream-json)))))
 
 (defn transit-body-interceptor
   "Returns an interceptor which sets the Content-Type header to the

--- a/tests/test/io/pedestal/http_test.clj
+++ b/tests/test/io/pedestal/http_test.clj
@@ -172,7 +172,10 @@
 
 (deftest json-body-test
   (let [response (response-for (app) :get "/data-as-json")]
-    (is (= "application/json;charset=UTF-8" (get-in response [:headers "Content-Type"])))))
+    (is (match?
+          {:headers {"Content-Type" "application/json;charset=UTF-8"}
+           :body "{\"a\":1}"}
+          response))))
 
 (deftest plaintext-body-with-json-interceptor-test
   ;; Explicit request for plain-text content-type is honored by json-body interceptor.


### PR DESCRIPTION
This was introduced in a recent change (39cc924a08c1b662e8aec3cb1adc7cc3190ef0f7).