### PR TITLE
Jetty: Only enable scanning when :keystore is a string (not a Keystore object)

### DIFF
--- a/jetty/src/io/pedestal/http/jetty.clj
+++ b/jetty/src/io/pedestal/http/jetty.clj
@@ -79,14 +79,16 @@
   "Create an SslConnectionFactory instance."
   [server options]
   (let [{:keys [alpn container-options]}    options
-        {:keys [keystore-scal-interval]
+        {:keys [keystore-scal-interval keystore]
          :or   {keystore-scal-interval 60}} container-options
         ssl-context                         (ssl-context-factory container-options)
         factory                             (SslConnectionFactory. ssl-context (if alpn
                                                                                  (.getProtocol ^ALPNServerConnectionFactory alpn)
                                                                                  "http/1.1"))]
-    (.addBean server (doto (KeyStoreScanner. ssl-context)
-                       (.setScanInterval keystore-scal-interval)))
+    ;; When keystore is a filesystem path, enable scanning.
+    (when (string? keystore)
+      (.addBean server (doto (KeyStoreScanner. ssl-context)
+                         (.setScanInterval keystore-scal-interval))))
     factory))
 
 (defn- http-configuration


### PR DESCRIPTION
Per the spec, the `:keystore` container option can be a string (file path) or a `java.security.Keystore` object. If it is the latter, engaging scanning will lead to an NPE. This is related to the behavior mentioned in #975, but is slightly different as that failure can happen when a string is used. As I mentioned in that issue I can also add a manual shutoff here if that is desired.