### PR TITLE
Jetty's context map must be representable.

### DIFF
--- a/tests/test/io/pedestal/service/jetty_connector_test.clj
+++ b/tests/test/io/pedestal/service/jetty_connector_test.clj
@@ -104,9 +104,9 @@
     ;; Follows the same standard as
     ;; https://github.com/clojure/clojure/blob/clojure-1.12.3/src/clj/clojure/core_print.clj#L104-L115
     ;; Results in:
-    #_#object[org.eclipse.jetty.ee10.servlet.ServletApiResponse
-              0x00000000
-              "org.eclipse.jetty.ee10.servlet.ServletApiResponse@0x00000000"]
+    ;; #object[org.eclipse.jetty.ee10.servlet.ServletApiResponse
+    ;;         0x00000000
+    ;;         "org.eclipse.jetty.ee10.servlet.ServletApiResponse@0x00000000"
     [this ^Writer w]
     (let [class-name (-> this class .getName)
           id (System/identityHashCode this)]

--- a/tests/test/io/pedestal/service/jetty_connector_test.clj
+++ b/tests/test/io/pedestal/service/jetty_connector_test.clj
@@ -11,17 +11,19 @@
 
 (ns io.pedestal.service.jetty-connector-test
   "Tests when running Jetty as a connector, using test-request."
-  (:require [clojure.edn :as edn]
+  (:require [clojure.core.async :refer [go]]
+            [clojure.edn :as edn]
             [clojure.test :refer [deftest is use-fixtures]]
-            [clojure.core.async :refer [go]]
-            [io.pedestal.http.response :as response]
             [io.pedestal.connector :as connector]
-            [io.pedestal.http.jetty :as jetty]
-            [matcher-combinators.matchers :as m]
-            [ring.util.response :refer [response]]
             [io.pedestal.connector.test :as test]
+            [io.pedestal.http.jetty :as jetty]
+            [io.pedestal.http.response :as response]
+            [io.pedestal.http.route.definition.table :as table]
             [io.pedestal.interceptor :refer [interceptor]]
-            [io.pedestal.http.route.definition.table :as table]))
+            [matcher-combinators.matchers :as m]
+            [ring.util.response :refer [response]])
+  (:import (java.io Writer)
+           (org.eclipse.jetty.ee10.servlet ServletApiResponse)))
 
 (defn hello-page
   [_request]
@@ -96,3 +98,56 @@
                :body    (m/via edn/read-string
                                {"My-Key" "My-Value"})}
               (response-for :get "/echo/headers" :headers {:My-Key 'My-Value}))))
+
+;; A possible solution:
+#_(defmethod print-method ServletApiResponse
+    ;; Follows the same standard as
+    ;; https://github.com/clojure/clojure/blob/clojure-1.12.3/src/clj/clojure/core_print.clj#L104-L115
+    ;; Results in:
+    #_#object[org.eclipse.jetty.ee10.servlet.ServletApiResponse
+              0x00000000
+              "org.eclipse.jetty.ee10.servlet.ServletApiResponse@0x00000000"]
+    [this ^Writer w]
+    (let [class-name (-> this class .getName)
+          id (System/identityHashCode this)]
+      (.write w "#object [")
+      (.write w class-name)
+      (.write w " ")
+      (.write w (format "0x%x " id))
+      (print-method (format "%s@0x%x" class-name id) w)
+      (.write w "]")))
+
+
+(deftest context-scope-capture
+  (let [*ctx (promise)
+        conn (-> (connector/default-connector-map 8888)
+               (connector/with-default-interceptors)
+               (connector/with-routes #{["/" :get {:enter (fn [ctx]
+                                                            (deliver *ctx ctx)
+                                                            (assoc ctx :response {:status 204}))}
+                                         :route-name :context-scope-capture]})
+               (jetty/create-connector nil)
+               (connector/start!))]
+    (try
+      (slurp "http://localhost:8888")
+      (finally
+        (connector/stop! conn)))
+    (is (= :ok
+
+          ;; (class servlet-response) => org.eclipse.jetty.ee10.servlet.ServletApiResponse
+
+
+          ;; ServletApiResponse implements .toString here
+          ;; https://github.com/jetty/jetty.project/blob/jetty-12.0.29/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java#L527
+          ;; toString implementation calls getResponse,
+          ;; https://github.com/jetty/jetty.project/blob/jetty-12.0.29/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java#L97
+          ;; getResponse throws IllegalStateException when `this._response` is null (probably after close)
+          ;; https://github.com/jetty/jetty.project/blob/jetty-12.0.29/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletChannel.java#L300
+          (when (realized? *ctx)
+            (-> @*ctx
+              ;; debug helpers: the `servlet-response` is in two places.
+              #_(dissoc :servlet-response)
+              #_(update :request dissoc :servlet-response)
+              str)
+            :ok))
+      "It should be possible to represent the captured ctx as a string (it should not throw an exception)")))


### PR DESCRIPTION
Currently if you capture jettys context map and try to inspect with some clojure data inspection tool, you will have problems.

It can't represent jetty response map because servlet-response `.toString` method throws an exception.

This PR creates a test that reproduces the issue
And proposes a solution.


I don't know if this is the ideal solution.
The best pratices about extending a multimethod says that to extend, you should own the class, or own the defmulti.