### PR TITLE
Release from CI on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+on:
+  push:
+    tags:
+      - '[0-9]*'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Verify tag matches VERSION.txt
+        run: |
+          version="$(tr -d '[:space:]' < VERSION.txt)"
+          if [ "$version" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match VERSION.txt ($version)"
+            exit 1
+          fi
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          cli: 1.12.5.1654
+
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn', '**/deps.edn') }}
+
+      - name: Deploy to Clojars
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: clojure -T:build deploy-all
+
+  github-release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Check for prerelease
+        id: meta
+        run: |
+          case "$GITHUB_REF_NAME" in
+            *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Extract changelog entry
+        if: steps.meta.outputs.prerelease == 'false'
+        run: |
+          awk -v ver="$GITHUB_REF_NAME" '
+            index($0, "## " ver " ") == 1 { found = 1; next }
+            /^## / && found { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+      - name: Create GitHub release
+        if: steps.meta.outputs.prerelease == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+      - name: Create GitHub prerelease
+        if: steps.meta.outputs.prerelease == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,8 @@ From the root directory:
 # Install all modules to local Maven repository
 clj -T:build install
 
-# Build and deploy all modules (requires clean workspace)
+# Build and deploy all modules (normally done by the Release workflow in CI; requires clean
+# workspace and CLOJARS_USERNAME/CLOJARS_PASSWORD)
 clj -T:build deploy-all
 
 # Dry run (build and install locally, don't deploy)
@@ -90,10 +91,18 @@ clj -M:otel
 clj -M:otel-agent
 ```
 
-### Version Management
+### Releasing and Version Management
 
 ```bash
-# Advance version and commit/tag
+# Cut a release: advances the version, updates CHANGELOG.md, commits, tags, and pushes.
+# The pushed tag triggers the Release workflow (.github/workflows/release.yml), which
+# deploys all modules to Clojars and creates a GitHub release. See RELEASING.md.
+clj -T:build release :level :release
+
+# Preview the version numbers without changing anything
+clj -T:build release :level :beta :dry-run true
+
+# Advance version and commit/tag without releasing
 clj -T:build advance-version :level :patch :commit true :tag true
 
 # Valid levels: :major, :minor, :patch, :release, :snapshot, :beta, :rc, :alpha

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Releasing Pedestal
+
+Releases are cut locally with a single command; CI does the deploy.
+
+The repo is configured to use a [Clojars deploy token](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens) with permissions to `io.pedestal` group only and 2 github secrets `CLOJARS_USERNAME` and `CLOJARS_PASSWORD`.
+
+## Cutting a release
+
+1. Make sure CI is green and `CHANGELOG.md` is up to date under the `## <version> - UNRELEASED` heading.
+2. From the repository root:
+
+   ```
+   clj -T:build release :level :release
+   ```
+
+   Levels: `:release` (the default, strips the stability suffix, e.g. `1.2.3-beta-2` to `1.2.3`),
+   `:beta`, `:rc`, `:major`, `:minor`, `:patch`. Add `:dry-run true` to preview the version numbers
+   without changing anything.
+
+This advances the version (`VERSION.txt`, all module `deps.edn` files, docs), stamps today's date on
+the changelog heading (final releases only), commits, tags, and pushes. For final releases, it then
+advances to the next patch SNAPSHOT with a fresh UNRELEASED changelog heading and pushes that too.
+
+The pushed tag triggers the [Release workflow](.github/workflows/release.yml), which:
+
+1. Verifies the tag matches `VERSION.txt`.
+2. Builds all modules in dependency order and deploys them to Clojars.
+3. Creates a GitHub release with the changelog entry; beta/RC tags are marked as prereleases
+   with auto-generated notes.
+
+## Manual fallback
+
+`clj -T:build deploy-all` still deploys from a local checkout, with `CLOJARS_USERNAME` and
+`CLOJARS_PASSWORD` set in the environment. Add `:sign true` (and `CLOJARS_GPG_ID`) to GPG-sign
+the artifacts as in the pre-CI process.

--- a/build/build.clj
+++ b/build/build.clj
@@ -17,7 +17,10 @@
             [clojure.tools.build.api :as b]
             [babashka.fs :as fs]
             [clj-commons.ansi :refer [perr pout]]
-            [net.lewisship.build.versions :as v]))
+            [net.lewisship.build.versions :as v])
+  (:import (java.time LocalDate)
+           (java.time.format DateTimeFormatter)
+           (java.util Locale)))
 
 
 ;; General notes: have to do a *lot* of fighting with executing particular build commands from the root
@@ -165,20 +168,29 @@
 
   The workspace must be clean (no uncommitted changes).
 
+  Credentials are read from environment variables CLOJARS_USERNAME and CLOJARS_PASSWORD
+  (a Clojars deploy token). Artifacts are deployed unsigned by default; this is normally
+  executed by the Release workflow in CI.
+
   :dry-run - install to local Maven repository, but do not deploy to remote
   :force - deactivate the dirty workspace check
-  :sign-key-id - key id to sign with, if not provided, defaults to environment variable CLOJARS_GPG_ID"
-  [{:keys [dry-run sign-key-id force]}]
+  :sign - if true, GPG-sign artifacts before deploying (default: false)
+  :sign-key-id - key id to sign with (implies :sign); defaults to environment variable CLOJARS_GPG_ID"
+  [{:keys [dry-run sign sign-key-id force]}]
   (when-not force
     (ensure-workspace-clean))
 
   (println (str "Building version " version (when dry-run " (dry run)") " ..."))
 
   (let [build-and-install (requiring-resolve 'io.pedestal.deploy/build-and-install)
-        artifacts-data    (mapv #(build-and-install % version) module-dirs)]
+        artifacts-data    (mapv #(build-and-install % version) module-dirs)
+        sign?             (boolean (or sign sign-key-id))]
     (when-not dry-run
       (println "Deploying ...")
-      (run! #(deploy-jar (assoc % :sign-key-id sign-key-id)) artifacts-data)))
+      (run! #(deploy-jar (assoc %
+                                :sign-artifacts? sign?
+                                :sign-key-id sign-key-id))
+            artifacts-data)))
   (println "done"))
 
 (defn install
@@ -273,6 +285,97 @@
                           (dissoc :level :dry-run)
                           (assoc :version new-version))))))
 
+
+(defn ^:private git!
+  "Runs a git command, inheriting IO; exits on failure."
+  [& args]
+  (let [{:keys [exit]} (b/process {:command-args (into ["git"] args)})]
+    (when-not (zero? exit)
+      (perr [:red [:bold "ERROR: "] "git " (str/join " " args) " failed"])
+      (System/exit exit))))
+
+(def ^:private changelog-file "CHANGELOG.md")
+
+(defn ^:private stamp-changelog-release-date
+  "Replaces the version's UNRELEASED heading in CHANGELOG.md with today's date.
+  Returns the new heading."
+  [version]
+  (let [unreleased-heading (str "## " version " - UNRELEASED")
+        date               (.format (LocalDate/now)
+                                    (DateTimeFormatter/ofPattern "d MMM yyyy" Locale/ENGLISH))
+        released-heading   (str "## " version " - " date)
+        content            (slurp changelog-file)]
+    (when-not (str/includes? content unreleased-heading)
+      (perr [:red [:bold "ERROR: "] changelog-file " does not contain heading: " unreleased-heading])
+      (System/exit 1))
+    (b/write-file {:path   changelog-file
+                   :string (str/replace-first content unreleased-heading released-heading)})
+    released-heading))
+
+(defn ^:private add-unreleased-changelog-heading
+  "Adds an UNRELEASED heading for the next version above the just-released heading."
+  [next-base-version released-heading]
+  (let [content (slurp changelog-file)]
+    (b/write-file {:path   changelog-file
+                   :string (str/replace-first content released-heading
+                                              (str "## " next-base-version " - UNRELEASED\n\n"
+                                                   released-heading))})))
+
+(defn ^:private release-versions
+  [current-version level]
+  (let [new-version (-> current-version v/parse-version (v/advance level) v/unparse-version)
+        final?      (not (str/includes? new-version "-"))]
+    {:new-version  new-version
+     :final?       final?
+     :next-version (when final?
+                     (-> new-version
+                         v/parse-version
+                         (v/advance :patch)
+                         (v/advance :snapshot)
+                         v/unparse-version))}))
+
+(defn release
+  "Cuts a release: advances the version, updates CHANGELOG.md, commits, tags, and pushes.
+  The pushed tag triggers the Release workflow in CI, which deploys all modules to Clojars
+  and creates a GitHub release.
+
+  For final releases (e.g. \"1.2.3\"), the version's UNRELEASED heading in CHANGELOG.md is
+  stamped with today's date and, after tagging, the version is advanced to the next patch
+  SNAPSHOT (with a fresh UNRELEASED changelog heading) to reopen development.
+  Beta/RC releases skip the changelog and snapshot steps.
+
+  :level - :major, :minor, :patch, :release (the default), :snapshot, :beta, :rc, :alpha
+  :dry-run - print the computed versions, but change nothing"
+  [{:keys [level dry-run]
+    :or   {level :release}}]
+  (validate level #{:major :minor :patch :release :snapshot :beta :rc :alpha}
+            ":level must be one of: major, minor, patch, release, snapshot, beta, rc, alpha")
+  (if dry-run
+    (let [{:keys [new-version next-version]} (release-versions version level)]
+      (if next-version
+        (pout "Would release version " [:bold new-version] ", then advance to " [:bold next-version])
+        (pout "Would release version " [:bold new-version])))
+    (do
+      (ensure-workspace-clean)
+      (git! "pull" "--ff-only")
+      (let [current-version (-> version-file slurp str/trim)
+            {:keys [new-version final? next-version]} (release-versions current-version level)]
+        (pout "Releasing version " [:bold new-version] " ...")
+        (let [released-heading (when final?
+                                 (stamp-changelog-release-date new-version))]
+          (update-version {:version new-version})
+          (git! "commit" "-a" "-m" (str "Release " new-version))
+          (git! "tag" new-version)
+          (git! "push" "origin" "HEAD")
+          (git! "push" "origin" new-version)
+          (pout [:green "Pushed tag " [:bold new-version] "; CI will deploy to Clojars and create the GitHub release"])
+          (when final?
+            (add-unreleased-changelog-heading (str/replace next-version #"-SNAPSHOT$" "")
+                                              released-heading)
+            (update-version {:version next-version})
+            (git! "commit" "-a" "-m" (str "Advance to version " next-version))
+            (git! "push" "origin" "HEAD")
+            (pout [:green "Advanced to " [:bold next-version]])))))))
 
 (defn cve-check
   [_]


### PR DESCRIPTION
Moves releases from manual local deploys to CI, triggered by pushing a version tag.

- New Release workflow: on a version tag push, verifies the tag matches `VERSION.txt`, builds all modules in dependency order and deploys them to Clojars, then creates a GitHub release with the changelog entry (beta/rc tags become prereleases)
- New `clj -T:build release` task: advances the version, stamps the changelog date, commits, tags and pushes; for final releases it also advances to the next patch SNAPSHOT and adds a fresh UNRELEASED changelog heading
- `deploy-all` no longer GPG signs by default, `:sign true` restores the old behavior
- See RELEASING.md for the full flow

Before the first release the repo needs the `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` secrets, from a Clojars deploy token scoped to the io.pedestal group.