### PR TITLE
Add :dev alias exposing all module source paths

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -22,6 +22,10 @@
           org.clj-commons/pretty {:mvn/version "3.6.8"}
           babashka/fs {:mvn/version "0.5.31"}}}
 
+  :dev {:extra-paths ["common/src" "embedded/src" "error/src" "http-kit/src"
+                      "interceptor/src" "jetty/src" "log/src" "route/src"
+                      "service/src" "servlet/src" "telemetry/src"]}
+
   ;; Invoked via clj -T:build cve-check
   :nvd
   {:deps {nvd-clojure/nvd-clojure {:mvn/version "5.3.0"}


### PR DESCRIPTION
## Summary

- Adds a `:dev` alias in the root `deps.edn` that lists the `src` directories of every module in the monorepo (`common`, `embedded`, `error`, `http-kit`, `interceptor`, `jetty`, `log`, `route`, `service`, `servlet`, `telemetry`).
- This lets tools that read the root `deps.edn` — notably [clojure-lsp](https://clojure-lsp.io/) — detect the whole monorepo out of the box, so features like find-references, rename, and navigation work across modules without per-developer configuration.
- No runtime behaviour changes: the alias is opt-in and only affects tooling that explicitly activates `:dev`.

## Test plan

- [x] `clj -A:dev -Spath` resolves and includes every listed module source path.
- [x] Open the repo root in an editor with clojure-lsp and confirm cross-module references (e.g. from `service` into `interceptor`) are resolved.
- [x] Existing per-module aliases and builds are unaffected (the new alias is additive).

🤖 Generated with [eca](https://eca.dev)