### PR TITLE
Encourage use of io.pedestal.service.resources

### DIFF
--- a/docs/modules/guides/pages/embedded-template.adoc
+++ b/docs/modules/guides/pages/embedded-template.adoc
@@ -128,16 +128,20 @@ user=> (use 'dev)
 nil
 user=> (go!)
 Routing table:
-┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Method ┃  Path  ┃                 Name                 ┃
-┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-┃   :get ┃ /hello ┃ :com.blueant.peripheral.routes/hello ┃
-┃  :post ┃ /hello ┃ :com.blueant.peripheral.routes/greet ┃
-┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Method ┃  Path  ┃                     Name                     ┃
+┣━━━━━━━━╋━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+┃   :get ┃ /*path ┃ :io.pedestal.service.resources/get-resource  ┃
+┃  :head ┃ /*path ┃ :io.pedestal.service.resources/head-resource ┃
+┃   :get ┃ /hello ┃ :com.blueant.peripheral.routes/hello         ┃
+┃  :post ┃ /hello ┃ :com.blueant.peripheral.routes/greet         ┃
+┗━━━━━━━━┻━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 #object[io.pedestal.http.http_kit$create_connector$reify__17907 0x6e3f108c "io.pedestal.http.http_kit$create_connector$reify__17907@6e3f108c"]
 user=>
 ```
-<1> This activates both the :test and :dev-mode aliases; :dev-mode assists with reloading and is enables the printing of the routing table.
+<1> This activates both the :test and :dev-mode aliases; :dev-mode assists with reloading and
+is what enables the printing of the routing table. The full routing table contains both the routes
+defined for your app (`/hello`) and the routes for access to static resources (at `/*path`).
 
 From another window, you can open http://localhost:8080/index.html, to see
 a brief welcoming page.
@@ -195,6 +199,9 @@ Hello, Pedestal User.
 
 $
 ```
+
+The majority of those headers are contributed by the various default interceptors; they
+establish a base-line for security concerns.
 
 
 ## Starting the service

--- a/docs/modules/reference/pages/connector-map.adoc
+++ b/docs/modules/reference/pages/connector-map.adoc
@@ -55,12 +55,6 @@ It is intended as _scaffolding_: useful only at the outset of a new project, but
 removed and replaced with application specific setup once development is fully underway.
 ====
 
-== Files and Resources
-
-The api:with-file-access[] and api:with-resource-access[] functions add interceptors that will expose
-file system or class path resources to the client; this is an alternative to xref:resources.adoc[exposing
-files and resources via routes].
-
 == Routing
 
 The api:with-routes[] macro is used to set the routes for your service.

--- a/docs/modules/reference/pages/resources.adoc
+++ b/docs/modules/reference/pages/resources.adoc
@@ -41,7 +41,7 @@ Each of these functions take a single parameter, a map of options:
 |===
 | Option | Default | Only | Description
 
-| :prefix          | "/public" |          | The path prefix for the exposed resources.
+| :prefix          | "/" |          | The path prefix for the exposed resources.
 | :root-path       | -         | file     | Path to root directory to expose.
 | :resource-root   | -         | resource | Prefix on resources, limiting access to a safe subset of the classpath
 | :classloader     | -         | resource | Classloader used to find resources
@@ -55,7 +55,7 @@ Each of these functions take a single parameter, a map of options:
 |===
 
 Using the defaults, which enable fast responses and caching, the route-based resources are demonstrably faster
-than the xref:#service-map-options[interceptor-based] resources, especially for large resources ... though
+than the interceptor-based resource access, especially for large resources ... though
 for any reasonably sized resource, the response time is sub-millisecond.
 
 === Options notes
@@ -64,7 +64,7 @@ It is quite possible to use both `file` and `resource` together, as long as the 
 If necessary, it's even possible to use these functions multiple times, but care must be taken with the :route-namespace
 option to avoid route name collisions.
 
-The :prefix option should start with a "/" and not end with one.
+The :prefix option should start with a "/" and not end with one (with the exception that the default prefix, "/", is allowed).
 
 For the :index-files? option, Pedestal will identify requests that map to a directory, not to a specific file.
 Pedestal will search for one of the following:
@@ -99,42 +99,5 @@ The default used when the :classloader option is nil is the context class loader
 
 Finally, the options map will _also_ be passed to
 api:table-routes[ns=io.pedestal.http.route.definition.table], so you may use the keys it
-supports, particularly :scheme, :port, and :interceptors.
+supports; particularly :scheme, :port, and :interceptors.
 
-== Connector Options
-
-File and resource can also be exposed by configuration in the
-xref:service-map.adoc[]:
-
-[source,clojure]
-----
-(ns org.example.service
-  (:require [io.pedestal.connector :as conn]))
-
-(defn create-connector
-  []
-  (-> (conn/default-connector-map 8890)
-      (conn/with-default-interceptors)
-      (conn/with-file-access "web/public")
-      (conn/with-routes #{...})))
-----
-
-api:with-file-access[ns=io.pedestal.connector] exposes the file system resources directly under the `/` URI.
-Alternately, api:with-resource-access[ns=io.pedestal.connector] exposes classpath resources.
-
-Because these are interceptors, and not routes, they are not visible in the routing table.
-They *can* overlap with actual routes without an error: any requests that are not processed
-as resources will drop down into the routing interceptor.
-
-== io.pedestal.http.ring-middlewares
-
-The connector options are implemented in terms of two functions:
-
-* api:file[ns=io.pedestal.http.ring-middlewares]
-* api:resource[ns=io.pedestal.http.ring-middlewares]
-
-A third option, api:fast-resource[ns=io.pedestal.http.ring-middlewares], adds
-support for fast, asynchronous replies for large resources on the classpath.
-
-Each of these functions have additional options that can be configured when they are added
-explicitly as interceptors.

--- a/embedded/resources/io/pedestal/embedded/src/connector.tmpl
+++ b/embedded/resources/io/pedestal/embedded/src/connector.tmpl
@@ -1,6 +1,7 @@
 (ns {{top/ns}}.{{main/ns}}.connector
   "Defines the connector configuration for the {{name}} project."
   (:require [io.pedestal.connector :as connector]
+            [io.pedestal.service.resources :as resources]
             [io.pedestal.environment :as env]
             [io.pedestal.connector.dev :as dev]
             [{{top/ns}}.{{main/ns}}.routes :as routes]))
@@ -16,16 +17,18 @@
   (let [{:keys [dev-mode? trace? join?]
          :or {dev-mode? env/dev-mode?
               join? false}} opts]
-    (-> (connector/default-connector-map 8080)
-        (assoc :join? join?)
-        (cond->
-           dev-mode? dev/with-dev-interceptors
+    (->  (connector/default-connector-map 8080)
+         (cond->
+           join? (assoc :join? true)
+           dev-mode? (connector/with-interceptors dev/dev-interceptors)
            trace? dev/with-interceptor-observer)
-        ;; with-default-interceptors is only to be used for initial scaffolding and should be replaced
-        ;; with an application-specific set of calls to with-interceptor.
-        connector/with-default-interceptors
-        ;; This kind of file or resource access is separate from routing and must come first.
-        (connector/with-resource-access "public")
-        ;; Routing is generally the last interceptors added.
-        (connector/with-routes (routes/routes)))))
+         ;; with-default-interceptors is only to be used for initial scaffolding and should be replaced
+         ;; with an application-specific series of calls to with-interceptor.
+         connector/with-default-interceptors
+         ;; Routing is generally the last interceptors added.
+         ;; This adds application's API routes plus static files stored
+         ;; as resources.
+         (connector/with-routes
+           (routes/routes)
+           (resources/resource-routes {:resource-root "public"})))))
 

--- a/embedded/resources/io/pedestal/embedded/test/connector_test.tmpl
+++ b/embedded/resources/io/pedestal/embedded/test/connector_test.tmpl
@@ -4,7 +4,7 @@
             [matcher-combinators.matchers :as m]
             [io.pedestal.connector :as connector]
             [io.pedestal.http.http-kit :as hk]
-            [io.pedestal.service.test :as test :refer [response-for]]
+            [io.pedestal.connector.test :as test :refer [response-for]]
             [{{top/ns}}.{{main/ns}}.connector :refer [connector-map]]))
 
 (def ^:dynamic *connector* nil)

--- a/service/src/io/pedestal/connector.clj
+++ b/service/src/io/pedestal/connector.clj
@@ -141,28 +141,6 @@
                         (io.pedestal.http.secure-headers/secure-headers)
                         route/query-params])))
 
-(defn with-file-access
-  "Adds an interceptor exposing access to files on the file system, routed at file-path; this uses
-  [[file]]. The URI `/` maps to the contents of the directory at `file-path`.
-
-  This should be called just before adding a routing interceptor.
-
-  This is an alternative to [[file-routes]], and should only be used when file routing would conflict
-  with other routes."
-  [connector-map file-path]
-  (with-interceptor connector-map (ring-middlewares/file file-path)))
-
-(defn with-resource-access
-  "Adds an interceptor exposing access to resources on the classpath system, routed at root-path; this uses
-  [[file]]. The URI `/` maps to the contents of the classpath with a prefix of `root-path`.
-
-  This should be called just before adding a routing interceptor.
-
-  This is an alternative to [[resource-routes]], and should only be used when resource routing would conflict
-  with other routes."
-  [connector-map root-path]
-  (with-interceptor connector-map (ring-middlewares/resource root-path)))
-
 (defn start!
   "A convienience function for starting the connector.
 

--- a/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -91,10 +91,12 @@
   ReadableByteChannel
 
   (default-content-type [_] "application/octet-stream")
+  (write-body-to-stream [_ _])
 
   ByteBuffer
 
   (default-content-type [_] "application/octet-stream")
+  (write-body-to-stream [_ _])
 
   nil
   (default-content-type [_] nil)

--- a/servlet/src/io/pedestal/test.clj
+++ b/servlet/src/io/pedestal/test.clj
@@ -54,7 +54,7 @@
 (extend-protocol PrepareRequestBody
 
   nil
-  (->servlet-input-stream [_]
+  (body->input-stream [_]
     (body->input-stream ""))
 
   String

--- a/tests/test/io/pedestal/http/sse_test.clj
+++ b/tests/test/io/pedestal/http/sse_test.clj
@@ -28,7 +28,7 @@
            (java.net URI)
            (java.net.http HttpClient HttpRequest HttpResponse HttpResponse$BodyHandlers)
            (java.time Duration)
-           (java.util.concurrent Flow$Subscriber Flow$Subscription)))
+           (java.util.concurrent Flow$Subscriber)))
 
 (deftest sse-start-stream
   (let [fake-context        {:request {:headers {"origin" "http://foo.com:8080"}}}
@@ -159,7 +159,7 @@
     (is (= [:complete] (<!!? ch)))
 
     ;; And the channel closes
-    (is (= nil) (<!!? ch))))
+    (is (= nil (<!!? ch)))))
 
 (defn- end-to-end
   [id connector-fn]

--- a/tests/test/io/pedestal/service/resources_test.clj
+++ b/tests/test/io/pedestal/service/resources_test.clj
@@ -39,6 +39,22 @@
                  :body    "<h1>WOOT!</h1>\n"}
                 (responder :get "/res/index.html")))))
 
+(deftest get-index-files-resource-fails
+  ;; We don't (can't?) support index files for classpath resources.
+  (let [responder (create-responder)]
+    (is (match? {:status 404}
+                (responder :get "/res")))))
+
+(deftest resources-with-default-prefix
+  (let [responder        (-> {::http/port   8888
+                              ::http/routes (route/routes-from
+                                              (resources/resource-routes {:resource-root "clojure"}))}
+                             test/create-responder)
+        expected-content (-> "clojure/test.clj" io/resource slurp)]
+    (is (match? {:status 200
+                 :body   expected-content}
+                (responder :get "/test.clj")))))
+
 (deftest ignores-extra-slashes-in-path
   (let [responder (create-responder)]
     (is (match? {:status  200


### PR DESCRIPTION
- Update embedded template
- Allow mapping to "/" (because Sawtooth)
- Remove connector/with-file-access and with-resource-access