### PR TITLE
Suppress deprecation warnings when Pedestal code calls deprecated code

### DIFF
--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -278,7 +278,7 @@
   (let [{:keys [interceptors initial-context join?]} service-map
         ;; The options may include an :exception-analyzer function.
         service-fn        (si/http-interceptor-service-fn interceptors initial-context options)
-        servlet           (with-deprecations-suppressed (servlet/servlet :service service-fn))
+        servlet           (servlet/servlet :service service-fn)
         ;; Mixing service-map and options; another bit of relic that maybe can be fixed
         ;; with changes to io.pedestal.http (that are probably ok to do as it only concerns implementation
         ;; details).

--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -17,7 +17,7 @@
             [clojure.string :as string]
             [io.pedestal.http.response :as response]
             [io.pedestal.http.servlet :as servlet]
-            [io.pedestal.internal :refer [deprecated]]
+            [io.pedestal.internal :refer [deprecated with-deprecations-suppressed]]
             [io.pedestal.http.impl.servlet-interceptor :as si]
             [io.pedestal.service.protocols :as p]
             [io.pedestal.connector.test :as test]
@@ -223,7 +223,8 @@
                                                                    (deprecated ::websockets
                                                                      :in "0.8.0"
                                                                      :noun "non-routed websockets (via the :io.pedestal.http/websockets service map key)")
-                                                                   (ws/add-endpoints container websockets)))))
+                                                                   (with-deprecations-suppressed
+                                                                     (ws/add-endpoints container websockets))))))
     (when daemon?
       ;; Reflective; it is up to the caller to ensure that the thread-pool has a daemon boolean property if
       ;; :daemon? flag is true.
@@ -277,7 +278,7 @@
   (let [{:keys [interceptors initial-context join?]} service-map
         ;; The options may include an :exception-analyzer function.
         service-fn        (si/http-interceptor-service-fn interceptors initial-context options)
-        servlet           (servlet/servlet :service service-fn)
+        servlet           (with-deprecations-suppressed (servlet/servlet :service service-fn))
         ;; Mixing service-map and options; another bit of relic that maybe can be fixed
         ;; with changes to io.pedestal.http (that are probably ok to do as it only concerns implementation
         ;; details).

--- a/servlet/src/io/pedestal/http/servlet.clj
+++ b/servlet/src/io/pedestal/http/servlet.clj
@@ -19,7 +19,7 @@
   (:import (io.pedestal.servlet FnServlet)
            (jakarta.servlet.http HttpServlet)))
 
-(defn ^{:deprecated "0.8.0"} servlet
+(defn servlet
   "Returns an instance of jakarta.servlet.HttpServlet using provided
   functions for its implementation.
 
@@ -42,5 +42,4 @@
   container) use the Java class io.pedestal.servlet.ClojureVarServlet."
   ^HttpServlet [& {:keys [init service destroy]}]
   {:pre [(fn? service)]}
-  (deprecated `servlet :in "0.8.0")
   (FnServlet. init service destroy))


### PR DESCRIPTION
Client code that calls non-deprecated code should *not* see warnings when that code calls deprecated code.