### PR TITLE
Move the logic that extracts the buffer size from an HttpServletResponse into the servlet-interceptor namespace

### DIFF
--- a/service/src/io/pedestal/service/protocols.clj
+++ b/service/src/io/pedestal/service/protocols.clj
@@ -18,7 +18,7 @@
   is not a dependency available to the pedestal.service module."
 
   (response-buffer-size [this]
-    "Returns the buffer size, in bytes, available to this response, or nil if it can not be determined."))
+    "Returns the buffer size, in bytes, available to this response, or nil if it cannot be determined."))
 
 ;; Cover the case where the servlet response object is not available.
 

--- a/servlet/src/io/pedestal/http.clj
+++ b/servlet/src/io/pedestal/http.clj
@@ -41,7 +41,6 @@
             [io.pedestal.service.interceptors :as interceptors]
             [io.pedestal.interceptor.chain :as chain]
             [io.pedestal.interceptor.chain.debug :as chain.debug]
-            [io.pedestal.service.protocols :as sp]
             [io.pedestal.http.response :as response]
             [clojure.string :as string]
             [io.pedestal.log :as log])
@@ -52,13 +51,6 @@
 (try
   (require 'io.pedestal.http.jetty)
   (catch Exception _))
-
-(extend-protocol sp/ResponseBufferSize
-
-  HttpServletResponse
-
-  (response-buffer-size [response]
-    (.getBufferSize response)))
 
 ;; edn and json response formats
 

--- a/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -14,6 +14,7 @@
 (ns io.pedestal.http.impl.servlet-interceptor
   "Interceptors for adapting the Java HTTP Servlet interfaces."
   (:require [clojure.java.io :as io]
+            [io.pedestal.service.protocols :as sp]
             [clojure.core.async :as async]
             [io.pedestal.http.response :as response]
             [io.pedestal.interceptor.chain :as chain]
@@ -39,7 +40,12 @@
            (java.nio.channels ReadableByteChannel)
            (java.nio ByteBuffer)))
 
-;;; HTTP Response
+(extend-protocol sp/ResponseBufferSize
+
+  HttpServletResponse
+
+  (response-buffer-size [response]
+    (.getBufferSize response)))
 
 (defprotocol WriteableBody
   (default-content-type [body] "Get default HTTP content-type for `body`.")


### PR DESCRIPTION
Fixes #947 