### PR TITLE
fix broken cond-> link in the guides

### DIFF
--- a/docs/modules/guides/pages/hello-world-content-types.adoc
+++ b/docs/modules/guides/pages/hello-world-content-types.adoc
@@ -471,7 +471,7 @@ unmodified version of the input. The trouble with deeply nested `if`s
 is that it's too easy to get lost in the nesting.
 
 This pattern is very common, and Clojure includes macros to help.
-The slightly tricky clj:cond\->[]footnote:[That's read out loud as "cond arrow". Once you master it,
+The slightly tricky clj:cond\->[] footnote:[That's read out loud as "cond arrow". Once you master it,
 you'll really level up in Clojure skills.] macro is what we need here.
 `cond\->` is similar to the usual
 threading macro `\->`, but instead of a just a series of expressions, it precedes


### PR DESCRIPTION
I don't know how to generate the docs to check if this is correct. But it is rendering incorrectly in the website. I have a hunch that this will fix the problem (I'm assuming there is a regex somewhere that needs a trailing space to work)

https://pedestal.io/pedestal/0.7/guides/hello-world-content-types.html

![image](https://github.com/user-attachments/assets/1def5f6a-85f0-49b4-b3e2-fe966a141b72)


