### PR TITLE
docs: fix successful spelling in docs

### DIFF
--- a/docs/modules/reference/pages/request-map.adoc
+++ b/docs/modules/reference/pages/request-map.adoc
@@ -68,7 +68,7 @@ of the Ring request specification, and is kept for compatibility reasons.].
 | No
 | Map
 | *No*
-| Present after succesful routing, a map from keyword id to string value of path parameters defined by the route.
+| Present after successful routing, a map from keyword id to string value of path parameters defined by the route.
 
 | :protocol
 | Yes


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/modules/reference/pages/request-map.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
