### PR TITLE
Add arity for histograms to record per-event attributes

### DIFF
--- a/telemetry/src/io/pedestal/metrics.clj
+++ b/telemetry/src/io/pedestal/metrics.clj
@@ -97,7 +97,7 @@
   the event; a comment example is to use a histogram to track the size of incoming requests
   or outgoing responses.
 
-  Returns a function that records the dimension of an event."
+  Returns a function that records the dimension of an event, optionally with per-event attributes."
   ([metric-name attributes]
    (histogram *default-metric-source* metric-name attributes))
   ([metric-source metric-name attributes]

--- a/telemetry/src/io/pedestal/metrics/otel.clj
+++ b/telemetry/src/io/pedestal/metrics/otel.clj
@@ -74,11 +74,17 @@
         attributes' (map->Attributes attributes)]
     (if as-longs?
       (let [histogram (-> builder .ofLongs .build)]
-        (fn [^long value]
-          (.record ^LongHistogram histogram value attributes')))
+        (fn
+          ([^long value]
+           (.record ^LongHistogram histogram value attributes'))
+          ([^long value event-attributes]
+           (.record ^LongHistogram histogram value (map->Attributes (merge attributes event-attributes))))))
       (let [histogram (.build builder)]
-        (fn [^double value]
-          (.record histogram value attributes'))))))
+        (fn
+          ([^double value]
+           (.record histogram value attributes'))
+          ([^double value event-attributes]
+           (.record histogram value (map->Attributes (merge attributes event-attributes)))))))))
 
 (defn- new-gauge
   [^Meter meter metric-name attributes value-fn]

--- a/tests/test/io/pedestal/metrics/otel_test.clj
+++ b/tests/test/io/pedestal/metrics/otel_test.clj
@@ -505,6 +505,26 @@
     (is (match? [[:record-long "histogram.test" 42 clojure-domain-attributes]]
                 (events)))))
 
+(deftest histogram-with-event-attributes
+  (let [update-fn (metrics/histogram :histogram.attr {:domain               "clojure"
+                                                      ::metrics/description "histogram description"
+                                                      ::metrics/unit        "laughs"})]
+    (is (match? [[:setDescription "histogram.attr" "histogram description"]
+                 [:setUnit "histogram.attr" "laughs"]
+                 [:ofLongs "histogram.attr"]
+                 [:build-long "histogram.attr"]]
+                (events)))
+
+    (update-fn 42)
+
+    (is (match? [[:record-long "histogram.attr" 42 clojure-domain-attributes]]
+                (events)))
+
+    (update-fn 43 {:event-a :event-v})
+
+    (is (match? [[:record-long "histogram.attr" 43 (m/via str "{domain=\"clojure\", event-a=\"event-v\"}")]]
+                (events)))))
+
 (deftest double-histogram
   (let [update-fn (metrics/histogram :histogram.test {:domain               "clojure"
                                                       ::metrics/description "histogram description"


### PR DESCRIPTION
Fix #989 by adding an arity for recording per-event attributes.

(Replaces closed PR #996.)