### PR TITLE
feat: add WebSocket connection limit options (issue #968)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * The `body-params` interceptor now detects that the body is empty (not just nil) and does not attempt to
   parse the body; this means that derived keys (such as :form-params) may be absent, rather than nil or
   an empty map.
+* Added `id` method to `WebSocketChannel` protocol.
 
 Other Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Other Changes:
 * Expanded routes now, again, include the :path-re key (as in Pedestal 0.7 and earlier)
 * The result of `expand-routes`, the RoutingTable record, is now public in the io.pedestal.http.route.types namespace
 * When the routing table is automatically printed in dev mode, it now printed to `*err*`.
+* Added `:max-idle-timeout`, `:max-binary-message-buffer-size`, and `:max-text-message-buffer-size` options
+  to `upgrade-request-to-websocket`; supported by Jetty, ignored by Http-Kit.
 * The `:subprotocols` key in WebSocket options is now supported by the Http-Kit connector, in addition to Jetty.
   During the upgrade handshake, the server selects the first entry in `:subprotocols` that the client also supports
   and includes it in the `Sec-WebSocket-Protocol` response header.

--- a/docs/modules/reference/pages/websockets.adoc
+++ b/docs/modules/reference/pages/websockets.adoc
@@ -115,7 +115,30 @@ Unrecognized keys are silently ignored.
 | An optional callback for low-level configuration of the endpoint.
   Passed the `jakarta.websocket.server.ServerEndpointConfig.Builder` before the connection is established.
 
+| :max-idle-timeout
+| long
+| Maximum time in milliseconds the connection may be idle (no messages sent or received) before
+  the server closes it.
+
+| :max-binary-message-buffer-size
+| int
+| Maximum size in bytes of a binary message that the server will buffer.
+  Messages exceeding this limit cause the connection to be closed.
+
+| :max-text-message-buffer-size
+| int
+| Maximum size in bytes of a text message that the server will buffer.
+  Messages exceeding this limit cause the connection to be closed.
+
 |===
+
+[NOTE]
+====
+When Jetty enforces a limit (idle timeout or message size), it closes the underlying TCP connection
+directly rather than performing a WebSocket close handshake.
+As a result, the `:on-close` callback receives `:abnormal` (WebSocket close code 1006)
+rather than a more specific reason code.
+====
 
 Essentially, the :on-open callback is invoked when the client initiates the connection.
 

--- a/http-kit/src/io/pedestal/http/http_kit.clj
+++ b/http-kit/src/io/pedestal/http/http_kit.clj
@@ -104,47 +104,47 @@
   in the options map, or from [[default-options]]."
   [connector-map options]
   (let [{:keys [host port interceptors initial-context join?]} connector-map
-        options'     (merge default-options
-                            options
-                            {:ip   host
-                             :port port})
-        *server      (atom nil)
+        options'         (merge default-options
+                                options
+                                {:ip   host
+                                 :port port})
+        *server          (atom nil)
         initial-context' (response/terminate-when-response initial-context)
-        root-handler (fn [request]
-                       (let [{:keys [uri async-channel]} request
-                             response-commited-ch (chan)
-                             request'             (assoc request
-                                                         :io.pedestal.http.request/response-commited-ch response-commited-ch
-                                                         :path-info uri
-                                                         :headers (reduce-kv (fn [m k v]
-                                                                               (assoc m k (string/replace v "\n" ",")))
-                                                                             {}
-                                                                             (:headers request)))
-                             *async-channel       (atom nil)
-                             interceptors'        (into [(async-responder *async-channel)
-                                                        (response-committer response-commited-ch)
-                                                         response-converter]
-                                                        interceptors)
-                             context              (-> initial-context'
-                                                      (assoc :request request'
-                                                             :websocket-channel-source async-channel)
-                                                      (chain/on-enter-async (fn [_]
-                                                                              (reset! *async-channel (or async-channel
-                                                                                                         (throw (ex-info "No async channel in request map"
-                                                                                                                         {:request request}))))))
-                                                      (chain/execute interceptors'))]
-                         ;; When processing goes async, chain/execute will return nil but we'll have captured the Http-Kit async channel.
-                         (if-let [async-channel @*async-channel]
-                           ;; Returning this to Http-Kit causes it to set things up for an async response to be delivered
-                           ;; via hk/send!.
-                           {:body async-channel}
-                           (or (:response context)
-                               (do
-                                 (log/error :msg "Execution completed without producing a response"
-                                            :request request)
-                                 {:status  500
-                                  :headers {"Content-Type" "text/plain"}
-                                  :body    "Execution completed without producing a response"})))))]
+        root-handler     (fn [request]
+                           (let [{:keys [uri async-channel]} request
+                                 response-commited-ch (chan)
+                                 request'             (assoc request
+                                                             :io.pedestal.http.request/response-commited-ch response-commited-ch
+                                                             :path-info uri
+                                                             :headers (reduce-kv (fn [m k v]
+                                                                                   (assoc m k (string/replace v "\n" ",")))
+                                                                                 {}
+                                                                                 (:headers request)))
+                                 *async-channel       (atom nil)
+                                 interceptors'        (into [(async-responder *async-channel)
+                                                             (response-committer response-commited-ch)
+                                                             response-converter]
+                                                            interceptors)
+                                 context              (-> initial-context'
+                                                          (assoc :request request'
+                                                                 :websocket-channel-source async-channel)
+                                                          (chain/on-enter-async (fn [_]
+                                                                                  (reset! *async-channel (or async-channel
+                                                                                                             (throw (ex-info "No async channel in request map"
+                                                                                                                             {:request request}))))))
+                                                          (chain/execute interceptors'))]
+                             ;; When processing goes async, chain/execute will return nil but we'll have captured the Http-Kit async channel.
+                             (if-let [async-channel @*async-channel]
+                               ;; Returning this to Http-Kit causes it to set things up for an async response to be delivered
+                               ;; via hk/send!.
+                               {:body async-channel}
+                               (or (:response context)
+                                   (do
+                                     (log/error :msg "Execution completed without producing a response"
+                                                :request request)
+                                     {:status  500
+                                      :headers {"Content-Type" "text/plain"}
+                                      :body    "Execution completed without producing a response"})))))]
     (reify p/PedestalConnector
 
       (start-connector! [this]
@@ -201,8 +201,11 @@
         *on-text   (atom nil)
         *on-binary (atom nil)
         *proc      (atom nil)
+        id         (str (random-uuid))
         ws-channel (reify ws/WebSocketChannel
 
+                     (id [_] id)
+                     
                      (on-text [_ callback]
                        (when @*on-text
                          (throw (ex-info "on-text callback has already been set"
@@ -250,29 +253,29 @@
                      (when-let [f (:on-binary ws-opts)]
                        (ws/on-binary ws-channel :byte-buffer f)))
         hk-response
-        (if subprotocols
-          ;; When subprotocols are specified we must send the handshake manually so that we
-          ;; can include the negotiated Sec-WebSocket-Protocol header.
-          (when-let [sec-ws-accept (hk/websocket-handshake-check request)]
-            (hk/on-receive ch (partial on-receive ch))
-            (when on-close
-              (hk/on-close ch (fn [_ status-code]
-                                (on-close ws-channel @*proc status-code))))
-            (let [negotiated (negotiate-subprotocol subprotocols request)
-                  headers    (cond-> {"Upgrade"              "websocket"
-                                      "Connection"           "Upgrade"
-                                      "Sec-WebSocket-Accept" sec-ws-accept}
-                               negotiated (assoc "Sec-WebSocket-Protocol" negotiated))]
-              (.sendHandshake ^AsyncChannel ch headers))
-            (open-fn nil)
-            {:body ch})
-          ;; No subprotocol negotiation — use the standard as-channel path.
-          (hk/as-channel request
-                         (cond-> {:on-receive on-receive
-                                  :on-open    open-fn}
-                           on-close (assoc :on-close
-                                           (fn [_ status-code]
-                                             (on-close ws-channel @*proc status-code))))))]
+                   (if subprotocols
+                     ;; When subprotocols are specified we must send the handshake manually so that we
+                     ;; can include the negotiated Sec-WebSocket-Protocol header.
+                     (when-let [sec-ws-accept (hk/websocket-handshake-check request)]
+                       (hk/on-receive ch (partial on-receive ch))
+                       (when on-close
+                         (hk/on-close ch (fn [_ status-code]
+                                           (on-close ws-channel @*proc status-code))))
+                       (let [negotiated (negotiate-subprotocol subprotocols request)
+                             headers    (cond-> {"Upgrade"              "websocket"
+                                                 "Connection"           "Upgrade"
+                                                 "Sec-WebSocket-Accept" sec-ws-accept}
+                                          negotiated (assoc "Sec-WebSocket-Protocol" negotiated))]
+                         (.sendHandshake ^AsyncChannel ch headers))
+                       (open-fn nil)
+                       {:body ch})
+                     ;; No subprotocol negotiation — use the standard as-channel path.
+                     (hk/as-channel request
+                                    (cond-> {:on-receive on-receive
+                                             :on-open    open-fn}
+                                      on-close (assoc :on-close
+                                                      (fn [_ status-code]
+                                                        (on-close ws-channel @*proc status-code))))))]
     ;; The :status is needed to keep the interceptor terminator checker from complaining.
     (assoc context :response (assoc hk-response :status 200))))
 

--- a/service/src/io/pedestal/service/websocket.clj
+++ b/service/src/io/pedestal/service/websocket.clj
@@ -92,6 +92,15 @@
   The server selects the first entry in :subprotocols that the client also supports.
   Supported by the Jetty and Http-Kit connectors.
 
+  :max-idle-timeout - maximum time in milliseconds that the connection may be idle before it is closed.
+  Supported by Jetty; ignored by Http-Kit.
+
+  :max-binary-message-buffer-size - maximum size in bytes of a binary message that may be received.
+  Supported by Jetty; ignored by Http-Kit.
+
+  :max-text-message-buffer-size - maximum size in bytes of a text message that may be received.
+  Supported by Jetty; ignored by Http-Kit.
+
   Additional options may be supported by specific network connectors; unrecognized keys are silently ignored.
 
   Jetty-specific options:

--- a/service/src/io/pedestal/service/websocket.clj
+++ b/service/src/io/pedestal/service/websocket.clj
@@ -1,4 +1,4 @@
-; Copyright 2025 Nubank NA
+; Copyright 2025-2026 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/service/src/io/pedestal/service/websocket.clj
+++ b/service/src/io/pedestal/service/websocket.clj
@@ -49,7 +49,11 @@
     Returns true on success, false if the channel has closed.")
 
   (close! [this]
-    "Closes the channel, preventing further sends or receives.  Returns nil."))
+    "Closes the channel, preventing further sends or receives.  Returns nil.")
+  
+  (id [this]
+    "Returns a unique identifier assigned to this session. The contents of the string are intentionally opaque
+    and defined by the underlying websocket implementation."))
 
 (defprotocol InitializeWebSocket
   "Converts a native value (supplied by the network connector) into a WebSocketChannel.
@@ -164,5 +168,3 @@
         (close! ws-channel)))
     ;; Return the channel used to send messages to the client
     send-ch))
-
-

--- a/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -1,4 +1,4 @@
-; Copyright 2023-2025 Nubank NA
+; Copyright 2023-2026 Nubank NA
 ; Copyright 2013 Relevance, Inc.
 ; Copyright 2014-2022 Cognitect, Inc.
 
@@ -453,19 +453,21 @@
 (defn- websocket-channel-callback
   "Creates the callback from the FnEndpoint to handle lifecycle (open, close, error) of the WebSocket."
   [request *ws-channel ws-opts]
-  (let [*proc (atom nil)]
+  (let [{:keys [max-idle-timeout
+                max-binary-message-buffer-size
+                max-text-message-buffer-size]} ws-opts
+        *proc (atom nil)]
     (fn [event-type ^Session session extra]
       (case event-type
         :on-open
         (let [ws-channel (reify WebSocketChannel
                            (id [_]
                              (.getId session))
-                           
+
                            (on-text [this callback]
                              (.addMessageHandler session String (message-handler this *proc callback)))
                            (on-binary [this format callback]
                              (.addMessageHandler session
-
                                                  ByteBuffer
                                                  (message-handler this *proc
                                                                   (fn [ws-channel proc data]
@@ -481,6 +483,12 @@
                            (close! [_]
                              (.close session
                                      (CloseReason. CloseReason$CloseCodes/NORMAL_CLOSURE nil))))]
+          (when max-idle-timeout
+            (.setMaxIdleTimeout session (long max-idle-timeout)))
+          (when max-binary-message-buffer-size
+            (.setMaxBinaryMessageBufferSize session (int max-binary-message-buffer-size)))
+          (when max-text-message-buffer-size
+            (.setMaxTextMessageBufferSize session (int max-text-message-buffer-size)))
           (when-let [f (:on-open ws-opts)]
             (reset! *proc (f ws-channel request)))
           (when-let [f (:on-text ws-opts)]

--- a/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
+++ b/servlet/src/io/pedestal/http/impl/servlet_interceptor.clj
@@ -458,6 +458,9 @@
       (case event-type
         :on-open
         (let [ws-channel (reify WebSocketChannel
+                           (id [_]
+                             (.getId session))
+                           
                            (on-text [this callback]
                              (.addMessageHandler session String (message-handler this *proc callback)))
                            (on-binary [this format callback]

--- a/tests/test/io/pedestal/service/hk_websocket_test.clj
+++ b/tests/test/io/pedestal/service/hk_websocket_test.clj
@@ -100,13 +100,21 @@
     (assoc default-ws-opts
            :subprotocols ["graphql-ws" "chat"])))
 
+(def id-reporter
+  (websocket/websocket-interceptor
+    ::id-reporter
+    {:on-open (fn [channel _request]
+                (write-event :channel-id (websocket/id channel))
+                nil)}))
+
 (def routes
   (table/table-routes
     [["/ws/echo/:prefix" :get echo-prefix]
      ["/ws/reverser" :get byte-reverser]
      ["/ws/countdown" :get countdown]
      ["/ws/oneshot" :get oneshot]
-     ["/ws/subprotocol" :get subprotocol-handler]]))
+     ["/ws/subprotocol" :get subprotocol-handler]
+     ["/ws/id" :get id-reporter]]))
 
 (def ws-uri "ws://localhost:8080")
 
@@ -300,6 +308,12 @@
       (expect-event :open)
       (is (= "graphql-ws" (deref *negotiated 1000 ::timeout)))
       (ws/close! session))))
+
+(deftest channel-id-is-non-empty-string
+  (with-connector routes
+    @(ws/websocket (str ws-uri "/ws/id") {})
+    (is (match? [(m/pred (every-pred string? seq))]
+                (expect-event :channel-id)))))
 
 (deftest no-subprotocol-when-none-match
   ;; Client requests a subprotocol the server does not support; no Sec-WebSocket-Protocol header is sent.

--- a/tests/test/io/pedestal/service/jetty_websocket_test.clj
+++ b/tests/test/io/pedestal/service/jetty_websocket_test.clj
@@ -91,12 +91,20 @@
                       (websocket/send-text! conn (str "oneshot: " text))
                       (websocket/close! conn)))))
 
+(def id-reporter
+  (websocket/websocket-interceptor
+    ::id-reporter
+    {:on-open (fn [channel _request]
+                (write-event :channel-id (websocket/id channel))
+                nil)}))
+
 (def routes
   (table/table-routes
     [["/ws/echo/:prefix" :get echo-prefix]
      ["/ws/reverser" :get byte-reverser]
      ["/ws/countdown" :get countdown]
-     ["/ws/oneshot" :get oneshot]]))
+     ["/ws/oneshot" :get oneshot]
+     ["/ws/id" :get id-reporter]]))
 
 (def ws-uri "ws://localhost:8080")
 
@@ -193,6 +201,12 @@
                        ;; Note: differs from Http-Kit
                        [:close :normal]])
                     events))))))
+
+(deftest channel-id-is-non-empty-string
+  (with-connector routes
+    @(ws/websocket (str ws-uri "/ws/id") {})
+    (is (match? [(m/pred (every-pred string? seq))]
+                (expect-event :channel-id)))))
 
 
 

--- a/tests/test/io/pedestal/service/jetty_websocket_test.clj
+++ b/tests/test/io/pedestal/service/jetty_websocket_test.clj
@@ -1,4 +1,4 @@
-; Copyright 2025 Nubank NA
+; Copyright 2025-2026 Nubank NA
 
 ; The use and distribution terms for this software are covered by the
 ; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0)

--- a/tests/test/io/pedestal/service/jetty_websocket_test.clj
+++ b/tests/test/io/pedestal/service/jetty_websocket_test.clj
@@ -208,5 +208,40 @@
     (is (match? [(m/pred (every-pred string? seq))]
                 (expect-event :channel-id)))))
 
+(deftest max-idle-timeout-closes-connection
+  (with-connector (table/table-routes
+                    [["/ws/idle" :get (websocket/websocket-interceptor
+                                        ::idle-ws
+                                        {:on-close         (fn [_ _ reason]
+                                                             (write-event :close reason))
+                                         :max-idle-timeout 300})]])
+    @(ws/websocket (str ws-uri "/ws/idle") {})
+    ;; Server closes the connection once idle timeout elapses with no messages.
+    (expect-event :close)))
+
+(deftest max-text-message-buffer-size-closes-connection
+  (with-connector (table/table-routes
+                    [["/ws/text-limit" :get (websocket/websocket-interceptor
+                                              ::text-limit-ws
+                                              {:on-text                    (fn [_ _ _] nil)
+                                               :on-close                   (fn [_ _ reason]
+                                                                             (write-event :close reason))
+                                               :max-text-message-buffer-size 5})]])
+    (let [session @(ws/websocket (str ws-uri "/ws/text-limit") {})]
+      (ws/send! session "this message is much longer than 5 bytes")
+      (expect-event :close))))
+
+(deftest max-binary-message-buffer-size-closes-connection
+  (with-connector (table/table-routes
+                    [["/ws/binary-limit" :get (websocket/websocket-interceptor
+                                                ::binary-limit-ws
+                                                {:on-binary                      (fn [_ _ _] nil)
+                                                 :on-close                       (fn [_ _ reason]
+                                                                                   (write-event :close reason))
+                                                 :max-binary-message-buffer-size 5})]])
+    (let [session @(ws/websocket (str ws-uri "/ws/binary-limit") {})]
+      (ws/send! session (as-buffer "this message is much longer than 5 bytes"))
+      (expect-event :close))))
+
 
 


### PR DESCRIPTION
Fixes #968.

- Adds `:max-idle-timeout`, `:max-binary-message-buffer-size`, and `:max-text-message-buffer-size` to `upgrade-request-to-websocket` ws-opts
- Applied to the Jakarta `Session` in the Jetty connector on WebSocket open; silently ignored by Http-Kit
- Also includes the `id` method added to `WebSocketChannel` protocol (with Jetty and Http-Kit implementations and tests)
- Documents the new options in `websockets.adoc`, including the note that limit violations close the connection with an `:abnormal` reason (code 1006)

Fixes #968 

🤖 Generated with [Claude Code](https://claude.com/claude-code)