### PR TITLE
Update tests and enable support for async execution in response-for

### DIFF
--- a/http-kit/deps.edn
+++ b/http-kit/deps.edn
@@ -12,7 +12,7 @@
  :deps  {org.clojure/clojure          {:mvn/version "1.12.0"}
          io.pedestal/pedestal.log     {:mvn/version "0.8.0-SNAPSHOT"}
          io.pedestal/pedestal.service {:mvn/version "0.8.0-SNAPSHOT"}
-         http-kit/http-kit            {:mvn/version "2.8.0"}}
+         http-kit/http-kit            {:mvn/version "2.9.0-alpha4"}}
 
  :aliases
  {:local

--- a/http-kit/src/io/pedestal/http/http_kit.clj
+++ b/http-kit/src/io/pedestal/http/http_kit.clj
@@ -62,7 +62,6 @@
                              {:ip   host
                               :port port})
         *server       (atom nil)
-        *join-promise (promise)
         root-handler  (fn [request]
                         ;; TODO: something like stylobate,
                         (let [*async-channel (atom nil)
@@ -97,19 +96,15 @@
         (reset! *server (hk/run-server root-handler
                                        options'))
 
-        ;; TODO: Broken because doesn't work right when restarting a stopped
-        ;; connection.
-        ;; See https://github.com/http-kit/http-kit/pull/589
         (when join?
-          @*join-promise)
+          (hk/server-join @*server))
 
         this)
 
       (stop-connector! [this]
         (when-let [server @*server]
           (hk/server-stop! server)
-          (reset! *server nil)
-          (deliver *join-promise nil))
+          (reset! *server nil))
 
         this)
 

--- a/http-kit/src/io/pedestal/http/http_kit/response.clj
+++ b/http-kit/src/io/pedestal/http/http_kit/response.clj
@@ -11,37 +11,39 @@
 (defprotocol HttpKitResponse
 
   (convert-response-body [body]
-    "Converts a body value to a type compatible with HttpKit."))
+    "Converts a body value to a type compatible with HttpKit.
+
+    Returns a tuple of the default content type to use (or nil), and the body converted to an acceptible type for Http-Kit."))
 
 (extend-protocol HttpKitResponse
 
   nil
-  (convert-response-body [_] _)
+  (convert-response-body [_] [nil nil])
 
   String
-  (convert-response-body [s] s)
+  (convert-response-body [s] ["text/plain" s])
 
   InputStream
-  (convert-response-body [stream] stream)
+  (convert-response-body [stream] ["application/octet-stream" stream])
 
   File
-  (convert-response-body [file] file)
+  (convert-response-body [file] ["application/octet-stream" file])
 
   ByteBuffer
   (convert-response-body [buffer]
-    (impl/byte-buffer->input-stream buffer))
+    ["application/octet-stream" (impl/byte-buffer->input-stream buffer)])
 
   ReadableByteChannel
   (convert-response-body [channel]
-    (impl/byte-channel->input-stream channel))
+    ["application/octet-stream" (impl/byte-channel->input-stream channel)])
 
   Fn
   (convert-response-body [f]
-    (impl/function->input-stream f))
+    ["application/octet-stream" (impl/function->input-stream f)])
 
   IPersistentCollection
   (convert-response-body [coll]
-    (pr-str coll))
+    ["application/edn" (pr-str coll)])
 
   Channel                                                   ; core.async
   (convert-response-body [ch]
@@ -51,4 +53,5 @@
 
   HttpKitResponse
 
-  {:convert-response-body identity})
+  {:convert-response-body (fn [byte-array]
+                            ["application/octet-stream" byte-array])})

--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -257,16 +257,16 @@
   [service-map options]
   (let [{:keys [interceptors initial-context join?]} service-map
         ;; The options may include an :exception-analyzer function.
-        service-fn        (si/http-interceptor-service-fn interceptors initial-context options)
-        servlet           (servlet/servlet :service service-fn)
+        service-fn   (si/http-interceptor-service-fn interceptors initial-context options)
+        servlet      (servlet/servlet :service service-fn)
         ;; Mixing service-map and options; another bit of relic that maybe can be fixed
         ;; with changes to io.pedestal.http (that are probably ok to do as it only concerns implementation
         ;; details).
-        server            (create-server servlet (merge service-map options))
-        ;; TODO: Async support
-        test-context      (-> initial-context
-                              response/terminate-when-response)
-        test-interceptors interceptors]
+        server       (create-server servlet (merge service-map options))
+        ;; Normally, apply-default-content-type is provided by http-interceptor-service-fn, but since
+        ;; we are bypassing that for testing, need to explicitly add it back in.
+        test-interceptors (into [si/apply-default-content-type] interceptors)
+        test-context (response/terminate-when-response initial-context)]
     (reify
       p/PedestalConnector
 

--- a/service/src/io/pedestal/service/impl.clj
+++ b/service/src/io/pedestal/service/impl.clj
@@ -51,7 +51,6 @@
                      (Integer/parseInt port)
                      -1)
      :uri          uri
-     :path-info    uri                                      ; specific to Pedestal?
      :query-string query-string}))
 
 (defn  format-exception

--- a/service/src/io/pedestal/service/test.clj
+++ b/service/src/io/pedestal/service/test.clj
@@ -14,10 +14,11 @@
   {:added "0.8.0"}
   (:require [clj-commons.ansi :as ansi]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [io.pedestal.http.route :as route]
             [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.service.impl :as impl]
-            [clojure.core.async :refer [<!!]]
+            [clojure.core.async :refer [<!! put! chan]]
             [io.pedestal.interceptor :refer [interceptor]]
             [io.pedestal.service.protocols :as p])
   (:import (clojure.core.async.impl.protocols Channel)
@@ -108,12 +109,12 @@
    (fn [^bytes bytes]
      (ByteArrayInputStream. bytes))})
 
-(defn- capture-context
-  [*prom]
-  (interceptor {:name  ::capture-context
-                :leave (fn [context]
-                         (deliver *prom context)
-                         context)}))
+(defn- convey-response
+  [ch]
+  (interceptor
+    {:name  ::convey-response
+     :leave (fn [context]
+              (put! ch (:response context)))}))
 
 (defn execute-interceptor-chain
   "Executes the interceptor chain for a Ring request, and returns a Ring response.
@@ -125,17 +126,15 @@
   (let [request'      (-> request
                           (assoc :path-info (:uri request))
                           (update :body convert-request-body))
-        *prom         (promise)
-        interceptors' (into [(capture-context *prom)] interceptors)
+        response-ch   (chan 1)
+        interceptors' (into [(convey-response response-ch)] interceptors)
         _             (-> initial-context
                           (assoc :request request')
                           (chain/execute interceptors'))
-        context'      @*prom
-        response      (:response context')]
+        response      (<!! response-ch)]
     (when-not response
       (throw (ex-info "No :response provided after execution"
-                      {:context context'
-                       :request request})))
+                      {:request request})))
     (-> response
         (select-keys [:status :headers :body])
         (update :body convert-response-body))))
@@ -156,10 +155,20 @@
              {}
              headers))
 
+(defn- convert-response-headers
+  [headers]
+  (reduce-kv (fn [m k v]
+               (assoc m (-> k string/lower-case keyword) v))
+             {}
+             headers))
+
 (defn response-for
   "Works with a [[PedestalConnector]] to test a Ring request map; returns a Ring response map.
 
   The :body of the response map will be either nil, or an InputStream.
+
+  In the response; the :headers map is converted; keys are converted to lower-case
+  and converted to keywords.
 
   Options:
 
@@ -174,6 +183,7 @@
                    :headers        (create-request-headers headers)
                    :body           body}
                   (impl/parse-url url))]
-    (p/test-request connector request)))
+    (-> (p/test-request connector request)
+        (update :headers convert-response-headers))))
 
 

--- a/service/src/io/pedestal/service/test.clj
+++ b/service/src/io/pedestal/service/test.clj
@@ -122,7 +122,9 @@
 
   The :body of the returned response map will be nil, or InputStream."
   [initial-context interceptors request]
-  (let [request'      (update request :body convert-request-body)
+  (let [request'      (-> request
+                          (assoc :path-info (:uri request))
+                          (update :body convert-request-body))
         *prom         (promise)
         interceptors' (into [(capture-context *prom)] interceptors)
         _             (-> initial-context
@@ -164,10 +166,7 @@
   Key      | Value
   ---      |---
   :headers | Map; keys and values are converted from keyword or symbol to string
-  :body    | Body to send (nil, String, File, InputStream)
-
-
-  "
+  :body    | Body to send (nil, String, File, InputStream)"
   [connector request-method url & {:as options}]
   (let [{:keys [headers body]} options
         request (merge

--- a/tests/test/io/pedestal/service/dev_mode_test.clj
+++ b/tests/test/io/pedestal/service/dev_mode_test.clj
@@ -82,6 +82,7 @@
 
 (deftest debug-observer-is-active
   (is (match? {:status 200
+               :headers {:content-type "text/plain"}
                :body   (m/via slurp "HELLO")}
               (response-for :get "/hello")))
 
@@ -99,7 +100,7 @@
   (let [response (response-for :get "/fail")
         body (-> response :body slurp)]
     (is (match? {:status 500
-                 :headers {"Content-Type" "text/plain"}}
+                 :headers {:content-type "text/plain"}}
                 response))
 
     ;; The full output is quite verbose, but these parts indicate that the exception has been formatted

--- a/tests/test/io/pedestal/service/dev_mode_test.clj
+++ b/tests/test/io/pedestal/service/dev_mode_test.clj
@@ -30,7 +30,7 @@
   (response {:origin (get-in request [:headers "origin"])}))
 
 (defn fail-page
-  [request]
+  [_request]
   (throw (IllegalStateException. "Gentlemen, failure is not an option.")))
 
 (def routes

--- a/tests/test/io/pedestal/service/hk_connector_test.clj
+++ b/tests/test/io/pedestal/service/hk_connector_test.clj
@@ -87,23 +87,27 @@
 
 (deftest basic-access
   (is (match? {:status 200
+               :headers {"Content-Type" "text/plain"}
                :body   (m/via slurp "HELLO")}
               (response-for :get "/hello"))))
 
 
 (deftest chain-goes-async
   (is (match? {:status 200
+               :headers {"Content-Type" "text/plain"}
                :body   (m/via slurp "ASYNC HELLO")}
               (response-for :get "/async/hello"))))
 
 (deftest edn-response-body
   (is (match? {:status 200
+               :headers {"Content-Type" "application/edn"}
                :body   (m/via #(-> % slurp edn/read-string)
                               {"My-Key" "My-Value"})}
               (response-for :get "/echo/headers" :headers {:My-Key 'My-Value}))))
 
 (deftest async-bytes-response
   (is (match? {:status 200
+               :headers {"Content-Type" "application/octet-stream"}
                :body   (m/via slurp "ASYNC BYTES")}
               (response-for :get "/async/bytes"))))
 

--- a/tests/test/io/pedestal/service/hk_connector_test.clj
+++ b/tests/test/io/pedestal/service/hk_connector_test.clj
@@ -87,27 +87,27 @@
 
 (deftest basic-access
   (is (match? {:status 200
-               :headers {"Content-Type" "text/plain"}
+               :headers {:content-type "text/plain"}
                :body   (m/via slurp "HELLO")}
               (response-for :get "/hello"))))
 
 
 (deftest chain-goes-async
   (is (match? {:status 200
-               :headers {"Content-Type" "text/plain"}
+               :headers {:content-type "text/plain"}
                :body   (m/via slurp "ASYNC HELLO")}
               (response-for :get "/async/hello"))))
 
 (deftest edn-response-body
   (is (match? {:status 200
-               :headers {"Content-Type" "application/edn"}
+               :headers {:content-type "application/edn"}
                :body   (m/via #(-> % slurp edn/read-string)
                               {"My-Key" "My-Value"})}
               (response-for :get "/echo/headers" :headers {:My-Key 'My-Value}))))
 
 (deftest async-bytes-response
   (is (match? {:status 200
-               :headers {"Content-Type" "application/octet-stream"}
+               :headers {:content-type "application/octet-stream"}
                :body   (m/via slurp "ASYNC BYTES")}
               (response-for :get "/async/bytes"))))
 

--- a/tests/test/io/pedestal/service/hk_http_test.clj
+++ b/tests/test/io/pedestal/service/hk_http_test.clj
@@ -11,7 +11,7 @@
 
 (ns io.pedestal.service.hk-http-test
   "Test Http-Kit connector using HTTP requests (to fully exercise async code paths)."
-  (:require [io.pedestal.http.jetty :as jetty]
+  (:require [io.pedestal.http.http-kit :as http-kit]
             [clojure.test :refer [deftest is use-fixtures]]
             [io.pedestal.http.response :as response]
             [matcher-combinators.matchers :as m]
@@ -55,7 +55,7 @@
   (-> (service/default-service-map port)
       (service/with-default-interceptors)
       (service/with-routing :sawtooth routes)
-      (jetty/create-connector nil)))
+      (http-kit/create-connector nil)))
 
 (use-fixtures :once
               tc/instrument-specs-fixture
@@ -68,12 +68,15 @@
                       (service/stop! conn))))))
 
 (deftest basic-access
-  (is (match? {:status 200
-               :body   (m/via slurp "HELLO")}
+  (is (match? {:status  200
+               ;; Http-Kit client returns headers with names lowercase keywords
+               :headers {:content-type "text/plain"}
+               :body    (m/via slurp "HELLO")}
               (get! "/hello"))))
 
 
 (deftest async-request-handling
   (is (match? {:status 200
+               :headers {:content-type "text/plain"}
                :body   (m/via slurp "ASYNC HELLO")}
               (get! "/async/hello"))))

--- a/tests/test/io/pedestal/service/jetty_connector_test.clj
+++ b/tests/test/io/pedestal/service/jetty_connector_test.clj
@@ -68,27 +68,30 @@
 
 (deftest basic-access
   (is (match? {:status 200
+               :headers {:content-type "text/plain"}
                :body   (m/via slurp "HELLO")}
               (response-for :get "/hello"))))
 
 (deftest includes-essential-security-headers
   (is (match? {:status  200
-               :headers {"Strict-Transport-Security"         "max-age=31536000; includeSubdomains"
-                         "X-Frame-Options"                   "DENY"
-                         "X-Content-Type-Options"            "nosniff"
-                         "X-XSS-Protection"                  "1; mode=block"
-                         "X-Download-Options"                "noopen"
-                         "X-Permitted-Cross-Domain-Policies" "none"
-                         "Content-Security-Policy"           "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"}}
+               :headers {:strict-transport-security         "max-age=31536000; includeSubdomains"
+                         :x-frame-options                   "DENY"
+                         :x-content-type-options            "nosniff"
+                         :x-xss-protection                  "1; mode=block"
+                         :x-download-options                "noopen"
+                         :x-permitted-cross-domain-policies "none"
+                         :content-security-policy           "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"}}
               (response-for :get "/hello"))))
 
 (deftest chain-goes-async
   (is (match? {:status 200
+              :headers {:content-type "text/plain"}
                :body   (m/via slurp "ASYNC HELLO")}
               (response-for :get "/async/hello"))))
 
 (deftest edn-response-body
   (is (match? {:status 200
+               :headers {:content-type "application/edn"}
                :body   (m/via #(-> % slurp edn/read-string)
                               {"My-Key" "My-Value"})}
               (response-for :get "/echo/headers" :headers {:My-Key 'My-Value}))))


### PR DESCRIPTION
Fix some Http-Kit tests that were actually testing Jetty
Ensure that defaulted content-type header is propagated back to test
Change response-for to return headers with keys converted to keywords
