### PR TITLE
Update embedded jetty template

### DIFF
--- a/docs/modules/guides/pages/embedded-template.adoc
+++ b/docs/modules/guides/pages/embedded-template.adoc
@@ -73,6 +73,7 @@ Creating project from io.pedestal/embedded in peripheral
 ├── doc
 │   └── intro.md
 ├── resources
+│   ├── logback.xml
 │   ├── pedestal-config.edn
 │   └── public
 │       └── index.html
@@ -80,6 +81,7 @@ Creating project from io.pedestal/embedded in peripheral
 │   └── com
 │       └── blueant
 │           └── peripheral
+│               ├── main.clj
 │               ├── routes.clj
 │               ├── service.clj
 │               └── telemetry_init.clj
@@ -93,8 +95,7 @@ Creating project from io.pedestal/embedded in peripheral
     ├── logback-test.xml
     └── pedestal-test-config.edn
 
-17 directories, 18 files
-
+17 directories, 20 files
 >
 ```
 
@@ -168,6 +169,23 @@ DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.impl
 DEBUG io.pedestal.interceptor.chain.debug - {:interceptor :io.pedestal.http.impl.servlet-interceptor/stylobate, :stage :leave, :execution-id 1, :context-changes nil, :line 128}
 ```
 
+## Starting the service
+
+Alternately, you can start the service directly without starting a REPL:
+
+```
+> clj -X:run
+INFO  com.blueant.peripheral.main - {:msg "Service com.blueant/peripheral startup", :port 8080, :line 9}
+```
+
+At this point, the service is running; you can use another window to execute HTTP requests. If you open
+a browser window to http://localhost:8080/index.html, you'll see the following logged to the service's console:
+
+```
+INFO  io.pedestal.http - {:msg "GET /index.html", :line 83}
+INFO  io.pedestal.http - {:msg "GET /favicon.ico", :line 83}
+```
+
 
 ## Gathering Telemetry
 
@@ -204,6 +222,7 @@ Routing table:
 ┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
 ┃ :get   ┃ /hello ┃ :com.blueant.peripheral.routes/hello ┃
 ┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
 #:io.pedestal.http{:port 8080, :service-fn #object[io.pedestal.http.impl ...
 >
 ```

--- a/embedded/resources/io/pedestal/embedded/build/deps.tmpl
+++ b/embedded/resources/io/pedestal/embedded/build/deps.tmpl
@@ -1,9 +1,9 @@
 {:paths ["src"
          "resources"]
- :deps {org.clojure/clojure            {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure            {:mvn/version "1.11.3"}
         io.pedestal/pedestal.service   {:mvn/version "0.7.0-rc-2"}
         io.pedestal/pedestal.jetty     {:mvn/version "0.7.0-rc-2"}
-        ch.qos.logback/logback-classic {:mvn/version "1.4.14"}}
+        ch.qos.logback/logback-classic {:mvn/version "1.5.6"}}
  :aliases
  {:test
   {:extra-paths ["test"
@@ -16,6 +16,9 @@
                 {:git/tag "v0.5.1"
                  :git/sha "dfb30dd"}}}
 
+  :run
+  {:exec-fn  {{top/ns}}.{{main/ns}}.main/start-service}
+
   :otel-agent
   {:jvm-opts ["-Dotel.exporter.oltp.endpoint=http://localhost:4317"
               "-Dotel.resource.attributes=service.name={{name}}"
@@ -26,8 +29,8 @@
               ;; https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
               "-javaagent:target/opentelemetry-javaagent.jar"]}
 
-  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
-                 slipset/deps-deploy           {:mvn/version "0.2.0"}
-                 org.clj-commons/pretty        {:mvn/version "2.5.1"}
-                 clj-kondo/clj-kondo           {:mvn/version "2024.03.13"}}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.4"}
+                 slipset/deps-deploy           {:mvn/version "0.2.2"}
+                 org.clj-commons/pretty        {:mvn/version "3.0.0"}
+                 clj-kondo/clj-kondo           {:mvn/version "2024.05.24"}}
           :ns-default build}}}

--- a/embedded/resources/io/pedestal/embedded/config/logback.tmpl
+++ b/embedded/resources/io/pedestal/embedded/config/logback.tmpl
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="{{top/ns}}.{{main/ns}}" level="info"/>
+    <logger name="io.pedestal.http" level="info"/>
+
+</configuration>

--- a/embedded/resources/io/pedestal/embedded/src/main.tmpl
+++ b/embedded/resources/io/pedestal/embedded/src/main.tmpl
@@ -1,0 +1,19 @@
+(ns {{top/ns}}.{{main/ns}}.main
+  "Runs the {{name}} service."
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.log :as log]
+            [{{top/ns}}.{{main/ns}}.service :as service]))
+
+(defn- log-startup
+  [service-map]
+  (log/info :msg "Service {{name}} startup"
+            :port (::http/port service-map))
+  service-map)
+
+(defn start-service
+  [_]
+  (-> (service/service-map {:join? true})
+      http/create-server
+      log-startup
+      http/start))
+

--- a/embedded/resources/io/pedestal/embedded/src/service.tmpl
+++ b/embedded/resources/io/pedestal/embedded/src/service.tmpl
@@ -9,17 +9,19 @@
   "Creates a service map for the {{name}} service.
 
   Options:
-    dev-mode: enables dev-interceptors and interceptor logging if true, defaults from
-    Pedestal's development mode."
+  - dev-mode: enables dev-interceptors and interceptor logging if true, defaults from
+    Pedestal's development mode.
+  - join?: if true, then the current thread will block when the service is started (default is false)."
   [opts]
-  (let [{:keys [dev-mode]
-         :or {dev-mode dev-mode?}} opts]
+  (let [{:keys [dev-mode join?]
+         :or {dev-mode dev-mode?
+              join? false}} opts]
     (-> {::http/port 8080
          ::http/type :jetty
          ::http/routes (routes-from (routes/routes))
          ;; Serve classpath resources under the public folder:
          ::http/resource-path "public"
-         ::http/join? false}
+         ::http/join? join?}
          http/default-interceptors
          (cond-> dev-mode (-> http/dev-interceptors
                               http/enable-debug-interceptor-observer)))))

--- a/embedded/resources/io/pedestal/embedded/template.edn
+++ b/embedded/resources/io/pedestal/embedded/template.edn
@@ -27,12 +27,14 @@
     "dev.tmpl"            "dev.clj"
     "telemetry_test_init.tmpl" "{{top/file}}/{{main/file}}/telemetry_test_init.clj"}]
   ["config" "resources"
-   {"pedestal-config.tmpl" "pedestal-config.edn"}]
+   {"pedestal-config.tmpl" "pedestal-config.edn"
+    "logback.tmpl" "logback.xml"}]
   ["test-config" "test-resources"
    {"pedestal-test-config.tmpl" "pedestal-test-config.edn"}]
   ["src" "src/{{top/file}}"
    {"service.tmpl"   "{{main/file}}/service.clj"
     "routes.tmpl"    "{{main/file}}/routes.clj"
+    "main.tmpl"      "{{main/file}}/main.clj"
     "telemetry_init.tmpl" "{{main/file}}/telemetry_init.clj"}]
   ["test" "test/{{top/file}}"
    {"service_test.tmpl" "{{main/file}}/service_test.clj"}]]}

--- a/service/src/io/pedestal/http.clj
+++ b/service/src/io/pedestal/http.clj
@@ -463,6 +463,9 @@
   "Given a server map, as returned by [[server]] (usually via [[create-server]]),
    starts the server. The server may later be stopped via [[stop]].
 
+  Note that if the ::join? option is true, then this function will block until the
+  started server stops.
+
   Returns the server map unchanged."
   [server-map]
   ((::start-fn server-map))


### PR DESCRIPTION
This change primarily adds the ability to run the service using `clj -X:run`.  It also updates dependencies, and provides a simple `logback.xml` file.