### PR TITLE
Expose web socket upgrade requests via ordinary routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The main focus of this release is to improve routing and upgrade to Jetty 12.
 - The `io.pedestal/pedestal.service-tools` library has been removed
 - Significant changes to `io.pedestal.http.route` have occured
 - The first argument to `io.pedestal.http.route.definition.table/table-routes` may now be nil or a map
-- WebSockets are now routable, and the route schemes may now also be :ws or :wss
+- WebSockets are now routable
 - A new router, `io.pedestal.http.route.sawtooth`, has been added
   - Sawtooth identfies conflicting routes
   - Sawtooth is now the *default router*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The main focus of this release is to improve routing and upgrade to Jetty 12.
 - Many APIs deprecated in Pedestal 0.7.0 have been removed outright
 - The `io.pedestal/pedestal.service-tools` library has been removed
 - Significant changes to `io.pedestal.http.route` have occured
+- The first argument to `io.pedestal.http.route.definition.table/table-routes` may now be nil or a map
+- WebSockets are now routable, and the route schemes may now also be :ws or :wss
 - A new router, `io.pedestal.http.route.sawtooth`, has been added
   - Sawtooth identfies conflicting routes
   - Sawtooth is now the *default router*

--- a/docs/modules/ROOT/pages/decision-log.adoc
+++ b/docs/modules/ROOT/pages/decision-log.adoc
@@ -70,6 +70,8 @@ Likewise, getEndpointInstance(), which can be built around the shell class.
 
 Is the classpath for the server module not quite right w.r.t. websocket-api dependency?
 
+Add support for partial text messages?  :on-partial-text.
+
 
 == Testing Revamp (Jan 2025)
 

--- a/docs/modules/ROOT/pages/decision-log.adoc
+++ b/docs/modules/ROOT/pages/decision-log.adoc
@@ -143,17 +143,18 @@ by the framework.
 
 == Sawtooth Router (Sep 2024)
 
-A common query internally at Nubank, when asked "How can we make things better?" was a call for help with
+A common query internally at Nubank, when asked "How can we make Pedestal better?" was a call for help with
 routes, particularily identifying routing conflicts.
 
 The existing router implementation, the
-xref:reference:prefix-tree-router.adoc[]
-had specific rules for dealing with any conflicts, but did a bad job of emitting warnings
+xref:reference:prefix-tree-router.adoc[],
+has specific rules for dealing with any path conflicts, but did a bad job of emitting warnings
 about such conflicts.
 
 xref:reference:sawtooth-router.adoc[Sawtooth]
-was created to address these concerns; it's behavior when conflicts occur is not defined, but
-it was designed to do a good job of identifying routing conflicts.
+was created to address these concerns; it's behavior when conflicts occur is not defined
+(in the sense that when there are path conflicts, we don't specify which path will be selected), but
+Sawtooth was designed to do a good job of identifying routing conflicts.
 
 Although the original goal was to create a router that was as fast, or faster, than
 prefix tree, that turned out to be difficult to achieve footnote:[There was a long series of

--- a/docs/modules/ROOT/pages/decision-log.adoc
+++ b/docs/modules/ROOT/pages/decision-log.adoc
@@ -5,6 +5,72 @@ Document design and architecture decisions.
 A lighter-weight alternative to
 https://github.com/joelparkerhenderson/architecture-decision-record[Architecture Decision Record (ADR)].
 
+== Websocket Routes (Feb 2025)
+
+Support for WebSockets has been evolving over time; originally added as Jetty-specific prior to Pedestal 0.6.0, it was made more general in Pedestal 0.7.0; however it has always operated outside of
+routing, which has proven even more problematic than for resources.
+
+These prior attempts were based around `ServerContainer.addEndpoint()`, which establishes
+an addressable WebSocket endpoint, as-if it had been specified in a WAR's web.xml.
+
+WebSockets are specified by https://www.rfc-editor.org/info/rfc6455[RFC 6455] and
+https://jcp.org/aboutJava/communityprocess/final/jsr356/index.html[JSR-000356  Java API for WebSocket],
+
+Jetty 12: Java 17, Jakarta EE8 - EE10.
+
+Java API is clearly oriented towards Java-code w/ annotations, things we have to fight against in Clojure-land.
+
+Ping/Pong - check that connection is still alive.  Receive a ping, respond to that peer with a pong.
+
+Explicit references to path params, that map perfectly to Pedestal.
+
+Lot of notes about path conflicts which we'll avoid with Sawtooth.
+
+6.4 - Programmatic Server Deployment
+
+ServerContainer.addEndpoint(), called from a ServletContextListener.
+Is it possible they knew web.xml was running out of steam?
+
+No mention of ServerContainer.upgradeHttpToWebSocket().
+
+Maybe extend table routes to allow extra key/value pairs in the routes.
+
+Ah. https://jakarta.ee/specifications/websocket/2.1/jakarta-websocket-spec-2.1.pdf[Jakarta EE - WebSocket 2.1 Specification] (PDF).
+
+https://github.com/jakartaee/websocket/issues/211[jakartaee issue 211] discusses need for `upgradeHttpToWebSocket`.
+- Pedestal is the "front controller / front servlet"
+
+Inside `upgradeHttpToWebSocket`, a response is sent to the client; will need a Pedestal mechanism to support
+this case, where we unwind the interceptor chain w/o a :response being present. Maybe add an empty response map
+to signal that response was provided out-of-band?
+
+Negotiation (of protocol, etc.) via a stack of interceptors?  How to wrap modifyHandshake()?
+
+```
+        public static final String JAKARTA_WEBSOCKET_CONTAINER_ATTRIBUTE = jakarta.websocket.server.ServerContainer.class.getName();
+
+        // Store a reference to the ServerContainer per - jakarta.websocket spec 1.0 final - section 6.4: Programmatic Server Deployment
+        servletContext.setAttribute(JAKARTA_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
+```
+
+    (-> request :servlet-request .getServletContext (.getAttribute "jakarta.websocket.server.ServerContainer"))
+
+
+Must have a ServerEndpointConfig, it must be built with a non-nil class (i.e., `FnEndpoint`).
+
+Class must extend Endpoint, or have one of a couple of annotations. We have the former.
+
+Class must be public. Ok.
+
+Sub-class or reified impl of ServerEndpointConfig$Configurator, to provide modifyHandshake()? I'd favor a shell class
+like `FnEndpoint` that delegates to a Clojure function.
+
+Likewise, getEndpointInstance(), which can be built around the shell class.
+
+
+Is the classpath for the server module not quite right w.r.t. websocket-api dependency?
+
+
 == Testing Revamp (Jan 2025)
 
 In earlier versions of Pedestal, the `io.pedestal.test` namespace directly contained `reify`-ed mock
@@ -94,7 +160,7 @@ prefix tree, that turned out to be difficult to achieve footnote:[There was a lo
 attempted optimizations to address this, which bore very limited fruit.];
 Sawtooth is nearly as fast as Prefix Tree, with a difference in micro-seconds per routing execution.
 
-The final decision was whether to sawtooth the _default_ router; this seemed acceptible
+The final decision was whether to make sawtooth the _default_ router; this seemed acceptible
 give its reasonable performance, and improved ergonomics.  The other routers, prefix tree included,
 continue to exist for backwards compatibility reasons, and to support cases where Sawtooth
 is not the best fit.

--- a/docs/modules/ROOT/pages/decision-log.adoc
+++ b/docs/modules/ROOT/pages/decision-log.adoc
@@ -13,65 +13,11 @@ routing, which has proven even more problematic than for resources.
 These prior attempts were based around `ServerContainer.addEndpoint()`, which establishes
 an addressable WebSocket endpoint, as-if it had been specified in a WAR's web.xml.
 
-WebSockets are specified by https://www.rfc-editor.org/info/rfc6455[RFC 6455] and
-https://jcp.org/aboutJava/communityprocess/final/jsr356/index.html[JSR-000356  Java API for WebSocket],
+The new approach is based on `ServetContainer.upgradeHttpToWebSocket()`, which still wants to instantiate a fresh
+instance of the endpoint class, but allows Pedestal to do all the request handling and routing work leading up to
+this point.
 
-Jetty 12: Java 17, Jakarta EE8 - EE10.
-
-Java API is clearly oriented towards Java-code w/ annotations, things we have to fight against in Clojure-land.
-
-Ping/Pong - check that connection is still alive.  Receive a ping, respond to that peer with a pong.
-
-Explicit references to path params, that map perfectly to Pedestal.
-
-Lot of notes about path conflicts which we'll avoid with Sawtooth.
-
-6.4 - Programmatic Server Deployment
-
-ServerContainer.addEndpoint(), called from a ServletContextListener.
-Is it possible they knew web.xml was running out of steam?
-
-No mention of ServerContainer.upgradeHttpToWebSocket().
-
-Maybe extend table routes to allow extra key/value pairs in the routes.
-
-Ah. https://jakarta.ee/specifications/websocket/2.1/jakarta-websocket-spec-2.1.pdf[Jakarta EE - WebSocket 2.1 Specification] (PDF).
-
-https://github.com/jakartaee/websocket/issues/211[jakartaee issue 211] discusses need for `upgradeHttpToWebSocket`.
-- Pedestal is the "front controller / front servlet"
-
-Inside `upgradeHttpToWebSocket`, a response is sent to the client; will need a Pedestal mechanism to support
-this case, where we unwind the interceptor chain w/o a :response being present. Maybe add an empty response map
-to signal that response was provided out-of-band?
-
-Negotiation (of protocol, etc.) via a stack of interceptors?  How to wrap modifyHandshake()?
-
-```
-        public static final String JAKARTA_WEBSOCKET_CONTAINER_ATTRIBUTE = jakarta.websocket.server.ServerContainer.class.getName();
-
-        // Store a reference to the ServerContainer per - jakarta.websocket spec 1.0 final - section 6.4: Programmatic Server Deployment
-        servletContext.setAttribute(JAKARTA_WEBSOCKET_CONTAINER_ATTRIBUTE, container);
-```
-
-    (-> request :servlet-request .getServletContext (.getAttribute "jakarta.websocket.server.ServerContainer"))
-
-
-Must have a ServerEndpointConfig, it must be built with a non-nil class (i.e., `FnEndpoint`).
-
-Class must extend Endpoint, or have one of a couple of annotations. We have the former.
-
-Class must be public. Ok.
-
-Sub-class or reified impl of ServerEndpointConfig$Configurator, to provide modifyHandshake()? I'd favor a shell class
-like `FnEndpoint` that delegates to a Clojure function.
-
-Likewise, getEndpointInstance(), which can be built around the shell class.
-
-
-Is the classpath for the server module not quite right w.r.t. websocket-api dependency?
-
-Add support for partial text messages?  :on-partial-text.
-
+Some effort was made to adjust for the fact that WebSocket upgrade requests have _no response_.
 
 == Testing Revamp (Jan 2025)
 
@@ -164,7 +110,7 @@ attempted optimizations to address this, which bore very limited fruit.];
 Sawtooth is nearly as fast as Prefix Tree, with a difference in micro-seconds per routing execution.
 
 The final decision was whether to make sawtooth the _default_ router; this seemed acceptible
-give its reasonable performance, and improved ergonomics.  The other routers, prefix tree included,
+given its reasonable performance, and improved ergonomics.  The other routers, prefix tree included,
 continue to exist for backwards compatibility reasons, and to support cases where Sawtooth
 is not the best fit.
 

--- a/docs/modules/ROOT/pages/deprecations.adoc
+++ b/docs/modules/ROOT/pages/deprecations.adoc
@@ -19,6 +19,13 @@ Newly deprecated namespaces:
 These represent functionality that is not well supported by Pedestal, or internal namespaces that should not be
 used by application code.
 
+WebSockets upgrade requests are now routed, like any other request; the prior approach
+(the ::http/websockets service map key) has been deprecated.
+
+In `io.pedestal.websocket`, the following functions are deprecated:
+- add-endpoint
+- add-endpoints
+
 == 0.7.0
 
 In _most_ cases, Pedestal can now emit a warning the first time a deprecated function, macro,

--- a/docs/modules/ROOT/pages/deprecations.adoc
+++ b/docs/modules/ROOT/pages/deprecations.adoc
@@ -2,7 +2,7 @@
 
 == 0.8.0
 
-The focus of release 0.8 is to improve routing and support xref:reference:jetty.adoc[], but a secondary focus
+The focus of release 0.8 is to improve and unify routing, and to support xref:reference:jetty.adoc[], but a secondary focus
 is to remove dead code.
 
 Many functions, macros, and even namespaces deprecated in 0.7.0 have been fully removed in 0.8.0.
@@ -19,7 +19,7 @@ Newly deprecated namespaces:
 These represent functionality that is not well supported by Pedestal, or internal namespaces that should not be
 used by application code.
 
-WebSockets upgrade requests are now routed, like any other request; the prior approach
+xref:reference:websockets.adoc#upgrade[WebSocket upgrade requests] are now routed, like any other request; the prior approach
 (the ::http/websockets service map key) has been deprecated.
 
 In `io.pedestal.websocket`, the following functions are deprecated:

--- a/docs/modules/guides/pages/defining-routes.adoc
+++ b/docs/modules/guides/pages/defining-routes.adoc
@@ -302,6 +302,7 @@ literal in the route vector:
 ["/user/:user-id" :post update-user :constraints user-id]
 ----
 
+[#considering-constraints]
 === Considering Constraints
 
 The thing about constraints is that they are not used to distinguish

--- a/docs/modules/guides/pages/hello-world-content-types.adoc
+++ b/docs/modules/guides/pages/hello-world-content-types.adoc
@@ -62,7 +62,7 @@ preferred content type and make a decision about what to return.
 If you worked through xref:hello-world-query-parameters.adoc[]
 then you already have all the files you need. If
 not, take a moment to grab the sources from the
-xref:hello-world-query-parameters.adoc#_the_whole_shebang[whole shebang] in
+xref:hello-world-query-parameters.adoc#whole-shebang[whole shebang] in
 that guide.  Feel free to browse the complete sources in
 link:{guides_examples_root}/hello-content[the
 repository], but be warned that the file contains all the versions
@@ -120,6 +120,7 @@ We're going to define `echo` differently than our handler function
 `hello`. Instead of a simple handler function, we're going to define
 an interceptor.
 
+[#interceptors]
 == Interceptors
 
 Interceptors are the basic unit of work in Pedestal.
@@ -181,6 +182,7 @@ functions, turn it into a response at the tail end of the interceptor
 queue, and then refine the response map with defaults, headers, cookies,
 and so on in :leave functions.
 
+[#echo-interceptor]
 == An Echo Interceptor
 
 We're ready to define `echo` as an interceptor:

--- a/docs/modules/guides/pages/hello-world-query-parameters.adoc
+++ b/docs/modules/guides/pages/hello-world-query-parameters.adoc
@@ -80,6 +80,7 @@ interactive session (called a REPL, rhymes with ripple) then starting
 the service in that session. Before we do that, though, let's discuss
 interactive development.
 
+[#interactive]
 == Interactive Development
 
 It's really not optimal to be restarting your REPL in order to restart
@@ -464,6 +465,7 @@ Looks like it mostly works, though it has some trouble with different
 capitalization. Take a look at the docs for http://clojure.github.io/clojure/clojure.string-api.html[`clojure.string`] and see
 if you can figure out how to make the comparison case-insensitive.
 
+[#whole-shebang]
 == The Whole Shebang
 
 Once again, we built this thing in small steps, so it may seem like

--- a/docs/modules/guides/pages/hello-world.adoc
+++ b/docs/modules/guides/pages/hello-world.adoc
@@ -457,7 +457,7 @@ you get tired of poking it, just hit Control-C in the terminal that is
 running the server to kill it.
 
 Later on, we'll see how to make Jetty
-xref:hello-world-query-parameters.adoc#_interactive_development[run on its own thread] so
+xref:hello-world-query-parameters.adoc#interactive[run on its own thread] so
 you can get your REPL prompt back.
 
 == The Whole Shebang

--- a/docs/modules/guides/pages/your-first-api.adoc
+++ b/docs/modules/guides/pages/your-first-api.adoc
@@ -125,7 +125,7 @@ did go look up code link:https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 Second, we're going to define all our routes right away, but have them
 all use an `echo` handler so we can test the routes separately from
 everything else{empty}footnote:[See the
-xref:hello-world-content-types.adoc#_an_echo_interceptor[Hello World With Content Types tutorial]
+xref:hello-world-content-types.adoc#echo_interceptor[Hello World With Content Types tutorial]
 for an explanation of the `echo` interceptor.].
 
 [source,clojure]
@@ -137,7 +137,7 @@ include::example$todo-api/src/main.clj[tags=routes]
 Pedestal makes it possible to invoke these routes directly from the REPL, without involving HTTP at all.
 This is a nice way to break your work up into incremental steps.
 It goes together nicely with the interactive development support we introduced in the
-xref:hello-world-query-parameters.adoc#_interactive_development[Hello World, With Parameters tutorial].
+xref:hello-world-query-parameters.adoc#interactive[Hello World, With Parameters tutorial].
 
 Get ready for a _ton_ of output:
 
@@ -331,7 +331,7 @@ order.
 There are a couple of things to notice about this updated route
 definition. First, instead of using `echo` here, we have a vector with
 our `db-interceptor` and `list-create` interceptors. Recall from
-xref:hello-world-content-types.adoc#_interceptors[the introduction to
+xref:hello-world-content-types.adoc#interceptors[the introduction to
 interceptors] that interceptors have two functions. The :enter
 functions get called from left to right, then the :leave functions
 get called from right to left. That means calls to the

--- a/docs/modules/reference/pages/context-map.adoc
+++ b/docs/modules/reference/pages/context-map.adoc
@@ -105,6 +105,12 @@ specifically modify.
 | Added by an interceptor or handler, at which point the :enter phase of request processing is completed, and
 the :leave phase begins.
 
+
+| :route
+| xref:routing-quick-reference.adoc[route map]
+| Added after request routing takes place, this is either the specifically match route map, or nil
+  to indicate that the request could not be mapped to a route.
+
 |===
 
 == Servlet Keys

--- a/docs/modules/reference/pages/error-handling.adoc
+++ b/docs/modules/reference/pages/error-handling.adoc
@@ -25,8 +25,8 @@ attached to it.
 This error handling proceeds the same way regardless of whether
 interceptors in the chain returned a xref:context-map.adoc[context map] or
 async channel. (See
-xref:interceptors.adoc#_interceptor_return_values[Interceptor Return
-Values] for details on async return.) As a result, Pedestal unifies
+xref:interceptors.adoc#return[Interceptor Return Values] for details on async return.)
+As a result, Pedestal unifies
 error handling for synchronous interceptors and asynchronous
 interceptors.
 

--- a/docs/modules/reference/pages/important-protocols.adoc
+++ b/docs/modules/reference/pages/important-protocols.adoc
@@ -17,7 +17,7 @@ IntoInterceptor is legal to use in the interceptor vector of a
 route.
 
 This protocol also comes into play when
-xref:interceptors.adoc#_manipulating_the_interceptor_queue[appending new interceptors to the queue].
+xref:interceptors.adoc#manipulating[appending new interceptors to the queue].
 
 Pedestal extends IntoInterceptor onto a variety of Clojure and Java
 types. See the xref:interceptors.adoc[interceptors reference] for details of their behaviors.
@@ -47,7 +47,7 @@ Since the call to expand-routes comes from application code, it
 would be rare for an application to need to extend ExpandableRoutes.
 
 The result of expand-routes is a wrapper around a
-xref:routing-quick-reference.adoc#_routing_table[seq of maps]
+xref:routing-quick-reference.adoc#routing-table[seq of maps]
 that will be passed to the routing contructor function.
 
 == Servlet Protocols

--- a/docs/modules/reference/pages/interceptors.adoc
+++ b/docs/modules/reference/pages/interceptors.adoc
@@ -66,6 +66,7 @@ xref:servlet-interceptor.adoc[] adds these details.
 
 Further keys are described in the xref:context-map.adoc[] reference.
 
+[#return]
 == Interceptor Return Values
 
 Interceptor functions must return values. Returning `nil` will cause
@@ -76,7 +77,7 @@ this case, processing continues with the next interceptor.
 
 If the interceptor is expected to take a long time to return a result, it may
 instead return a {core_async} channel. Pedestal will yield the request processing thread back
-the the servlet container (so that it can process other incoming requests) and
+to the servlet container (so that it can process other incoming requests) and
 wait for a value to be produced.
 
 Only one value will be consumed from the returned channel, and the value must be a context map.
@@ -113,8 +114,8 @@ represents anything that can be used as an interceptor. Pedestal extends that pr
 | The :enter, :leave, :error, and :name keys are used directly.
 
 | Function
-| The function is interpreted as a link:#_handlers[handler] (or, rarely, as
-an link:#_indirect_interceptors[indirect interceptor].)
+| The function is interpreted as a link:#handler[handler] (or, rarely, as
+an link:#indirect[indirect interceptor].)
 
 | List
 | The list is evaluated and its result is used as an interceptor. footnote:[This is supported behavior
@@ -139,6 +140,7 @@ Applications should mainly use the map form as shown in the
 earlier examples when defining interceptors for routing
 purposes.
 
+[#manipulating]
 == Manipulating the interceptor queue
 
 The queue of interceptors remaining to execute is held in the
@@ -177,6 +179,7 @@ in the queue, then a few interceptors that provide behavior common to all routes
 common interceptors will run before any route-specific interceptors.
 
 
+[#handler]
 == Handlers
 
 A handler function is a special case of an interceptor.
@@ -193,6 +196,7 @@ position of an interceptor stack.
 Handlers are always synchronous; they must return a response map, they may
 not return a channel that delivers a response map.
 
+[#indirect]
 == Indirect Interceptors
 
 When IntoInterceptor is applied to a function _and_ that function has either the :interceptor
@@ -207,6 +211,12 @@ and not on the symbol or Var associated with the function:
     ^{:interceptor true} (fn [] ...)
 ----
 
+[WARNING]
+====
+Support for functions with this meta-data (^:interceptor or ^:interceptorfn) is
+*deprecated* in Pedestal 0.7, and may be removed in a future release.
+====
+
 == Error Handling
 
 Pedestal supports defining interceptor-specific error handlers via the
@@ -217,7 +227,8 @@ Pedestal supports defining interceptor-specific error handlers via the
 The io.pedestal/pedestal.service library includes a large set of interceptors
 that are specialized for HTTP request handling.
 Many of these interceptors are automatically added to the
-interceptor queue by the api:default-interceptors[] function.
+interceptor queue by the api:default-interceptors[] function,
+using information from the xref:service-map.adoc[].
 
 - api:allow-origin[ns=io.pedestal.http.cors]
 - api:anti-forgery[ns=io.pedestal.http.csrf]
@@ -234,4 +245,4 @@ Routing-related interceptors are provided by the io.pedestal/pedestal.route libr
 
 - api:path-params-decoder[ns=io.pedestal.http.route]
 - api:query-params[ns=io.pedestal.http.route]
-- api:router[ns=io.pedestal.http.route
+- api:router[ns=io.pedestal.http.route]

--- a/docs/modules/reference/pages/parameters.adoc
+++ b/docs/modules/reference/pages/parameters.adoc
@@ -69,7 +69,7 @@ Query parameters are also merged into the :params map inside the
 xref:request-map.adoc[].
 
 Query parameters are a feature of the
-xref:routing-quick-reference.adoc#_builtin_routers[built in routers].
+xref:routing-quick-reference.adoc#builtin[built-in routers].
 If you supply your own router, it may or may not support query parameters.
 
 == Path Parameters
@@ -94,7 +94,7 @@ In every case, the value of the parameter is a string, taken from the
 corresponding segment of the URL.
 
 Path parameters are a feature of the
-xref:routing-quick-reference.adoc#_builtin_routers[built in routers]. If you supply your own
+xref:routing-quick-reference.adoc#builtin[built in routers]. If you supply your own
 router, it may or may not support path parameters.
 
 == Body Parameters

--- a/docs/modules/reference/pages/request-map.adoc
+++ b/docs/modules/reference/pages/request-map.adoc
@@ -90,6 +90,22 @@ Pedestal uses an extended version of the link:https://github.com/ring-clojure/ri
 | int
 | Port number to which the request was sent
 
+| :servlet
+| Y
+| Servlet
+| Servlet instance that the request was provided to.
+
+| :servlet-request
+| Y
+| HttpServletRequest
+| Request instance provided to the servlet; the request map consists primarily of data extracted from
+  this object.
+
+| :servlet-response
+| Y
+| HttpServletResponse
+| Response instance provided to the servlet.
+
 | :scheme
 | Y
 | String
@@ -109,3 +125,4 @@ Pedestal uses an extended version of the link:https://github.com/ring-clojure/ri
 Many more keys are added to the request map by the
 xref:default-interceptors.adoc[default interceptors], many of the new keys are related to parsing query parameters and the
 request body; this is described more fully in xref:parameters.adoc[the parameters reference].
+

--- a/docs/modules/reference/pages/routing-quick-reference.adoc
+++ b/docs/modules/reference/pages/routing-quick-reference.adoc
@@ -218,7 +218,7 @@ one of the built-in algorithms:
 | Keyword | Router | Performance
 
 | :map-tree
-| xref:map-tree-router.adoc[Map Tree]  (default)
+| xref:map-tree-router.adoc[Map Tree]
 | Very fast
 
 
@@ -226,9 +226,9 @@ one of the built-in algorithms:
 | xref:prefix-tree-router.adoc[Prefix Tree]
 | High performance, space efficient
 
-| :sawtooth
+| :sawtooth (default router)
 | xref:sawtooth-router.adoc[Sawtooth]
-| High performance, reports conflicts, *default router*
+| High performance, reports conflicts
 
 | :linear-search
 | xref:linear-search-router.adoc[Linear Search]

--- a/docs/modules/reference/pages/routing-quick-reference.adoc
+++ b/docs/modules/reference/pages/routing-quick-reference.adoc
@@ -130,6 +130,7 @@ ExpandableRoutes protocol.
 formats, plus the results of directly calling a definition function, such as
 `table-routes`.  The routing table is the merged result of all of these.
 
+[#routing-table]
 == Routing Table
 
 The expanded routing table is a wrapper object containing a :routes key;
@@ -193,7 +194,8 @@ provide a path parameter named :ids, and will contain anything on the URL after 
 
 A path parameter must match at least one term, so a URL of just `/accounts` or `/accounts/` would not match the route.
 
-== Builtin Routers
+[#builtin]
+== Built-in Routers
 
 Pedestal includes several routing algorithms; this reflects not only the evolution of the Pedestal library,
 but also allows for different trade-offs in the algorithm used by each Router.  In rare cases, an application

--- a/docs/modules/reference/pages/service-map.adoc
+++ b/docs/modules/reference/pages/service-map.adoc
@@ -179,7 +179,7 @@ the container should be configured to open a port for HTTPs traffic.
 | ::http/websockets
 | N
 | Map
-| Defines websocket routing. See xref:websockets.adoc[].
+| *Deprecated in 0.8*: Prior approach to xref:websockets.adoc#upgrade[websocket routing].
 
 |===
 

--- a/docs/modules/reference/pages/table-syntax.adoc
+++ b/docs/modules/reference/pages/table-syntax.adoc
@@ -156,4 +156,4 @@ Route name is required unless route name can be deduced from the handler, or fin
 A constraint clause is the keyword :constraints followed by a map.
 
 Note that support for constraints exists today only for backwards compatibility;
-use of path parameter and query parameter constraints is xref:guides:defining-routes.adoc#_considering_constraints[no longer advised].
+use of path parameter and query parameter constraints is xref:guides:defining-routes.adoc#considering-constraints[no longer advised].

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -45,6 +45,17 @@ api:upgrade-request-to-websocket[]
 instead of attaching a response.
 In many cases, the final interceptor is created via api:websocket-upgrade[].
 
+[NOTE]
+====
+A WebSocket upgrade request has _no_ response.  If your application includes interceptors that
+examine or modify the :response key of the xref:context-map.adoc[] (in the :leave or :error phase), they may need to be adjusted for
+an entirely missing :response key.
+
+If some interceptor does attach a response key, it will be ignored by the xref:servlet-interceptor.adoc[].
+
+====
+
+
 == WebSocket Endpoint Map
 
 The behavior of the endpoint is defined in terms of a _websocket endpoint map_ which provides configuration for the WebSocket,

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -1,4 +1,4 @@
-= Websockets
+= WebSockets
 :default_api_ns: io.pedestal.websocket
 
 link:https://en.wikipedia.org/wiki/WebSocket[WebSockets] are an asynchronous and bidirectional connection between
@@ -27,9 +27,17 @@ For example, to handle initial setup when a connection is first opened, the
 https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/jakarta/websocket/OnOpen.html[@OnOpen]
 annotation can be applied.
 
-Other annotations cover receiving text or binary messages.
+The https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/jakarta/websocket/Session.html[Session]
+object passed to the `@OnOpen` callback can be retained by the application code, and later used to send text and binary messages
+to the client.
+
+Other annotations cover receiving text or binary messages from the client.
 
 == WebSockets in Pedestal
+
+POJOs and annotations make sense in Java, but do not fit well with Clojure, so Pedestal redefines this in terms
+of maps and Clojure functions as callbacks footnote:[Pedestal provides a Java class, `FnEndpont`, as the bridge between
+the Jakarta APIs and Clojure].
 
 Under Pedestal, a WebSocket request is routed like any other request, but the final interceptor
 must invoke
@@ -47,7 +55,6 @@ as well as callbacks for specific events in the WebSocket lifecyle.
 | :on-open
 | (Session, EndpointConfig) -> Object
 | Invoked when the client first opens a connection.
-  The returned value is retained and passed as the first argument of the remaining callbacks.
 
 | :on-close
 | (Object, Session, CloseReason) -> nil
@@ -93,22 +100,72 @@ Essentially, the :on-open callback is invoked when the client initiates the conn
 
 It is intended that, when the client connects, some form of server-side process will be initiated
 capable of sending messages to the client asynchronously.
-It is the responsibility of the :on-open callback to create such a process.
-One common option is to use the api:on-open-start-ws-connection[] function to create the callback, or
-construct the :on-open callback around the api:start-ws-connection[] function.
+It is the responsibility of the :on-open callback to create such a process, and to shut it down
+from an :on-close callback.
+
+[TIP]
+====
+Whatever value is returned from the :on-open callback is retained, and passed as the first
+argument to the :on-close, :on-error, :on-text, and :on-binary callbacks.
+This can be a single value, such as a {core_async} channel, or a map, or whatever your application needs it to be.
+
+If no :on-open callback is provided, the value will be nil, and it will not be possible to send messages
+to the client, only receive via the :on-text and :on-binary callbacks.
+====
 
 The :on-text and :on-binary callbacks are invoked when a text or binary message from the client
 is received.
 
+== Limitiations
 
+The Jakarta WebSocket API supports receiving _partial_ messages, useful when streaming very large objects.
+The :on-text and :on-binary callbacks only support _whole_ objects.
+
+== Sending Messages
+
+The Session passed to the :on-open callback contains further objects that are used to send
+messages to the client.
+
+Pedestal provides utility functions to make it easier to  send messages, in the form of
+a {core_async} channel.
+
+The function api:start-ws-connection[] is passed the Session and options, and returns
+a channel.  The connection receives values from the channel, and sends those values to the client.
+
+* A String is sent as a text message
+* A ByteBuffer is sent as a binary message
+* A vector is used to monitor the result, asynchronously.
+  ** The first element is the value to send (String or ByteBuffer)
+  ** The second element is a channel that will convey the result
+  ** The result is either :success, or an Exception (if unable to send the message)
+
+[IMPORTANT]
+====
+Closing the channel will close the WebSocket session.
+====
+
+As currently implemented, the sending of messages is not fully asynchronous: the processing loop waits for
+each send to complete before it advances to the next value in the channel.
+
+The function api:on-open-start-ws-connection[]  wraps around `start-ws-connection`;
+it is passed options, and returns a function that can be included in the websocket map as the :on-open callback.
+
+== WebSocketSendAsync
+
+The api:WebSocketSendAsync[] protocol does the actual work of  sending a value (String
+or ByteBuffer) asynchronously. This protocol could be extended to, for example,
+convert EDN data to JSON before sending it to the client as a text message.
+
+[#upgrade]
 == Upgrading from Pedestal 0.7
 
+In Pedestal 0.7, WebSockets are specified using the :io.pedestal.http/websockets key of
+the xref:service-map.adoc[].  This approach is supported in Pedestal 0.8, but is *deprecated*, and may
+be removed in a later release entirely.
 
-
-
-
-Websocket requests are not routed the way HTTP requests are; instead, the mapping from incoming requests
-to Websocket handlers is defined in the xref:service-map.adoc[].
+WebSocket requests are routed entirely outside of the xref:interceptors.adoc[interceptor chain], so they do not
+benefit from logging, exception handling, telemetry, or any other application-specific behaviors
+provided by the interceptor chain.
 
 In the service map, the :io.pedestal.http/websockets key
-maps string routes to endpoint maps.
+maps string routes to endpoint maps.  There is no facility for using path parameters in these requests.

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -3,7 +3,7 @@
 
 link:https://en.wikipedia.org/wiki/WebSocket[WebSockets] are an asynchronous and bidirectional connection between
 a client and a server.  Once a Websocket connection is established, either
-party may send messages to the other party - this unleashes truly unbounded possibilities for creating dynamic, real-time, and asynchronous applications.
+party may transmit messages to the other party - this unleashes truly unbounded possibilities for creating dynamic, real-time, and asynchronous applications.
 
 == WebSocket Lifecycle
 
@@ -13,7 +13,7 @@ always a GET request.
 
 In the handling of this kind of request, there's a point where the request is
 https://javadoc.io/static/jakarta.websocket/jakarta.websocket-api/2.2.0/jakarta/websocket/server/ServerContainer.html#upgradeHttpToWebSocket(java.lang.Object,java.lang.Object,jakarta.websocket.server.ServerEndpointConfig,java.util.Map)[upgraded to a WebSocket connection].
-There is _no_ response to this request. Instead, both the client and the server may begin sending and receiving text
+There is _no_ response to this request. Instead, both the client and the server may begin transmitting and receiving text
 and binary messages until the connection is closed by either party.
 
 == WebSockets in Java
@@ -28,7 +28,7 @@ https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/j
 annotation can be applied.
 
 The https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/jakarta/websocket/Session.html[Session]
-object passed to the `@OnOpen` callback can be retained by the application code, and later used to send text and binary messages
+object passed to the `@OnOpen` callback can be retained by the application code, and later used to transmit text and binary messages
 to the client.
 
 Other annotations cover receiving text or binary messages from the client.
@@ -45,7 +45,9 @@ api:upgrade-request-to-websocket[]
 instead of attaching a response.
 In many cases, the final interceptor is created via api:websocket-upgrade[].
 
-The behavior of the endpoint is defined in terms of a _websocket map_ which provides configuration for the WebSocket,
+== WebSocket Endpoint Map
+
+The behavior of the endpoint is defined in terms of a _websocket endpoint map_ which provides configuration for the WebSocket,
 as well as callbacks for specific events in the WebSocket lifecyle.
 
 .Callbacks
@@ -99,7 +101,7 @@ https://javadoc.io/static/jakarta.websocket/jakarta.websocket-api/2.2.0/jakarta/
 Essentially, the :on-open callback is invoked when the client initiates the connection.
 
 It is intended that, when the client connects, some form of server-side process will be initiated
-capable of sending messages to the client asynchronously.
+capable of transmitting messages to the client asynchronously.
 It is the responsibility of the :on-open callback to create such a process, and to shut it down
 from an :on-close callback.
 
@@ -109,7 +111,7 @@ Whatever value is returned from the :on-open callback is retained, and passed as
 argument to the :on-close, :on-error, :on-text, and :on-binary callbacks.
 This can be a single value, such as a {core_async} channel, or a map, or whatever your application needs it to be.
 
-If no :on-open callback is provided, the value will be nil, and it will not be possible to send messages
+If no :on-open callback is provided, the value will be nil, and it will not be possible to transmit messages
 to the client, only receive via the :on-text and :on-binary callbacks.
 ====
 
@@ -121,40 +123,44 @@ is received.
 The Jakarta WebSocket API supports receiving _partial_ messages, useful when streaming very large objects.
 The :on-text and :on-binary callbacks only support _whole_ objects.
 
-== Sending Messages
+Likewise, the underlying APIs do provide support for streaming transmissions to the client, but
+the built-in approach to transmitting messages does not.
 
-The Session passed to the :on-open callback contains further objects that are used to send
+== Transmitting Messages
+
+The Session passed to the :on-open callback contains further objects that are used to transmit
 messages to the client.
 
-Pedestal provides utility functions to make it easier to  send messages, in the form of
+Pedestal provides utility functions to make it easier to  transmit messages, in the form of
 a {core_async} channel.
 
-The function api:start-ws-connection[] is passed the Session and options, and returns
-a channel.  The connection receives values from the channel, and sends those values to the client.
+The function api:start-ws-connection[] is passed the Session and options, and sets up a transmission loop, driven
+by a channel, which is returns.
+The transmission loop receives values from the channel, and transmits those values to the client.
 
 * A String is sent as a text message
 * A ByteBuffer is sent as a binary message
 * A vector is used to monitor the result, asynchronously.
-  ** The first element is the value to send (String or ByteBuffer)
-  ** The second element is a channel that will convey the result
-  ** The result is either :success, or an Exception (if unable to send the message)
+  ** The first element is the value to transmit (String or ByteBuffer)
+  ** The second element is a channel that will convey the transmission result
+  ** The result is either :success, or an Exception (if unable to transmit the message)
 
 [IMPORTANT]
 ====
-Closing the channel will close the WebSocket session.
+Closing the channel will shut down the transmission loop, and close the WebSocket session.
 ====
 
-As currently implemented, the sending of messages is not fully asynchronous: the processing loop waits for
-each send to complete before it advances to the next value in the channel.
+As currently implemented, the transmission of messages is not fully asynchronous: the processing loop waits for
+each transmission to complete before it advances to the next value in the channel.
 
 The function api:on-open-start-ws-connection[]  wraps around `start-ws-connection`;
-it is passed options, and returns a function that can be included in the websocket map as the :on-open callback.
+it is passed options used to create the transmission loop, and returns a function that can be included in the websocket map as the :on-open callback.
 
 == WebSocketSendAsync
 
-The api:WebSocketSendAsync[] protocol does the actual work of  sending a value (String
+The api:WebSocketSendAsync[] protocol does the actual work of  transmitting a value (String
 or ByteBuffer) asynchronously. This protocol could be extended to, for example,
-convert EDN data to JSON before sending it to the client as a text message.
+convert EDN data to JSON before transmitting it to the client as a text message.
 
 [#upgrade]
 == Upgrading from Pedestal 0.7

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -1,24 +1,44 @@
 = Websockets
 :default_api_ns: io.pedestal.websocket
 
-[WARNING]
-====
-Websocket support was present prior to Pedestal 0.7, but was a container-specific option for
-Jetty. In Pedestal 0.7, websocket support was refactored to be more universal and declarative, part of
-the xref:service-map.adoc[].
-====
-
-link:https://en.wikipedia.org/wiki/WebSocket[Websockets] are an asynchronous and bidirectional connection between a client and a server.  Once a Websocket connection is established, either
+link:https://en.wikipedia.org/wiki/WebSocket[WebSockets] are an asynchronous and bidirectional connection between
+a client and a server.  Once a Websocket connection is established, either
 party may send messages to the other party - this unleashes truly unbounded possibilities for creating dynamic, real-time, and asynchronous applications.
 
-Websocket requests are not routed the way HTTP requests are; instead, the mapping from incoming requests
-to Websocket handlers is defined in the xref:service-map.adoc[].
+== WebSocket Lifecycle
 
-In the service map, the :io.pedestal.http/websockets key
-maps string routes to endpoint maps.
+A WebSocket connection starts with the client (the web browser) sending an HTTP or HTTPS request; this request
+includes a special header to indicate that it is intended to upgrade the request to a WebSocket connection; it is
+always a GET request.
 
-The endpoint map is a set of callbacks and configuration.  The path and endpoint map are ultimately passed to the api:add-endpoint[] function, which describes
-in detail how the callbacks are used.
+In the handling of this kind of request, there's a point where the request is
+https://javadoc.io/static/jakarta.websocket/jakarta.websocket-api/2.2.0/jakarta/websocket/server/ServerContainer.html#upgradeHttpToWebSocket(java.lang.Object,java.lang.Object,jakarta.websocket.server.ServerEndpointConfig,java.util.Map)[upgraded to a WebSocket connection].
+There is _no_ response to this request. Instead, both the client and the server may begin sending and receiving text
+and binary messages until the connection is closed by either party.
+
+== WebSockets in Java
+
+In Java, WebSocket endpoints are POJO objects with
+a https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/jakarta/websocket/ClientEndpoint.html[@ClientEndpoint]
+class annotation.
+
+Such endpoints will annotate specific methods to mark them as callbacks for asynchronous events.
+For example, to handle initial setup when a connection is first opened, the
+https://javadoc.io/static/jakarta.websocket/jakarta.websocket-client-api/2.2.0/jakarta/websocket/OnOpen.html[@OnOpen]
+annotation can be applied.
+
+Other annotations cover receiving text or binary messages.
+
+== WebSockets in Pedestal
+
+Under Pedestal, a WebSocket request is routed like any other request, but the final interceptor
+must invoke
+api:upgrade-request-to-websocket[]
+instead of attaching a response.
+In many cases, the final interceptor is created via api:websocket-upgrade[].
+
+The behavior of the endpoint is defined in terms of a _websocket map_ which provides configuration for the WebSocket,
+as well as callbacks for specific events in the WebSocket lifecyle.
 
 .Callbacks
 |===
@@ -47,8 +67,12 @@ in detail how the callbacks are used.
 
 | :configure
 | (ServerEndpointConfig$Builder) -> nil
-| Allows additional configuration using an instance of `jakarta.websocket.server.ServerEndpointConfig.Builder`.
 
+| Allows additional configuration using an instance of
+https://javadoc.io/static/jakarta.websocket/jakarta.websocket-api/2.2.0/jakarta/websocket/ClientEndpointConfig.Builder.html[ClientEndpointConfig.Builder].
+
+  This configuration occurs before the request is upgraded to a connection, and provides access to other configuration
+  options, such as encoders and decoders, that are not yet exposed by Pedestal's API.
 
 |===
 
@@ -77,3 +101,14 @@ The :on-text and :on-binary callbacks are invoked when a text or binary message 
 is received.
 
 
+== Upgrading from Pedestal 0.7
+
+
+
+
+
+Websocket requests are not routed the way HTTP requests are; instead, the mapping from incoming requests
+to Websocket handlers is defined in the xref:service-map.adoc[].
+
+In the service map, the :io.pedestal.http/websockets key
+maps string routes to endpoint maps.

--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -1,4 +1,4 @@
-; Copyright 2023-2024 Nubank NA
+; Copyright 2023-2025 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2022 Cognitect, Inc.
 

--- a/route/src/io/pedestal/http/route.clj
+++ b/route/src/io/pedestal/http/route.clj
@@ -1,4 +1,4 @@
-; Copyright 2024 Nubank NA
+; Copyright 2024-2025 Nubank NA
 ; Copyright 2014-2022 Cognitect, Inc.
 ; Copyright 2013 Relevance, Inc.
 
@@ -340,7 +340,7 @@
   :context      | varied          | String, function that returns a string, or symbol that resolves to a function; specifies root context for the URL
   :fragment     | String          | The fragment part of the URL
   :absolute?    | Boolean         | True to force an absolute URL
-  :scheme       | :http or :https | Used to override the scheme portion of the URL
+  :scheme       | :http, :https   | Used to override the scheme portion of the URL
   :host         | String          | Used to override the host portion of the URL
   :port         | Integer         | Used to override the port in the URL
 
@@ -351,7 +351,7 @@
   {:pre []}
   (let [routes (internal/extract-routes routing-table)
         {:as default-opts} default-options
-        m (linker-map routes)]
+        m      (linker-map routes)]
     (fn [route-name & options]
       (let [{:keys [app-name] :as options-map} options
             default-app-name (:app-name default-opts)
@@ -457,6 +457,8 @@
                  :url-for linker)
           (assoc-in [:bindings #'*url-for*] linker)
           (interceptor.chain/enqueue (:interceptors route))))
+    ;; Key present but nil indicates that routing failed (the request could not be
+    ;; mapped to a route).
     (assoc context :route nil)))
 
 (defn- construct-router-interceptor-from-table
@@ -597,7 +599,7 @@
   [routing-table & default-options]
   (let [routes (internal/extract-routes routing-table)
         {:as default-opts} default-options
-        m (linker-map routes)]
+        m      (linker-map routes)]
     (fn [route-name & options]
       (let [{:keys [app-name] :as options-map} options
             {:keys [method] :as route} (find-route m app-name route-name)

--- a/route/src/io/pedestal/http/route/definition/table.clj
+++ b/route/src/io/pedestal/http/route/definition/table.clj
@@ -154,7 +154,8 @@
    (table-routes (or (first (filter map? routes)) {})
                  (filterv vector? routes)))
   ([opts routes]
-   {:pre [(map? opts)
+   {:pre [(or (nil? opts)
+              (map? opts))
           (or (set? routes)
               (sequential? routes))]}
    (types/->RoutingFragmentImpl

--- a/route/src/io/pedestal/http/route/specs.clj
+++ b/route/src/io/pedestal/http/route/specs.clj
@@ -227,7 +227,7 @@
         :args (s/or
                 :informal (s/*
                             (s/or
-                              :options ::table-options
+                              :options (s/nilable ::table-options)
                               :route ::table-route))
                 :proper (s/cat
                           :options (s/? ::table-options)

--- a/service/deps.edn
+++ b/service/deps.edn
@@ -54,7 +54,8 @@
   ;; When developing with Cursive you should enable the servlet-api alias in the Clojure Deps tool.
   :servlet-api
   {:extra-deps {jakarta.servlet/jakarta.servlet-api {:mvn/version "6.0.0"}
-                jakarta.websocket/jakarta.websocket-client-api {:mvn/version "2.1.1"}}}
+                jakarta.websocket/jakarta.websocket-client-api {:mvn/version "2.1.1"}
+                jakarta.websocket/jakarta.websocket-api {:mvn/version "2.1.1"}}}
   ;; clj -T:build <command>
   :build {:deps {io.github.hlship/build-tools {:git/tag "0.10.2" :git/sha "3c446e4"}}
           :ns-default build}}}

--- a/service/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/service/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -167,17 +167,18 @@
     (update resp-map :headers merge {"Content-Type" (or content-type
                                                         (default-content-type body))})))
 
-(defn expect-no-response
+(defn disable-response
   "Updates the context to identify that no response is expected; this typically is because
    the request was upgraded to a WebSocket connection."
   {:added "0.8.0"}
   [context]
-  (assoc context ::expect-no-response true))
+  (assoc context ::response-disabled true))
 
 (defn response-expected?
+  "Returns true unless [[disable-response]] was previously invoked."
   {:added "0.8.0"}
   [context]
-  (-> context ::expect-no-response not))
+  (-> context ::response-disabled not))
 
 (defn set-response
   ([^HttpServletResponse servlet-resp resp-map]

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -15,6 +15,7 @@
   for applications that make use Pedestal's websocket support."
   {:added "0.7.0"}
   (:require [clojure.core.async :as async :refer [go-loop put!]]
+            [io.pedestal.http.impl.servlet-interceptor :as servlet-interceptor]
             [io.pedestal.interceptor :as interceptor]
             [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.log :as log])
@@ -155,8 +156,9 @@
                              servlet-response
                              config
                              (-> request :path-params servlet-path-parameters)))
-  ;; TODO: Does no :response cause problems?
-  (chain/terminate context))
+  (-> context
+      servlet-interceptor/expect-no-response
+      chain/terminate))
 
 
 (defn websocket-upgrade

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -1,4 +1,4 @@
-; Copyright 2023-2024 Nubank NA
+; Copyright 2023-2025 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)
@@ -82,7 +82,7 @@
   is saved as the \"session object\" which is then passed to the remaining callbacks as the first
   function argument.
 
-  :on-open (jakarta.websocket.Session,  jakarta.websocket.EndpointConfig)
+  :on-open (jakarta.websocket.Session, jakarta.websocket.EndpointConfig)
   : Invoked when client first opens a connection.  The returned value is retained
     and passed as the first argument of the remaining callbacks.
 
@@ -200,7 +200,7 @@
       (add-endpoint container path endpoint))))
 
 (defprotocol WebSocketSendAsync
-  (ws-send-async [msg remote-endpoint]
+  (ws-send-async [msg ^RemoteEndpoint$Async remote-endpoint]
     "Sends `msg` to `remote-endpoint`. Returns a
      promise channel from which the result can be taken.
 
@@ -232,6 +232,8 @@
 
   Returns a channel used to send messages to the client.
 
+  Closing the channel will close the WebSocket session.
+
   The values written to the channel are either
   a payload (a String, ByteBuffer, or some object
   that satisfies the WebSocketSendAsync protocol) or is a tuple of a payload and a response channel.
@@ -253,7 +255,7 @@
       (if-let [payload (and (.isOpen ws-session)
                             (async/<! send-ch))]
         ;; The payload is a message and an optional response channel; a message is either
-        ;; a String or a ByteBuffer (or something that implement WebSocketSendAsync).
+        ;; a String or a ByteBuffer (or something that implements WebSocketSendAsync).
         (let [[out-msg resp-ch] (if (sequential? payload)
                                   payload
                                   [payload nil])

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -23,7 +23,7 @@
            (jakarta.websocket EndpointConfig SendHandler Session MessageHandler$Whole RemoteEndpoint$Async)
            (jakarta.websocket.server ServerContainer ServerEndpointConfig ServerEndpointConfig$Builder)
            (java.nio ByteBuffer)
-           (java.util HashMap Map$Entry)))
+           (java.util HashMap)))
 
 (defn- message-handler
   ^MessageHandler$Whole [session-object f]

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -15,11 +15,15 @@
   for applications that make use Pedestal's websocket support."
   {:added "0.7.0"}
   (:require [clojure.core.async :as async :refer [go-loop put!]]
+            [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.log :as log])
   (:import (io.pedestal.websocket FnEndpoint)
+           (jakarta.servlet.http HttpServletRequest)
            (jakarta.websocket EndpointConfig SendHandler Session MessageHandler$Whole RemoteEndpoint$Async)
-           (jakarta.websocket.server ServerContainer ServerEndpointConfig$Builder)
-           (java.nio ByteBuffer)))
+           (jakarta.websocket.server ServerContainer ServerEndpointConfig ServerEndpointConfig$Builder)
+           (java.nio ByteBuffer)
+           (java.util HashMap Map$Entry)))
 
 (defn- message-handler
   ^MessageHandler$Whole [session-object f]
@@ -45,27 +49,27 @@
                                                            .getUserProperties
                                                            (.get session-object-key))]
                                     (f session-object session event-value))))
-        full-on-open (fn [^Session session ^EndpointConfig config]
-                       (let [session-object (when on-open
-                                              (on-open session config))]
-                         ;; Store this for on-close, on-error
-                         (-> session .getUserProperties (.put session-object-key session-object))
+        full-on-open          (fn [^Session session ^EndpointConfig config]
+                                (let [session-object (when on-open
+                                                       (on-open session config))]
+                                  ;; Store this for on-close, on-error
+                                  (-> session .getUserProperties (.put session-object-key session-object))
 
-                         (when idle-timeout-ms
-                           (.setMaxIdleTimeout session (long idle-timeout-ms)))
+                                  (when idle-timeout-ms
+                                    (.setMaxIdleTimeout session (long idle-timeout-ms)))
 
-                         (when on-text
-                           (.addMessageHandler session String (message-handler session-object on-text)))
+                                  (when on-text
+                                    (.addMessageHandler session String (message-handler session-object on-text)))
 
-                         (when on-binary
-                           (.addMessageHandler session ByteBuffer (message-handler session-object on-binary)))))]
+                                  (when on-binary
+                                    (.addMessageHandler session ByteBuffer (message-handler session-object on-binary)))))]
     (fn [event-type ^Session session event-value]
       (case event-type
         :on-open (full-on-open session event-value)
         :on-error (maybe-invoke-callback on-error session event-value)
         :on-close (maybe-invoke-callback on-close session event-value)))))
 
-(defn add-endpoint
+(defn create-server-endpoint-config
   "Adds a WebSocket endpoint to a ServerContainer.
 
   The path provides the mapping to the endpoint, and must start with a slash.
@@ -103,19 +107,82 @@
 
   All callbacks are optional.  The :on-open callback is critical, as it performs all the one-time setup
   for the WebSocket connection. The [[on-open-start-ws-connection]] function is a good starting place."
-  [^ServerContainer container ^String path ws-endpoint-map]
+  {:since "0.8.0"}
+  ^ServerEndpointConfig [^String path ws-endpoint-map]
   (let [callback (make-endpoint-delegate-callback ws-endpoint-map)
         {:keys [subprotocols configure]} ws-endpoint-map
-        builder (ServerEndpointConfig$Builder/create FnEndpoint path)
-        _ (do
-            (when subprotocols
-              (.subprotocols builder subprotocols))
-            (when configure
-              (configure builder)))
-        config (.build builder)]
+        builder  (ServerEndpointConfig$Builder/create FnEndpoint path)
+        _        (do
+                   (when subprotocols
+                     (.subprotocols builder subprotocols))
+                   (when configure
+                     (configure builder)))
+        config   (.build builder)]
     (.put (.getUserProperties config) FnEndpoint/USER_ATTRIBUTE_KEY callback)
-    (.addEndpoint container config)))
+    config))
 
+(defn- servlet-path-parameters
+  [path-params]
+  (let [result (HashMap.)]
+    (doseq [[k v] path-params]
+      (.put result (name k) v))
+    result))
+
+(defn upgrade-request-to-websocket
+  "Upgrades the current request to be a WebSocket connection.
+
+  The core of this invokes [[create-server-endpoint-config]].
+
+  Terminates the interceptor chain, without adding a response."
+  {:added "0.8.0"}
+  [context ws-endpoint-map]
+  (let [{:keys [^HttpServletRequest servlet-request servlet-response request route]} context
+        _               (do
+                          (assert servlet-request)
+                          (assert servlet-response)
+                          (assert route))
+        servlet-context (.getServletContext servlet-request)
+        container       ^ServerContainer (.getAttribute servlet-context "jakarta.websocket.server.ServerContainer")
+        _               (assert container)
+        ;; TODO: May need to do some transformation of the :path
+        config          (create-server-endpoint-config (:path route)
+                                                       ws-endpoint-map)]
+    ;; The path-params are included because they are in the Servlet API, and that's normally the only way
+    ;; the FnEndpoint class would have access to them, but in a Pedestal app, if they are needed
+    ;; they will be in the request map prior to calling upgrade-request-to-websocket.
+    (.upgradeHttpToWebSocket container
+                             servlet-request
+                             servlet-response
+                             config
+                             (-> request :path-params servlet-path-parameters)))
+  ;; TODO: Does no :response cause problems?
+  (chain/terminate context))
+
+
+(defn websocket-upgrade
+  "Returns a terminal interceptor for a route that will open a WebSocket connection.
+
+  The ws-endoint-map is passed to [[create-server-endpoint-config]].
+
+  This terminates the interceptor chain without adding a :response key."
+  {:added "0.8.0"}
+  [ws-endpoint-map]
+  (interceptor/interceptor
+    {:name  ::websocket-upgrade
+     :enter (fn [context]
+              (upgrade-request-to-websocket context ws-endpoint-map))}))
+
+(defn add-endpoint
+  "Adds a WebSocket endpoint to a ServerContainer.
+
+  The endpoint is constructed around a ServerEndpointConfig creates by
+  [[create-server-endpoint-config]].
+
+  Returns nil."
+  [^ServerContainer container ^String path ws-endpoint-map]
+  (let [config (create-server-endpoint-config path ws-endpoint-map)]
+    (.addEndpoint container config)
+    nil))
 
 (defn add-endpoints
   "Adds all websocket endpoints in the path-map."
@@ -168,8 +235,8 @@
   "
   [^Session ws-session opts]
   (let [{:keys [send-buffer-or-n]
-         :or {send-buffer-or-n 10}} opts
-        send-ch (async/chan send-buffer-or-n)
+         :or   {send-buffer-or-n 10}} opts
+        send-ch      (async/chan send-buffer-or-n)
         async-remote (.getAsyncRemote ws-session)]
     (go-loop []
       (if-let [payload (and (.isOpen ws-session)

--- a/service/src/io/pedestal/websocket.clj
+++ b/service/src/io/pedestal/websocket.clj
@@ -157,7 +157,7 @@
                              config
                              (-> request :path-params servlet-path-parameters)))
   (-> context
-      servlet-interceptor/expect-no-response
+      servlet-interceptor/disable-response
       chain/terminate))
 
 

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -102,7 +102,6 @@
     {:name  ::echo-prefix-ws
      :enter (fn [context]
               (let [prefix (get-in context [:request :path-params :prefix])]
-                #trace/result prefix
                 (websocket/upgrade-request-to-websocket
                   context
                   (assoc default-endpoint-map

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -125,7 +125,7 @@
   `(let [server# (ws-server ~ws-map)]
      (try
        (http/start server#)
-       (do ~@body)1
+       (do ~@body)
        (finally
          (http/stop server#)))))
 

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -1,4 +1,4 @@
-; Copyright 2024 Nubank NA
+; Copyright 2024-2025 Nubank NA
 ; Copyright 2023 Cognitect, Inc.
 
 ; The use and distribution terms for this software are covered by the

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -177,14 +177,13 @@
 
                  (ws/send! session "hello")
 
-                 (is (= [:text "back-hello"])
-                     (<event!!))
-
+                 (is (= [:text "back hello"]
+                        (<event!!)))
 
                  (ws/send! session "goodbye")
 
-                 (is (= [:text "back-goodbye"])
-                     (<event!!)))))
+                 (is (= [:text "back goodbye"]
+                        (<event!!))))))
 
 
 (deftest client-sends-binary

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -125,7 +125,7 @@
   `(let [server# (ws-server ~ws-map)]
      (try
        (http/start server#)
-       (do ~@body)
+       (do ~@body)1
        (finally
          (http/stop server#)))))
 

--- a/tests/test/io/pedestal/http/websocket_test.clj
+++ b/tests/test/io/pedestal/http/websocket_test.clj
@@ -16,6 +16,9 @@
     [hato.websocket :as ws]
     [io.pedestal.http :as http]
     [io.pedestal.http.jetty :as jetty]
+    [io.pedestal.http.route :as route]
+    [io.pedestal.http.route.definition.table :as table]
+    [io.pedestal.interceptor :as interceptor]
     [io.pedestal.test-common :as tc]
     [clojure.core.async :refer [chan put! close!] :as async]
     [net.lewisship.trace :refer [trace]]
@@ -94,12 +97,28 @@
 
 (def default-websockets-map {"/ws" default-endpoint-map})
 
+(def echo-prefix-interceptor
+  (interceptor/interceptor
+    {:name  ::echo-prefix-ws
+     :enter (fn [context]
+              (let [prefix (get-in context [:request :path-params :prefix])]
+                #trace/result prefix
+                (websocket/upgrade-request-to-websocket
+                  context
+                  (assoc default-endpoint-map
+                         :on-text (fn [_ text]
+                                    (put! events-chan [:text (str prefix " " text)]))))))}))
+
 (defn ws-server
   [websockets]
   (http/create-server {::http/type       jetty/server
                        ::http/join?      false
                        ::http/port       8080
-                       ::http/routes     []
+                       ::http/routes     (route/routes-from
+                                           (table/table-routes {}
+                                                               [["/ws/echo/:prefix"
+                                                                 :get
+                                                                 echo-prefix-interceptor]]))
                        ::http/websockets websockets}))
 
 (defmacro with-server
@@ -149,6 +168,24 @@
 
                  (is (= [:close 4000 "A valid reason"]
                         (<event!!))))))
+
+
+(deftest text-via-routed-websocket-connection
+  (with-server default-websockets-map
+               (let [session @(ws/websocket (str ws-uri "/echo/back") {})]
+                 (expect-event :open)
+
+                 (ws/send! session "hello")
+
+                 (is (= [:text "back-hello"])
+                     (<event!!))
+
+
+                 (ws/send! session "goodbye")
+
+                 (is (= [:text "back-goodbye"])
+                     (<event!!)))))
+
 
 (deftest client-sends-binary
   (with-server default-websockets-map

--- a/tests/test/io/pedestal/test_test.clj
+++ b/tests/test/io/pedestal/test_test.clj
@@ -14,8 +14,7 @@
 (ns io.pedestal.test-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer [deftest is]]
-            [io.pedestal.test :as test]
-            [io.pedestal.test :refer [parse-url]])
+            [io.pedestal.test :as test :refer [parse-url]])
   (:import (java.io BufferedInputStream ByteArrayInputStream)))
 
 (deftest non-root-url


### PR DESCRIPTION
In prior releases, WebSocket upgrade requests were mapped as special requests outside of routing.

This PR deprecates that, and replaces it with a mechanism to map upgrade requests to routes.