### PR TITLE
`SERVER` span status code should be `ERROR` for 5xx, unset otherwise

### DIFF
--- a/service/src/io/pedestal/http/tracing.clj
+++ b/service/src/io/pedestal/http/tracing.clj
@@ -80,7 +80,7 @@
          ::keys [span otel-context-cleanup prior-otel-context]} context
         {:keys [status]} response
         status-code (when status
-                      (if (<= status 299) :ok :error))
+                      (if (<= status 499) :unset :error))
         context'    (-> context
                         (update-span-if-routed)
                         (dissoc ::span ::otel-context-cleanup ::otel-context ::prior-otel-context)
@@ -98,7 +98,7 @@
 
 (defn- trace-error
   [context error]
-  ;; If an exception is trown inside trace-enter, trace-error will be called with the
+  ;; If an exception is thrown inside trace-enter, trace-error will be called with the
   ;; unmodified context, which does not have a context.
   (let [{:keys [::span]} context]
     (if-not span


### PR DESCRIPTION
The OpenTelemetry semantic conventions for HTTP spans state that when the HTTP response status code is known, the status code for a `SERVER` kind span MUST be:
- unset for HTTP response status codes in ranges 1xx, 2xx, 3xx, and 4xx
- `ERROR` for HTTP response status codes in 5xx range

See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status

This commit corrects Pedestal HTTP tracing behaviour to conform to the semantic conventions. Existing tests have been updated, and two tests added to exercise cases where 400 and 500 HTTP response status codes are returned.