### PR TITLE
body-params: don't attempt to parse if body is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * The `io.pedestal/pedestal.service-tools` library has been removed
 * Significant changes to `io.pedestal.http.route` have occurred
 * Server-Sent Events have been changed; fields are now terminated with a single `\n` rather than a `\r\n` (both are acceptible according to the SSE specification)
+* The `io.pedestal.http.body-params/body-params` interceptor now does nothing if the request :body is nil
 * Exceptions in interceptors:
     * The caught exception is now the `ex-cause` of the exception provided (in earlier releases, it was the :exception
       key of the data)

--- a/service/src/io/pedestal/http/body_params.clj
+++ b/service/src/io/pedestal/http/body_params.clj
@@ -43,10 +43,13 @@
 
 
 (defn- parse-content-type
-  "Runs the request through the appropriate parser"
+  "Runs the request through the appropriate parser.  Returns the request unchanged if the :body
+  is nil (or absent)."
   [parser-map request]
-  (let [parser-fn (parser-for parser-map (:content-type request))]
-    (parser-fn request)))
+  (if (-> request :body some?)
+    (let [parser-fn (parser-for parser-map (:content-type request))]
+      (parser-fn request))
+    request))
 
 (defn add-parser
   "Adds a parser to the parser map; content type can either be a string (to exactly match the content type),
@@ -187,7 +190,9 @@
   - :edn-params
   - :form-params
   - :transit-params
-  "
+
+  When the body is absent (or nil), then the request is not changed (no new keys are added, no
+  parsing is attempted)."
   ([] (body-params (default-parser-map)))
   ([parser-map]
    (interceptor

--- a/tests/test/io/pedestal/http/body_params_test.clj
+++ b/tests/test/io/pedestal/http/body_params_test.clj
@@ -1,4 +1,4 @@
-; Copyright 2024 Nubank NA
+; Copyright 2024-2025 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2022 Cognitect, Inc.
 
@@ -14,7 +14,8 @@
 (ns io.pedestal.http.body-params-test
   (:require [clojure.instant :as inst]
             [io.pedestal.http.body-params :refer [body-params default-parser-map]]
-            [clojure.test :refer [deftest is]])
+            [clojure.test :refer [deftest is]]
+            [matcher-combinators.matchers :as m])
   (:import (java.io ByteArrayInputStream)))
 
 (defn byte-context [content-type ^bytes body-bytes]
@@ -46,6 +47,13 @@
         new-context (i-using-opts json-context)
         new-request (:request new-context)]
     (is (= (:json-params new-request) {"foo" "BAR"}))))
+
+(deftest content-type-with-no-body
+  (let [json-context {:request {:content-type "application/json"
+                                :headers {"content-type" "application/json"}}}
+        result (i json-context)]
+    (is (match? {:request {:json-params m/absent}}
+                result))))
 
 (defn json-request
   [json-context options]


### PR DESCRIPTION
Fixes #949 

Is this a breaking change?  Previously invalid requests (which would throw an exception) may now operate, potentially leading to NPEs or incorrect behavior in downstream interceptors that expect :json-params (or other keys) to be present and have values.  However, I feel that well constructed applications will use some form of schema-based validating interceptor that will flag nil as invalid and return a proper 400 status response.