### PR TITLE
Embedded template: HTTP headers submitted in test should be lower case to align with the Ring specification

### DIFF
--- a/embedded/resources/io/pedestal/embedded/test/connector_test.tmpl
+++ b/embedded/resources/io/pedestal/embedded/test/connector_test.tmpl
@@ -36,5 +36,5 @@
                :body "Hello, Pedestal User."}
               (response-for *connector* :post "/hello"
                 :body (json/write-json-str {:name "Pedestal User"})
-                :headers {"Content-Type" "application/json"}))))
+                :headers {"content-type" "application/json"}))))
 


### PR DESCRIPTION
Running tests in #{"test"}

Testing com.blueant.peripheral.connector-test

FAIL in (can-access-greet) (connector_test.clj:35) expected: (match? {:status 200, :body "Hello, Pedestal User."} (response-for *connector* :post "/hello" :body (json/write-json-str {:name "Pedestal User"}) :headers {"Content-Type" "application/json"}))
  actual: {:status 200,
 :body
 (mismatch
  (expected "Hello, Pedestal User.")
  (actual "Hello, .")),
 :headers
 {"Strict-Transport-Security" "max-age=31536000; includeSubdomains",
  "X-Frame-Options" "DENY",
  "X-Content-Type-Options" "nosniff",
  "X-XSS-Protection" "1; mode=block",
  "X-Download-Options" "noopen",
  "X-Permitted-Cross-Domain-Policies" "none",
  "Content-Security-Policy"
  "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;",
  "Content-Type" "text/plain"}}