### PR TITLE
Include :exception in ex-data passed to error handler

### DIFF
--- a/docs/modules/reference/pages/error-handling.adoc
+++ b/docs/modules/reference/pages/error-handling.adoc
@@ -63,6 +63,10 @@ defined in its exception data map:
 | Keyword
 | Keywordized form of the exception's Java class name
 
+| :exception
+| Throwable
+| The original exception (also available via clj:ex-cause[]).
+
 |===
 
 The exception originally caught is provided as the clj:ex-cause[] of the provided exception.
@@ -77,10 +81,12 @@ handling and execute any remaining :leave handlers.
 2. Return the context map with the exception re-attached (using
   api:with-error[]).  This indicates that the
 handler doesn't recognize that exception and declines to handle
-it. Pedestal will continue looking for a handler.
-3. Throw a new exception. This indicates that the interceptor _intended_
+it. Pedestal will continue looking for an error handler.
+3. Rethrow the exception passed in; this works the same as case #2, and Pedestal
+will continue looking for an error handler.
+4. Throw a new exception. This indicates that the interceptor _intended_
 to handle the error, but something went wrong. Pedestal
-will start looking for a error handler for this new exception.
+will start looking for an error handler for this new exception.
 
 In that last case, Pedestal keeps track of the exceptions that were
 overridden. These are in a seq bound to

--- a/interceptor/src/io/pedestal/interceptor/chain.clj
+++ b/interceptor/src/io/pedestal/interceptor/chain.clj
@@ -1,4 +1,4 @@
-; Copyright 2023-2025 Nubank NA
+; Copyright 2023-2026 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2022 Cognitect, Inc.
 
@@ -25,7 +25,6 @@
 
 (declare ^:private execute-continue)
 
-
 (defn- name-for
   [interceptor]
   ;; Generally, interceptors will have a :name key that's a keyword, but there still
@@ -43,7 +42,8 @@
              (merge {:execution-id   execution-id
                      :stage          stage
                      :interceptor    interceptor-name
-                     :exception-type (keyword throwable-str)}
+                     :exception-type (keyword throwable-str)
+                     :exception t}
                     (ex-data t))
              t)))
 
@@ -133,8 +133,7 @@
         (let [context-out (callback context-in error)]
           (notify-observer interceptor :error context-in context-out))
         (catch Throwable t
-          ;; The error handling interceptor can rethrow the wrapped exception OR it can
-          ;; rethrow the actual/original exception.
+          ;; The error handling interceptor can rethrow the wrapped exception
           (if (identical? t error)
             (do
               (log/debug :rethrow t :execution-id (::excecution-id context))


### PR DESCRIPTION
Clarify throwing the passed exception from the error handler.

The prior change that removed the :exception key was an unnecessary breaking change; this has been discovered in working code (at Nubank) that was broken.  Passing the exception as :exception and as the cause is not ideal, but is compatible for people upgrading from Pedestal 0.6 or 0.7.