### PR TITLE
Remove reflective access to Java methods

### DIFF
--- a/tests/test/io/pedestal/metrics/otel_test.clj
+++ b/tests/test/io/pedestal/metrics/otel_test.clj
@@ -369,9 +369,9 @@
                                            :domain               "clojure"}
                                           f)
         setup-events       (events)
-        _                  (is (match? [[:ofLongs "example.gauge"]
-                                        [:setDescription "example.gauge" "gauge description"]
+        _                  (is (match? [[:setDescription "example.gauge" "gauge description"]
                                         [:setUnit "example.gauge" "yawns"]
+                                        [:ofLongs "example.gauge"]
                                         [:buildWithCallback :long "example.gauge" (m/pred some?)]]
                                        setup-events))
         ^Consumer callback (extract-callback setup-events)
@@ -494,9 +494,9 @@
   (let [update-fn (metrics/histogram :histogram.test {:domain               "clojure"
                                                       ::metrics/description "histogram description"
                                                       ::metrics/unit        "laughs"})]
-    (is (match? [[:ofLongs "histogram.test"]
-                 [:setDescription "histogram.test" "histogram description"]
+    (is (match? [[:setDescription "histogram.test" "histogram description"]
                  [:setUnit "histogram.test" "laughs"]
+                 [:ofLongs "histogram.test"]
                  [:build-long "histogram.test"]]
                 (events)))
 

--- a/tests/test/user.clj
+++ b/tests/test/user.clj
@@ -5,7 +5,7 @@
             [net.lewisship.trace :as trace]
             [io.pedestal.environment :refer [dev-mode?]]))
 
-(set! *warn-on-reflection* true)
+(alter-var-root #'*warn-on-reflection* (constantly true))
 
 (repl/install-pretty-exceptions)
 (trace/setup-default)


### PR DESCRIPTION
Some reflective access to a few Java objects has snuck in. This ensures that reflection warnings are always output (noisy!) and fixes all the Pedestal code that was using reflective access.  Every nanosecond counts!