### PR TITLE
Improve http-kit SSE client disconnect detection

### DIFF
--- a/http-kit/src/io/pedestal/http/http_kit/response.clj
+++ b/http-kit/src/io/pedestal/http/http_kit/response.clj
@@ -13,7 +13,7 @@
   "Utilities for converting Pedestal response :body types to those compatible with Http-Kit."
   {:added "0.8.0"}
   (:require [io.pedestal.service.impl :as impl]
-            [clojure.core.async :refer [<! go]]
+            [clojure.core.async :refer [<! go close!]]
             [org.httpkit.server :as hk])
   (:import (clojure.core.async.impl.protocols ReadPort)
            (clojure.lang Fn IPersistentCollection)


### PR DESCRIPTION
With this change, interceptors that return a core.async channel will have their channel closed as soon as http-kit invokes its `:on-close` callback.

The fix is located in `pipe-async-response-channel` since we need access to both the user's core.async channel and the http-kit `AsyncChannel`, and this function has access to both.

Edit: The CLA is signed; see [here](https://github.com/pedestal/pedestal/pull/966).