### PR TITLE
Fix problems with Http-Kit SSE responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ to the Jakarta Servlet API from those that are more general.
 **BREAKING CHANGES:**
 
 - Clojure 1.11 is now the minimum supported version
+- The new Sawtooth router is now the *default router*
 - Anonymous interceptors are deprecated
 - Many APIs deprecated in Pedestal 0.7.0 have been removed outright
 - The `io.pedestal/pedestal.service-tools` library has been removed
 - Significant changes to `io.pedestal.http.route` have occured
 - The first argument to `io.pedestal.http.route.definition.table/table-routes` may now be nil or a map
 - Fix reloading behavior when namespaces are reloaded via [clj-reload](https://github.com/tonsky/clj-reload)
-- A new router, `io.pedestal.http.route.sawtooth`, has been added
-  - Sawtooth identfies conflicting routes
-  - Sawtooth is now the *default router*
+- Server-Sent Events have been changed; fields are now terminated with a single `\n` rather than a `\r\n` (both 
+  are acceptible according to the SSE specification)
 - `io.pedestal.test` has been rewritten, nearly from scratch
   - The Servlet API mocks are now Java classes, not `reify`-ed classes
   - A request body may now be a java.io.File
@@ -52,6 +52,9 @@ Newly deprecated namespaces:
 - `io.pedestal.jetty.util`
 
 Other changes:
+- A new router, `io.pedestal.http.route.sawtooth`, has been added
+    - Sawtooth identfies conflicting routes
+    - Sawtooth prefers literal routes over routes with path parameters (i.e., `/users/search` vs. `/users/:id`)
 - Metrics can now be configured to accept longs or doubles as their values.
 - _Pedestal Connectors_ are a new abstraction around an HTTP library such as Jetty or Http-Kit; connectors
   do not use the Servlet API, and so are much lighter weight.

--- a/docs/modules/reference/pages/response-bodies.adoc
+++ b/docs/modules/reference/pages/response-bodies.adoc
@@ -32,6 +32,12 @@ https://docs.oracle.com/javaee/7/tutorial/servlets012.htm[asynchronous processin
 This returns the thread to the container's request processing thread pool,
 and the container will (efficiently) stream the contents of the buffer or channel to the client.
 
+[NOTE]
+====
+This applies to xref:jetty.adoc[] (which is Servlet based) but not to xref:http-kit.adoc[], which
+is not servlet based.
+====
+
 == Core Async Channel
 
 When a {core_async} channel delivers a message, that message is written

--- a/tests/test/io/pedestal/http/sse_test.clj
+++ b/tests/test/io/pedestal/http/sse_test.clj
@@ -85,11 +85,12 @@
                                      (>! ch t))
                                    (<! (timeout 100))
                                    (close! ch)))]
-                (sse/start-stream process-fn
-                                  context
-                                  1
-                                  ;; A function that returns the buffer size (just to get code coverage)
-                                  (constantly 10))))}))
+                (go
+                  (sse/start-stream process-fn
+                                    context
+                                    1
+                                    ;; A function that returns the buffer size (just to get code coverage)
+                                    (constantly 10)))))}))
 
 (def multi-line-interceptor
   (interceptor/interceptor
@@ -181,6 +182,7 @@
                         :data "3...\n"
                         :id   id})
 
+      ;; Note that ticker uses an async interceptor, the others are sync
       (expect-messages "http://localhost:9876/api/sse/ticker"
 
                        ;;"message" is a default indicated in the SSE Spec
@@ -210,5 +212,23 @@
 (deftest hk-end-to-end
   (end-to-end "hk2.9.0" hk/create-connector))
 
+(defonce *conn (atom nil))
 
+(defn start []
+  (reset! *conn (-> (new-connector)
+                    (hk/create-connector nil)
+                    conn/start!))
+  :started)
+
+(defn stop []
+  (conn/stop! @*conn)
+  (reset! *conn nil)
+  :stopped)
+
+(comment
+
+
+  (start)
+  (stop)
+  )
 

--- a/tests/test/io/pedestal/service/hk_websocket_test.clj
+++ b/tests/test/io/pedestal/service/hk_websocket_test.clj
@@ -86,6 +86,7 @@
     ::oneshot
     (assoc default-ws-opts
            :on-text (fn [conn _ text]
+                      #trace/result text
                       (websocket/send-text! conn (str "oneshot: " text))
                       (websocket/close! conn)))))
 

--- a/tests/test/io/pedestal/service/hk_websocket_test.clj
+++ b/tests/test/io/pedestal/service/hk_websocket_test.clj
@@ -12,7 +12,7 @@
 (ns io.pedestal.service.hk-websocket-test
   (:require [clojure.string :as string]
             [clojure.test :refer [deftest is use-fixtures]]
-            [clojure.core.async :refer [put! >!! close! chan]]
+            [clojure.core.async :refer [go put! >!! close! chan]]
             io.pedestal.http.http-kit
             [io.pedestal.http.route.definition.table :as table]
             [matcher-combinators.matchers :as m]
@@ -81,14 +81,18 @@
                           (put! ch
                                 (str (- count i)))))
                       (put! ch "Launch!")))))
+
 (def oneshot
-  (websocket/websocket-interceptor
-    ::oneshot
-    (assoc default-ws-opts
-           :on-text (fn [conn _ text]
-                      #trace/result text
-                      (websocket/send-text! conn (str "oneshot: " text))
-                      (websocket/close! conn)))))
+  (interceptor
+    {:name  ::oneshot
+     :enter (fn [context]
+              (go
+                (websocket/upgrade-request-to-websocket
+                  context
+                  (assoc default-ws-opts
+                         :on-text (fn [conn _ text]
+                                    (websocket/send-text! conn (str "oneshot: " text))
+                                    (websocket/close! conn))))))}))
 
 (def routes
   (table/table-routes
@@ -176,6 +180,7 @@
       (is (match? [(m/via str "Launch!")]
                   (expect-event :response))))))
 
+;; This test *also* demonstrates an async interceptor that upgrades to a WebSocket.
 
 (deftest server-closes-channel
   (with-connector routes


### PR DESCRIPTION
The response status and (very important) headers were being lost when the response was an SSE response.  Needed to add some better coordination to ensure that headers were written (even in the async case) before any SSE events were written.