### PR TITLE
Make level of cors interceptor logging configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Other changes:
 - New functions and macros:
   - `io.pedestal.test/create-responder` - useful piece needed in most tests
   - `io.pedestal.interceptor/definterceptor` - easily create component records that transform into interceptors
+  - `io.pedestal.log/log` - logs with level determined at runtime
 - New namespaces: 
   - `io.pedestal.connector` - Replaces `io.pedestal.http` for setting up a connector
   - `io.pedestal.service.protocols` - Defines core protocols
@@ -82,6 +83,7 @@ Other changes:
   - Previously, with the terse or verbose routing specifications, the route name would overwrite the (missing) name
   of the interceptor; now interceptors always have names and this does not occur
   - Extracting default interceptor names from handlers can also be turned off, reverting to 0.7.x behavior
+- The `io.pedestal.http.cors/allow-origin` interceptor now, by default, logs at level debug (was level info previously)
 
 ## 0.7.2 - 1 Nov 2024
 

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -268,9 +268,7 @@
                          `(make-logger ~(name (ns-name *ns*))))
            ~@level-init]
        (when (io.pedestal.log/-level-enabled? ~logger' ~level')
-         (let [formatter# ~(if formatter
-                             formatter
-                             `(default-formatter))
+         (let [formatter# ~(or formatter `(default-formatter))
                ~string' (binding [*print-length* 80]
                           (formatter# ~keyvals-map'))
                ~@method-init]

--- a/log/src/io/pedestal/log.clj
+++ b/log/src/io/pedestal/log.clj
@@ -260,7 +260,10 @@
                                    (throw (ex-info (str "Unknown logging level: " ~level')
                                                    {:level ~level'})))))
         formatter     (::formatter keyvals-map)
-        log-line      (-> form meta :line)]
+        log-line      (-> form meta :line)
+        keyvals-map'  (-> keyvals-map
+                          (dissoc :exception ::logger ::formatter)
+                          (assoc :line log-line))]
     `(let [~logger' ~(or (::logger keyvals-map)
                          `(make-logger ~(name (ns-name *ns*))))
            ~@level-init]
@@ -269,11 +272,7 @@
                              formatter
                              `(default-formatter))
                ~string' (binding [*print-length* 80]
-                          (formatter# ~(assoc (dissoc keyvals-map
-                                                      :exception
-                                                      ::logger
-                                                      ::formatter)
-                                              :line log-line)))
+                          (formatter# ~keyvals-map'))
                ~@method-init]
            ~(if exception'
               `(~method' ~logger'


### PR DESCRIPTION
Fixes #916 

To fix this, I needed to retool some of the logging, to support determining the logging level at runtime.  Took some work to ensure this didn't change the normal case where the logging level is known at macro expansion time.