### PR TITLE
Fix .gitignore for development in IntelliJ + Cursive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,11 @@ tmp/
 *.tmp
 *.bak
 .clj-kondo/.cache/
+.cpcache/
 
 # Editors (IntelliJ / Eclipse)
-*/.idea
+.idea/
+*.iml
 */.classpath
 */.project
 */.settings


### PR DESCRIPTION
This commit ensures files specific to IntelliJ + Cursive project setup are ignored by git.