### PR TITLE
feat: support :subprotocols in Http-Kit WebSocket connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ Other Changes:
 * It is now possible to configure the JSON Processor used by Pedestal
 * Expanded routes now, again, include the :path-re key (as in Pedestal 0.7 and earlier)
 * The result of `expand-routes`, the RoutingTable record, is now public in the io.pedestal.http.route.types namespace
-* When the routing table is automatically printed in dev mode, it now printed to `*err*`. 
+* When the routing table is automatically printed in dev mode, it now printed to `*err*`.
+* The `:subprotocols` key in WebSocket options is now supported by the Http-Kit connector, in addition to Jetty.
+  During the upgrade handshake, the server selects the first entry in `:subprotocols` that the client also supports
+  and includes it in the `Sec-WebSocket-Protocol` response header.
 
 [Closed Issues](https://github.com/pedestal/pedestal/issues?q=is%3Aclosed%20milestone%3A%220.8.2%22)
 

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -83,6 +83,32 @@ as well as callbacks for specific events in the WebSocket lifecyle.
 
 |===
 
+== Connector-Specific Options
+
+The callbacks above (`:on-open`, `:on-close`, `:on-text`, `:on-binary`) are supported by all network connectors.
+Additional options in the websocket options map are defined by, and passed through to, the network connector.
+Unrecognized keys are silently ignored.
+
+=== Jetty
+
+The Jetty connector supports the following additional options:
+
+.Jetty Connection Options
+|===
+| Key | Type | Description
+
+| :subprotocols
+| Vector of String
+| An optional list of WebSocket subprotocols supported by the endpoint.
+  During the upgrade handshake, the client and server negotiate which subprotocol to use.
+
+| :configure
+| (ServerEndpointConfig.Builder) -> nil
+| An optional callback for low-level configuration of the endpoint.
+  Passed the `jakarta.websocket.server.ServerEndpointConfig.Builder` before the connection is established.
+
+|===
+
 Essentially, the :on-open callback is invoked when the client initiates the connection.
 
 It is intended that, when the client connects, some form of server-side process will be initiated

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -83,24 +83,32 @@ as well as callbacks for specific events in the WebSocket lifecyle.
 
 |===
 
-== Connector-Specific Options
+== Connection Options
 
-The callbacks above (`:on-open`, `:on-close`, `:on-text`, `:on-binary`) are supported by all network connectors.
-Additional options in the websocket options map are defined by, and passed through to, the network connector.
-Unrecognized keys are silently ignored.
+The following option is supported by all network connectors:
 
-=== Jetty
-
-The Jetty connector supports the following additional options:
-
-.Jetty Connection Options
+.Universal Connection Options
 |===
 | Key | Type | Description
 
 | :subprotocols
 | Vector of String
 | An optional list of WebSocket subprotocols supported by the endpoint.
-  During the upgrade handshake, the client and server negotiate which subprotocol to use.
+  During the upgrade handshake, the client and server negotiate which subprotocol to use;
+  the server selects the first entry in `:subprotocols` that the client also supports and
+  echoes it in the `Sec-WebSocket-Protocol` response header.
+  Supported by the Jetty and Http-Kit connectors.
+
+|===
+
+Additional options may be supported by specific network connectors.
+Unrecognized keys are silently ignored.
+
+=== Jetty-Specific Options
+
+.Jetty Connection Options
+|===
+| Key | Type | Description
 
 | :configure
 | (ServerEndpointConfig.Builder) -> nil

--- a/http-kit/src/io/pedestal/http/http_kit.clj
+++ b/http-kit/src/io/pedestal/http/http_kit.clj
@@ -15,7 +15,8 @@
   Http-Kit provides features similar to the Servlet API, including WebSockets, but does not
   implement any of the underlying Servlet API or WebSocket interfaces."
   {:added "0.8.0"}
-  (:require [io.pedestal.http.response :as response]
+  (:require [clojure.string :as string]
+            [io.pedestal.http.response :as response]
             [io.pedestal.log :as log]
             [io.pedestal.service.data :as data :refer [convert]]
             [io.pedestal.service.protocols :as p]
@@ -177,11 +178,20 @@
           ;; the test contract (nil or InputStream).
           (update response :body test/coerce-response-body))))))
 
+(defn- negotiate-subprotocol
+  "Given the server's list of supported subprotocols and the Ring request,
+  returns the first server subprotocol that the client also supports,
+  or nil if none match."
+  [server-subprotocols request]
+  (when-let [client-header (get-in request [:headers "sec-websocket-protocol"])]
+    (let [client-protocols (into #{} (map string/trim) (string/split client-header #","))]
+      (first (filter client-protocols server-subprotocols)))))
+
 (defn- initialize-websocket*
   "Knit together Pedestal's lifecycle with Http-Kit's."
   [ch context ws-opts]
   (let [{:keys [request]} context
-        {:keys [on-close]} ws-opts
+        {:keys [on-close subprotocols]} ws-opts
         ;; Http-Kit always wants to setup on-receive before the open, so we do that but allow
         ;; for the actual callback to be provided after the open callback.
         *on-text   (atom nil)
@@ -226,20 +236,39 @@
                            f         @*callback]
                        (when f
                          (f ws-channel @*proc message))))
-        ch-opts    (cond-> {:on-receive on-receive
-                            :on-open    (fn [_]
-                                          (when-let [f (:on-open ws-opts)]
-                                            (reset! *proc (f ws-channel request)))
+        open-fn    (fn [_]
+                     (when-let [f (:on-open ws-opts)]
+                       (reset! *proc (f ws-channel request)))
 
-                                          (when-let [f (:on-text ws-opts)]
-                                            (ws/on-text ws-channel f))
+                     (when-let [f (:on-text ws-opts)]
+                       (ws/on-text ws-channel f))
 
-                                          (when-let [f (:on-binary ws-opts)]
-                                            (ws/on-binary ws-channel :byte-buffer f)))}
-                     on-close (assoc :on-close
-                                     (fn [_ status-code]
-                                        (on-close ws-channel @*proc status-code))))
-        hk-response (hk/as-channel request ch-opts)]
+                     (when-let [f (:on-binary ws-opts)]
+                       (ws/on-binary ws-channel :byte-buffer f)))
+        hk-response
+        (if subprotocols
+          ;; When subprotocols are specified we must send the handshake manually so that we
+          ;; can include the negotiated Sec-WebSocket-Protocol header.
+          (when-let [sec-ws-accept (hk/websocket-handshake-check request)]
+            (hk/on-receive ch (partial on-receive ch))
+            (when on-close
+              (hk/on-close ch (fn [_ status-code]
+                                (on-close ws-channel @*proc status-code))))
+            (let [negotiated (negotiate-subprotocol subprotocols request)
+                  headers    (cond-> {"Upgrade"              "websocket"
+                                      "Connection"           "Upgrade"
+                                      "Sec-WebSocket-Accept" sec-ws-accept}
+                               negotiated (assoc "Sec-WebSocket-Protocol" negotiated))]
+              (.sendHandshake ^AsyncChannel ch headers))
+            (open-fn nil)
+            {:body ch})
+          ;; No subprotocol negotiation — use the standard as-channel path.
+          (hk/as-channel request
+                         (cond-> {:on-receive on-receive
+                                  :on-open    open-fn}
+                           on-close (assoc :on-close
+                                           (fn [_ status-code]
+                                             (on-close ws-channel @*proc status-code))))))]
     ;; The :status is needed to keep the interceptor terminator checker from complaining.
     (assoc context :response (assoc hk-response :status 200))))
 

--- a/service/src/io/pedestal/service/websocket.clj
+++ b/service/src/io/pedestal/service/websocket.clj
@@ -81,7 +81,18 @@
   :on-binary callback passed the WebSocketChannel, the process object, and the binary data (as a ByteBuffer); return value is ignored.
 
   Note that in order to override the type of binary data passed to the callback, you must make use of [[on-binary]] from
-  your :on-open callback."
+  your :on-open callback.
+
+  The above options are supported by all network connectors. Additional options may be supported by specific
+  network connectors; unrecognized keys are silently ignored.
+
+  Jetty-specific options:
+
+  :subprotocols - an optional vector of Strings listing the WebSocket subprotocols supported by the endpoint.
+  During the upgrade handshake, the client and server negotiate which subprotocol to use.
+
+  :configure - an optional callback passed the jakarta.websocket.server.ServerEndpointConfig.Builder,
+  allowing low-level configuration of the endpoint before the connection is established."
   [context ws-opts]
   ;; The Pedestal Connector is responsible for putting this key into the context:
   (initialize-websocket (:websocket-channel-source context) context ws-opts))

--- a/service/src/io/pedestal/service/websocket.clj
+++ b/service/src/io/pedestal/service/websocket.clj
@@ -83,13 +83,14 @@
   Note that in order to override the type of binary data passed to the callback, you must make use of [[on-binary]] from
   your :on-open callback.
 
-  The above options are supported by all network connectors. Additional options may be supported by specific
-  network connectors; unrecognized keys are silently ignored.
-
-  Jetty-specific options:
-
   :subprotocols - an optional vector of Strings listing the WebSocket subprotocols supported by the endpoint.
   During the upgrade handshake, the client and server negotiate which subprotocol to use.
+  The server selects the first entry in :subprotocols that the client also supports.
+  Supported by the Jetty and Http-Kit connectors.
+
+  Additional options may be supported by specific network connectors; unrecognized keys are silently ignored.
+
+  Jetty-specific options:
 
   :configure - an optional callback passed the jakarta.websocket.server.ServerEndpointConfig.Builder,
   allowing low-level configuration of the endpoint before the connection is established."

--- a/tests/test/io/pedestal/service/hk_websocket_test.clj
+++ b/tests/test/io/pedestal/service/hk_websocket_test.clj
@@ -94,12 +94,19 @@
                                     (websocket/send-text! conn (str "oneshot: " text))
                                     (websocket/close! conn))))))}))
 
+(def subprotocol-handler
+  (websocket/websocket-interceptor
+    ::subprotocol-handler
+    (assoc default-ws-opts
+           :subprotocols ["graphql-ws" "chat"])))
+
 (def routes
   (table/table-routes
     [["/ws/echo/:prefix" :get echo-prefix]
      ["/ws/reverser" :get byte-reverser]
      ["/ws/countdown" :get countdown]
-     ["/ws/oneshot" :get oneshot]]))
+     ["/ws/oneshot" :get oneshot]
+     ["/ws/subprotocol" :get subprotocol-handler]]))
 
 (def ws-uri "ws://localhost:8080")
 
@@ -280,6 +287,31 @@
     ;; The connection (send-ch) closes, but the WebSocketChannel does not.
 
     (is (= false @*closed?))))
+
+(deftest subprotocol-is-negotiated
+  ;; Server supports ["graphql-ws" "chat"]; client offers ["chat" "graphql-ws"].
+  ;; Server selects "graphql-ws" — its first preference that the client also supports.
+  (with-connector routes
+    (let [*negotiated (promise)
+          session     @(ws/websocket (str ws-uri "/ws/subprotocol")
+                                     {:subprotocols ["chat" "graphql-ws"]
+                                      :on-open      (fn [^java.net.http.WebSocket ws]
+                                                      (deliver *negotiated (.getSubprotocol ws)))})]
+      (expect-event :open)
+      (is (= "graphql-ws" (deref *negotiated 1000 ::timeout)))
+      (ws/close! session))))
+
+(deftest no-subprotocol-when-none-match
+  ;; Client requests a subprotocol the server does not support; no Sec-WebSocket-Protocol header is sent.
+  (with-connector routes
+    (let [*negotiated (promise)
+          session     @(ws/websocket (str ws-uri "/ws/subprotocol")
+                                     {:subprotocols ["unknown-protocol"]
+                                      :on-open      (fn [^java.net.http.WebSocket ws]
+                                                      (deliver *negotiated (.getSubprotocol ws)))})]
+      (expect-event :open)
+      (is (= "" (deref *negotiated 1000 ::timeout)))
+      (ws/close! session))))
 
 (deftest thrown-exception-is-reported-and-does-not-kill-loop
   (let [*messages (atom [])


### PR DESCRIPTION
## Summary

- Implement WebSocket subprotocol negotiation (`Sec-WebSocket-Protocol`) in the Http-Kit connector; server selects its first preference that the client also supports
- Document `:subprotocols` as supported by both Http-Kit and Jetty; `:configure` remains Jetty-specific in docstrings and reference docs

🤖 Generated with [eca](https://eca.dev)