### PR TITLE
Rollback Jetty to version 12.0.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'corretto'
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@13.4
         with:
-          cli: 1.12.1.1561
+          cli: 1.12.2.1565
 
       - name: Cache Clojure dependencies
         uses: actions/cache@v4

--- a/common/deps.edn
+++ b/common/deps.edn
@@ -9,5 +9,5 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-{:deps {org.clojure/clojure    {:mvn/version "1.12.1"}
+{:deps {org.clojure/clojure    {:mvn/version "1.12.2"}
         org.clj-commons/pretty {:mvn/version "3.6.3"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
           borkdude/rewrite-edn {:mvn/version "0.4.9"}
           clj-kondo/clj-kondo {:mvn/version "2025.07.28"}
           org.clj-commons/pretty {:mvn/version "3.6.3"}
-          babashka/fs {:mvn/version "0.5.26"}}}
+          babashka/fs {:mvn/version "0.5.27"}}}
 
   ;; Invoked via clj -T:build cve-check
   :nvd

--- a/http-kit/deps.edn
+++ b/http-kit/deps.edn
@@ -9,7 +9,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps  {org.clojure/clojure          {:mvn/version "1.12.1"}
+ :deps  {org.clojure/clojure          {:mvn/version "1.12.2"}
          io.pedestal/pedestal.log     {:mvn/version "0.8.0-rc-2"}
          io.pedestal/pedestal.service {:mvn/version "0.8.0-rc-2"}
          http-kit/http-kit            {:mvn/version "2.8.1"}}

--- a/interceptor/deps.edn
+++ b/interceptor/deps.edn
@@ -12,7 +12,7 @@
 
 {:paths ["src"
          "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         org.clojure/core.async {:mvn/version "1.8.741"}
         org.clj-commons/pretty {:mvn/version "3.6.3"}
         io.pedestal/pedestal.log {:mvn/version "0.8.0-rc-2"}

--- a/jetty/deps.edn
+++ b/jetty/deps.edn
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         io.pedestal/pedestal.log {:mvn/version "0.8.0-rc-2"}
         io.pedestal/pedestal.service {:mvn/version "0.8.0-rc-2"}
         io.pedestal/pedestal.servlet {:mvn/version "0.8.0-rc-2"}

--- a/log/deps.edn
+++ b/log/deps.edn
@@ -12,7 +12,7 @@
 
 {:paths ["src"
          "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         io.pedestal/pedestal.common {:mvn/version "0.8.0-rc-2"}
         ;; logging
         org.slf4j/slf4j-api {:mvn/version "2.0.17"}}

--- a/route/deps.edn
+++ b/route/deps.edn
@@ -12,7 +12,7 @@
 
 {:paths ["src"
          "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         org.clojure/core.async {:mvn/version "1.8.741"}
         org.clj-commons/pretty {:mvn/version "3.6.3"}
         io.pedestal/pedestal.log {:mvn/version "0.8.0-rc-2"}

--- a/service/deps.edn
+++ b/service/deps.edn
@@ -11,7 +11,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps  {org.clojure/clojure              {:mvn/version "1.12.1"}
+ :deps  {org.clojure/clojure              {:mvn/version "1.12.2"}
          io.pedestal/pedestal.log         {:mvn/version "0.8.0-rc-2"}
          io.pedestal/pedestal.telemetry   {:mvn/version "0.8.0-rc-2"}
          io.pedestal/pedestal.interceptor {:mvn/version "0.8.0-rc-2"}

--- a/servlet/deps.edn
+++ b/servlet/deps.edn
@@ -13,7 +13,7 @@
 {:paths ["src"
          "java"
          "target/classes"]
- :deps  {org.clojure/clojure              {:mvn/version "1.12.1"}
+ :deps  {org.clojure/clojure              {:mvn/version "1.12.2"}
          io.pedestal/pedestal.log         {:mvn/version "0.8.0-rc-2"}
          io.pedestal/pedestal.telemetry   {:mvn/version "0.8.0-rc-2"}
          io.pedestal/pedestal.interceptor {:mvn/version "0.8.0-rc-2"}

--- a/telemetry/deps.edn
+++ b/telemetry/deps.edn
@@ -10,7 +10,7 @@
 ; You must not remove this notice, or any other, from this software.
 
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.2"}
         io.pedestal/pedestal.common {:mvn/version "0.8.0-rc-2"}
         io.opentelemetry/opentelemetry-api {:mvn/version "1.53.0"}}
 

--- a/tests/deps.edn
+++ b/tests/deps.edn
@@ -81,10 +81,10 @@
 
 
   :1.12
-  {:override-deps {org.clojure/clojure {:mvn/version "1.12.1"}}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}}
 
   :1.11
-  {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
+  {:override-deps {org.clojure/clojure {:mvn/version "1.12.2"}}}
 
   ;; clj -X:test
   :test


### PR DESCRIPTION
There were some [reports on Slack](https://clojurians.slack.com/archives/C0K65B20P/p1756063425322459) about hangs related to fast resources (i.e., async responses) in Jetty.